### PR TITLE
[FIX] Fixing bug in test that caused the swift index test to not compile.

### DIFF
--- a/core/tests/index/test_index_swift.cpp
+++ b/core/tests/index/test_index_swift.cpp
@@ -31,6 +31,6 @@ SEQAN_DEFINE_TEST(test_index_swift_find_empty_pattern)
 
 SEQAN_BEGIN_TESTSUITE(test_index_swift)
 {
-	SEQAN_CALL_TEST(test_index_swift_bug_creation);
+	SEQAN_CALL_TEST(test_index_swift_find_empty_pattern);
 }
 SEQAN_END_TESTSUITE


### PR DESCRIPTION
Note that it now fails since there is a bug with the swift index search if the pattern is empty.
