### PR TITLE
[FIX] Fixing reading of first record after @CO header in SAM.

### DIFF
--- a/core/include/seqan/bam_io/read_sam.h
+++ b/core/include/seqan/bam_io/read_sam.h
@@ -217,10 +217,13 @@ int readRecord(BamHeaderRecord & record,
         }
     }
 
-    // Skip remaining line break.
-    int res = skipLine(reader);
-    if (res != 0 && res != EOF_BEFORE_SUCCESS)
-        return res;
+    // Skip remaining line break, in case of comment, we already skipped over it.
+    if (record.type != BAM_HEADER_COMMENT)
+    {
+        int res = skipLine(reader);
+        if (res != 0 && res != EOF_BEFORE_SUCCESS)
+            return res;
+    }
     return 0;
 }
 


### PR DESCRIPTION
Before this patch, the readRecord() function skips the first record.
