### PR TITLE
[FIX] Index: renamed some instances of DfsOrder as DFSOrder

### DIFF
--- a/core/include/seqan/index/index_esa_stree.h
+++ b/core/include/seqan/index/index_esa_stree.h
@@ -1943,7 +1943,7 @@ TA
 
         typename Iterator<Index<TText, TIndexSpec>, TSpec>::Type it(index);
 
-        if (IsSameType<typename TTraits::DfsOrder, Postorder_>::VALUE) {
+        if (IsSameType<typename TTraits::DFSOrder, Postorder_>::VALUE) {
             while (goDown(it)) ;
         }
 
@@ -2004,7 +2004,7 @@ TA
 
 		goRoot(it);
 
-		if (IsSameType<typename TTraits::DfsOrder, Postorder_>::VALUE) {
+		if (IsSameType<typename TTraits::DFSOrder, Postorder_>::VALUE) {
 			while (goDown(it)) ;
 			return;
 		}


### PR DESCRIPTION
Some builds (eg. dfi) failed because of referencing DfsOrder instead of DFSOrder. I took the former version for good. Jochen renamed it in cde25d7 but probably forgot to change these references.
