### PR TITLE
[FIX] Not writing out empty lines to FASTA any more.

### DIFF
--- a/core/include/seqan/seq_io/write_fasta_fastq.h
+++ b/core/include/seqan/seq_io/write_fasta_fastq.h
@@ -191,7 +191,7 @@ writeRecord(TStream & stream,
             res = streamWriteChar(stream, (char)*it);
             if (res)
                 return res;
-            if (++l == lineLength)
+            if (++l == lineLength && (it + 1 != it_end))
             {
                 res = streamWriteChar(stream, '\n');
                 l = 0;
@@ -201,7 +201,8 @@ writeRecord(TStream & stream,
         }
         if (res)
             return res;
-    } else
+    }
+    else
     {
         for (typename Iterator<TSeqString const, Rooted>::Type it = begin(seq, Rooted()); !atEnd(it); ++it)
             res = streamWriteChar(stream, (char)*it);

--- a/core/tests/seq_io/test_seq_io.cpp
+++ b/core/tests/seq_io/test_seq_io.cpp
@@ -166,6 +166,7 @@ SEQAN_BEGIN_TESTSUITE(test_seq_io)
 
     // Tests for FASTA
     SEQAN_CALL_TEST(test_stream_write_record_fasta_default);
+    SEQAN_CALL_TEST(test_stream_write_record_fasta_no_empty_lines);
     SEQAN_CALL_TEST(test_stream_write_record_fasta_nolinebreaks);
     SEQAN_CALL_TEST(test_stream_write_record_fastq_default_separate_qual);
     SEQAN_CALL_TEST(test_stream_write_record_fastq_default_qual_in_seq);

--- a/core/tests/seq_io/test_stream_write_fasta.h
+++ b/core/tests/seq_io/test_stream_write_fasta.h
@@ -63,6 +63,36 @@ SEQAN_DEFINE_TEST(test_stream_write_record_fasta_default)
     SEQAN_ASSERT_EQ(CharString(buffer), CharString(EXPECTED));
 }
 
+// Test that no empty lines are written if (seq_len % line_len) == 0.
+SEQAN_DEFINE_TEST(test_stream_write_record_fasta_no_empty_lines)
+{
+    using namespace seqan;
+
+    char buffer[1000];
+    Stream<CharArray<char *> > outStream(&buffer[0], &buffer[0] + 1000);
+
+    CharString meta1 = "meta1";
+    CharString meta2 = "meta2";
+    Dna5String seq1 = "CCCAAATTTN""CCCAAATTTN";
+    Dna5String seq2 = "CGATN";
+    SEQAN_ASSERT_EQ(length(seq1), 20u);
+
+    SequenceOutputOptions options;
+    options.lineLength = 10;
+
+    SEQAN_ASSERT_EQ(writeRecord(outStream, meta1, seq1, Fasta(), options), 0);
+    SEQAN_ASSERT_EQ(writeRecord(outStream, meta2, seq2, Fasta(), options), 0);
+    streamPut(outStream, '\0');
+
+    char const * EXPECTED =
+            ">meta1\n"
+            "CCCAAATTTN\n"
+            "CCCAAATTTN\n"
+            ">meta2\n"
+            "CGATN\n";
+    SEQAN_ASSERT_EQ(CharString(buffer), CharString(EXPECTED));
+}
+
 SEQAN_DEFINE_TEST(test_stream_write_record_fasta_nolinebreaks)
 {
     using namespace seqan;


### PR DESCRIPTION
This happened if the line length was a divisor of the sequence length.
