### PR TITLE
[API,FEATURE] added additional input and output type prefix to arg_parse

### DIFF
--- a/core/include/seqan/arg_parse/arg_parse_argument.h
+++ b/core/include/seqan/arg_parse/arg_parse_argument.h
@@ -151,12 +151,14 @@ public:
     enum ArgumentType
     {
         // argument is
-        STRING,     // .. a string
-        INTEGER,    // .. an integer
-        INT64,      // .. a 64 bit integer
-        DOUBLE,     // .. a float
-        INPUTFILE,  // .. an inputfile (implicitly also a string)
-        OUTPUTFILE  // .. an outputfile (implicitly also a string)
+        STRING,      // .. a string
+        INTEGER,     // .. an integer
+        INT64,       // .. a 64 bit integer
+        DOUBLE,      // .. a float
+        INPUTFILE,   // .. an inputfile (implicitly also a string)
+        OUTPUTFILE,  // .. an outputfile (implicitly also a string)
+        INPUTPREFIX, // .. an inputprefix (implicitly also a string)
+        OUTPUTPREFIX // .. an outoutprefix (implicitly also a string)
     };
 
 
@@ -256,6 +258,14 @@ inline std::string _typeToString(ArgParseArgument const & me)
         typeName = "outputfile";
         break;
 
+    case ArgParseArgument::INPUTPREFIX:
+        typeName = "inputprefix";
+        break;
+
+    case ArgParseArgument::OUTPUTPREFIX:
+        typeName = "outputprefix";
+        break;
+
     default:
         typeName = "unknown";
         break;
@@ -333,7 +343,9 @@ inline bool isStringArgument(ArgParseArgument const & me)
 {
     return (me._argumentType == ArgParseArgument::STRING) ||
            (me._argumentType == ArgParseArgument::INPUTFILE) ||
-           (me._argumentType == ArgParseArgument::OUTPUTFILE);
+           (me._argumentType == ArgParseArgument::OUTPUTFILE) ||
+           (me._argumentType == ArgParseArgument::INPUTPREFIX) ||
+           (me._argumentType == ArgParseArgument::OUTPUTPREFIX) ;
 }
 
 // ----------------------------------------------------------------------------
@@ -425,7 +437,7 @@ inline bool isInt64Argument(ArgParseArgument const & me)
 ..class:Class.ArgParseArgument
 ..summary:Returns whether the argument is a double.
 ..cat:Miscellaneous
-..signature:isListArgument(argument)
+..signature:isDoubleArgument(argument)
 ..param.argument:The @Class.ArgParseArgument@ object.
 ...type:Class.ArgParseArgument
 ..returns:$true$ if the argument argument is a double argument.
@@ -445,7 +457,7 @@ inline bool isDoubleArgument(ArgParseArgument const & me)
 /*!
  * @fn ArgParseArgument#isInputFileArgument
  * @headerfile <seqan/arg_parse.h>
- * @brief Returns whether the argument is a input file integer.
+ * @brief Returns whether the argument is a input file.
  *
  * @signature bool isInputFileArgument(arg);
  *
@@ -459,7 +471,7 @@ inline bool isDoubleArgument(ArgParseArgument const & me)
 ..class:Class.ArgParseArgument
 ..summary:Returns whether the argument is an input file.
 ..cat:Miscellaneous
-..signature:isListArgument(argument)
+..signature:isOutputFileArgument(argument)
 ..param.argument:The @Class.ArgParseArgument@ object.
 ...type:Class.ArgParseArgument
 ..returns:$true$ if the argument argument is an input file argument.
@@ -479,7 +491,7 @@ inline bool isInputFileArgument(ArgParseArgument const & me)
 /*!
  * @fn ArgParseArgument#isOutputFileArgument
  * @headerfile <seqan/arg_parse.h>
- * @brief Returns whether the argument is a output file integer.
+ * @brief Returns whether the argument is a output file.
  *
  * @signature bool isOutputFileArgument(arg);
  *
@@ -493,7 +505,7 @@ inline bool isInputFileArgument(ArgParseArgument const & me)
 ..class:Class.ArgParseArgument
 ..summary:Returns whether the argument is an output file.
 ..cat:Miscellaneous
-..signature:isListArgument(argument)
+..signature:isOutputFileArgument(argument)
 ..param.argument:The @Class.ArgParseArgument@ object.
 ...type:Class.ArgParseArgument
 ...type:Class.ArgParseOption
@@ -507,6 +519,76 @@ inline bool isOutputFileArgument(ArgParseArgument const & me)
     return me._argumentType == ArgParseArgument::OUTPUTFILE;
 }
 
+// ----------------------------------------------------------------------------
+// Function isOutputPrefixArgument()
+// ----------------------------------------------------------------------------
+
+/*!
+ * @fn ArgParseArgument#isOutputPrefixArgument
+ * @headerfile <seqan/arg_parse.h>
+ * @brief Returns whether the argument is an output prefix.
+ *
+ * @signature bool isOutputPrefixArgument(arg);
+ *
+ * @param arg The ArgParseArgument to query.
+ *
+ * @return bool <tt>true</tt> if it is an output prefix argument, <tt>false</tt> otherwise.
+ */
+
+/**
+ .Function.isOutputPrefixArgument
+ ..class:Class.ArgParseArgument
+ ..summary:Returns whether the argument is an output file.
+ ..cat:Miscellaneous
+ ..signature:isOutputPrefixArgument(argument)
+ ..param.argument:The @Class.ArgParseArgument@ object.
+ ...type:Class.ArgParseArgument
+ ...type:Class.ArgParseOption
+ ..returns:$true$ if the argument argument is an output file argument.
+ ..see:Memfunc.ArgParseArgument#ArgParseArgument.param.argumentType
+ ..include:seqan/arg_parse.h
+ */
+
+inline bool isOutputPrefixArgument(ArgParseArgument const & me)
+{
+    return me._argumentType == ArgParseArgument::OUTPUTPREFIX;
+}
+
+// ----------------------------------------------------------------------------
+// Function isOutputFileArgument()
+// ----------------------------------------------------------------------------
+
+/*!
+ * @fn ArgParseArgument#isInputPrefixArgument
+ * @headerfile <seqan/arg_parse.h>
+ * @brief Returns whether the argument is an input prefix argument.
+ *
+ * @signature bool isInputPrefixArgument(arg);
+ *
+ * @param arg The ArgParseArgument to query.
+ *
+ * @return bool <tt>true</tt> if it is an input prefix argument, <tt>false</tt> otherwise.
+ */
+
+/**
+ .Function.isInputPrefixArgument
+ ..class:Class.ArgParseArgument
+ ..summary:Returns whether the argument is an output file.
+ ..cat:Miscellaneous
+ ..signature:isInputPrefixArgument(argument)
+ ..param.argument:The @Class.ArgParseArgument@ object.
+ ...type:Class.ArgParseArgument
+ ...type:Class.ArgParseOption
+ ..returns:$true$ if the argument argument is an input prefix argument.
+ ..see:Memfunc.ArgParseArgument#ArgParseArgument.param.argumentType
+ ..include:seqan/arg_parse.h
+ */
+
+inline bool isInputPrefixArgument(ArgParseArgument const & me)
+{
+    return me._argumentType == ArgParseArgument::INPUTPREFIX;
+}
+    
 // ----------------------------------------------------------------------------
 // Function getArgumentLabel()
 // ----------------------------------------------------------------------------
@@ -548,6 +630,8 @@ inline std::string const getArgumentLabel(ArgParseArgument const & me)
         std::string baseLabel = "";
         if (isInputFileArgument(me) || isOutputFileArgument(me))
             baseLabel = "FILE";
+        else if (isInputPrefixArgument(me) || isOutputPrefixArgument(me))
+            baseLabel = "PREFIX";
         else if (isStringArgument(me))
             baseLabel = "STR";
         else if (isIntegerArgument(me) || isDoubleArgument(me))
@@ -893,7 +977,8 @@ inline void _checkStringRestrictions(ArgParseArgument const & me, std::string va
 {
     typedef std::vector<std::string>::const_iterator TVectorIterator;
 
-    if (!empty(me.validValues))
+    // we only check valid values for files and string arguments, but not for prefix arguments
+    if (!empty(me.validValues) && !(isInputPrefixArgument(me) || isOutputPrefixArgument(me)))
     {
         bool isContained = false;
         for (TVectorIterator validValue = me.validValues.begin();

--- a/core/include/seqan/arg_parse/arg_parse_ctd_support.h
+++ b/core/include/seqan/arg_parse/arg_parse_ctd_support.h
@@ -169,7 +169,7 @@ inline void
 _getRestrictions(std::vector<std::string> & restrictions, ArgParseArgument const & opt)
 {
     // we only extract non-file restrictions
-    if (isOutputFileArgument(opt) || isInputFileArgument(opt))
+    if (isOutputFileArgument(opt) || isInputFileArgument(opt) || isInputPrefixArgument(opt) || isOutputPrefixArgument(opt))
         return;
 
     if (length(opt.validValues) != 0)
@@ -209,7 +209,7 @@ inline void
 _getSupportedFormats(std::vector<std::string> & supported_formats, ArgParseArgument const & opt)
 {
     // we check only file arguments
-    if (!(isOutputFileArgument(opt) || isInputFileArgument(opt)))
+    if (!(isOutputFileArgument(opt) || isInputFileArgument(opt) || isInputPrefixArgument(opt) || isOutputPrefixArgument(opt)))
         return;
 
     if (length(opt.validValues) != 0)
@@ -408,6 +408,10 @@ writeCTD(ArgumentParser const & me, std::ostream & ctdfile)
             type = "input-file";
         else if (isOutputFileArgument(opt))
             type = "output-file";
+        else if (isInputPrefixArgument(opt))
+            type = "input-prefix";
+        else if (isOutputPrefixArgument(opt))
+            type = "output-prefix";
         else if (isStringArgument(opt) || isBooleanOption(opt))
             type = "string";
 
@@ -418,7 +422,6 @@ writeCTD(ArgumentParser const & me, std::ostream & ctdfile)
         // set up supported formats
         std::vector<std::string> supported_formats;
         _getSupportedFormats(supported_formats, opt);
-
 
         ctdfile << _indent(currentIndent)
                 << "<ITEM" << (isListArgument(opt) ? "LIST" : "") << " name=\"" << xmlEscape(optionName) << "\"";
@@ -487,6 +490,10 @@ writeCTD(ArgumentParser const & me, std::ostream & ctdfile)
             type = "input-file";
         else if (isOutputFileArgument(arg))
             type = "output-file";
+        else if (isInputPrefixArgument(arg))
+            type = "input-prefix";
+        else if (isOutputPrefixArgument(arg))
+            type = "output-prefix";
         else if (isStringArgument(arg))
             type = "string";
 

--- a/core/tests/arg_parse/test_app.ctd
+++ b/core/tests/arg_parse/test_app.ctd
@@ -33,6 +33,12 @@ The second one contains formating &lt;bla&gt;.
 		<clielement optionIdentifier="--out-file-ext" isList="false">
 			<mapping referenceName="test_app.out-file-ext" />
 		</clielement>
+		<clielement optionIdentifier="--input-prefix-option" isList="false">
+			<mapping referenceName="test_app.input-prefix-option" />
+		</clielement>
+		<clielement optionIdentifier="--output-prefix-option" isList="false">
+			<mapping referenceName="test_app.output-prefix-option" />
+		</clielement>
 		<clielement optionIdentifier="--hidden" isList="false">
 			<mapping referenceName="test_app.hidden" />
 		</clielement>
@@ -59,6 +65,8 @@ The second one contains formating &lt;bla&gt;.
 			<ITEM name="in-file-ext" value="" type="string" description="Override file extension for --in" restrictions="fasta" required="false" advanced="true" tags="file-ext-override,gkn-ignore" />
 			<ITEM name="out" value="" type="output-file" description="set an output file" supported_formats="*.sam" required="false" advanced="false" />
 			<ITEM name="out-file-ext" value="" type="string" description="Override file extension for --out" restrictions="sam" required="false" advanced="true" tags="file-ext-override,gkn-ignore" />
+			<ITEM name="input-prefix-option" value="" type="input-prefix" description="set an input prefix" supported_formats="*.btx" required="false" advanced="false" />
+			<ITEM name="output-prefix-option" value="" type="output-prefix" description="set an output prefix" supported_formats="*.blub" required="false" advanced="false" />
 			<ITEM name="hidden" value="" type="string" description="a hidden option - will be advanced in the ctd" required="false" advanced="true" />
 			<ITEM name="argument-0" value="" type="double" description="Double Argument" required="true" advanced="false" />
 			<ITEM name="argument-1" value="" type="string" description="Documentated Argument with formating" required="true" advanced="false" />

--- a/core/tests/arg_parse/test_arg_parse_ctd_support.h
+++ b/core/tests/arg_parse/test_arg_parse_ctd_support.h
@@ -66,6 +66,10 @@ SEQAN_DEFINE_TEST(test_arg_parse_ctd_support)
     setValidValues(parser, "f", "fasta");
     addOption(parser, seqan::ArgParseOption("o", "out", "set an output file", seqan::ArgParseArgument::OUTPUTFILE));
     setValidValues(parser, "o", "sam");
+    addOption(parser, seqan::ArgParseOption("ip", "input-prefix-option", "set an input prefix", seqan::ArgParseArgument::INPUTPREFIX));
+    setValidValues(parser, "ip", "btx");
+    addOption(parser, seqan::ArgParseOption("op", "output-prefix-option", "set an output prefix", seqan::ArgParseArgument::OUTPUTPREFIX));
+    setValidValues(parser, "output-prefix-option", "blub");
     addOption(parser, seqan::ArgParseOption("hi", "hidden", "a hidden option - will be advanced in the ctd", seqan::ArgParseArgument::STRING));
 
     hideOption(parser, "hi");


### PR DESCRIPTION
Added two new ArgumentTypes, `INPUTPREFIX` and `OUTPUTPREFIX`. The user can now declare prefix options/arguments which will be returned by the parser like a string option/argument but indicate that more then one file with this shared prefix will be generated by the tool. The user is responsible to make sure that all files he creates really share the prefix. Note that no restriction checking is carried out while parsing. The supported format is
only an indicator for workflow engines like knime.
