### PR TITLE
Fix for GKN version generation after move to git

### DIFF
--- a/util/cmake/SeqAnCtdSetup.cmake
+++ b/util/cmake/SeqAnCtdSetup.cmake
@@ -200,6 +200,7 @@ add_custom_command (OUTPUT ${WORKFLOW_PLUGIN_DIR}/plugin.properties
                     COMMAND ${CMAKE_COMMAND} "-DSEQAN_SOURCE_DIR=${CMAKE_SOURCE_DIR}"
                                              "-DWORKFLOW_PLUGIN_DIR=${WORKFLOW_PLUGIN_DIR}"
                                              "-DSEQAN_VERSION_STRING=${SEQAN_VERSION_STRING}"
+                                             "-DSEQAN_DATE=${SEQAN_DATE}"
                                              -P "${CMAKE_SOURCE_DIR}/util/cmake/ctd/configure_profile_properties.cmake"
                     DEPENDS ${WORKFLOW_PLUGIN_DIR}
                             ${CMAKE_SOURCE_DIR}/util/cmake/ctd/plugin.properties.in)

--- a/util/cmake/ctd/configure_profile_properties.cmake
+++ b/util/cmake/ctd/configure_profile_properties.cmake
@@ -1,12 +1,10 @@
 # If possible, get latest change date from SeqAn SVN.
-find_package(Subversion)
 message(STATUS "SEQAN_SOURCE_DIR ${SEQAN_SOURCE_DIR}")
-if (Subversion_FOUND AND EXISTS ${SEQAN_SOURCE_DIR}/.svn)
-  file (TO_CMAKE_PATH "${SEQAN_SOURCE_DIR}" _SEQAN_SOURCE_DIR)
-  Subversion_WC_INFO (${_SEQAN_SOURCE_DIR} SEQAN)
-  string(REGEX REPLACE "^([0-9]+)-([0-9]+)-([0-9]+) ([0-9]+):([0-9]+).*"
-    "\\1\\2\\3\\4\\5" SEQAN_LAST_CHANGE_DATE "${SEQAN_WC_LAST_CHANGED_DATE}")
-  set (CF_SEQAN_VERSION ${SEQAN_VERSION_STRING}.${SEQAN_LAST_CHANGE_DATE})
+message(STATUS "SEQAN_DATE ${SEQAN_DATE}")
+if (SEQAN_DATE)
+	string(REGEX REPLACE "^([0-9]+)-([0-9]+)-([0-9]+) ([0-9]+):([0-9]+).*"
+    "\\1\\2\\3\\4\\5" SEQAN_LAST_CHANGED_DATE "${SEQAN_DATE}")
+  set (CF_SEQAN_VERSION ${SEQAN_VERSION_STRING}.${SEQAN_LAST_CHANGED_DATE})
 else ()
   set (CF_SEQAN_VERSION "${SEQAN_VERSION_STRING}")
 endif ()


### PR DESCRIPTION
The version number in the plugin.properties file now gets generated from SEQAN_DATE which comes either from svn or git.
