### PR TITLE
[FIX] Reverting 308d5e which causes a regression with empty SWIFT pattern

### DIFF
--- a/core/include/seqan/index/index_wotd.h
+++ b/core/include/seqan/index/index_wotd.h
@@ -2056,13 +2056,6 @@ if it is traversed. For details see Giegerich et al., "Efficient implementation 
 		return true;
 	}
 
-    //TODO(singer): this is a temporary fix  -> move to index_shims.h
-	template <typename TText, typename TSpec, typename TFibre>
-    inline bool indexCreate(Index<TText, IndexWotd<TSpec> > &index, Tag<TFibre> const fibre) {
-    SEQAN_CHECKPOINT
-            return indexCreate(index, fibre, typename DefaultIndexCreator<Index<TText, TSpec>, Tag<TFibre> const>::Type());
-    }
-
 //////////////////////////////////////////////////////////////////////////////
 // clear
 

--- a/core/tests/index/CMakeLists.txt
+++ b/core/tests/index/CMakeLists.txt
@@ -110,6 +110,9 @@ add_executable (test_index_repeats
                test_index_repeats.h)
 target_link_libraries (test_index_repeats ${SEQAN_LIBRARIES})
 
+add_executable (test_index_swift
+                test_index_swift.cpp)
+target_link_libraries (test_index_swift ${SEQAN_LIBRARIES})
 
 # Add CXX flags found by find_package (SeqAn).
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SEQAN_CXX_FLAGS}")

--- a/core/tests/index/test_index_swift.cpp
+++ b/core/tests/index/test_index_swift.cpp
@@ -1,0 +1,36 @@
+#include <seqan/basic.h>
+#include <seqan/index.h>
+#include <seqan/sequence.h>
+
+// Test SWIFT finder with empty pattern.
+SEQAN_DEFINE_TEST(test_index_swift_find_empty_pattern)
+{
+    using namespace seqan;
+
+    typedef Finder<Dna5String, Swift<SwiftSemiGlobal> > TSwiftFinder;
+
+    typedef Dna5String TReadSeq_;
+    typedef StringSet<TReadSeq_> TReadSet;
+    typedef typename Value<TReadSet>::Type TReadSeq;
+    typedef typename Value<TReadSeq>::Type TAlphabet;
+    typedef Shape<TAlphabet, UngappedShape<10> > TShape;
+    typedef Index<TReadSet, IndexQGram<TShape, OpenAddressing> > TQGramIndex;
+    typedef Pattern<TQGramIndex, Swift<SwiftSemiGlobal> > TSwiftPattern;
+
+    Dna5String contigSeq = "CGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGAT";
+
+    StringSet<Dna5String> readSeqs;
+
+    TQGramIndex index(readSeqs);
+    TSwiftPattern swiftPattern(index);
+
+    TSwiftFinder swiftFinder(contigSeq);
+    while (find(swiftFinder, swiftPattern, 0.1))
+        continue;
+}
+
+SEQAN_BEGIN_TESTSUITE(test_index_swift)
+{
+	SEQAN_CALL_TEST(test_index_swift_bug_creation);
+}
+SEQAN_END_TESTSUITE


### PR DESCRIPTION
The new test in test_index_swift.cpp breaks without the patch in index_wotd.h.
