### PR TITLE
[FIX] Fixing nightly build warning in gustaf.

### DIFF
--- a/extras/apps/gustaf/gustaf_matepairs.h
+++ b/extras/apps/gustaf/gustaf_matepairs.h
@@ -292,7 +292,7 @@ void _initialiseGraphMatePairs(QueryMatches<StellarMatch<TSequence, TId> > & que
     typedef typename EdgeDescriptor<TGraph>::Type TEdgeDescriptor;
     typedef typename Iterator<String<StellarMatch<TSequence, TId> > >::Type TIterator;
     typedef typename TMSplazerChain::TInterval TInterval;
-    typedef typename TMSplazerChain::TIntervalTree TIntervalTree;
+    //typedef typename TMSplazerChain::TIntervalTree TIntervalTree;
 
     String<TInterval> leftMateMatches;
     String<TInterval> rightMateMatches;


### PR DESCRIPTION
There used to be an unused typedef.
