### PR TITLE
Fix count member name resolution on gcc

### DIFF
--- a/core/include/seqan/bam_io/cigar.h
+++ b/core/include/seqan/bam_io/cigar.h
@@ -150,21 +150,21 @@ template <typename TOperation, typename TCount>
 inline bool operator>(CigarElement<TOperation, TCount> const & lhs,
                       CigarElement<TOperation, TCount> const & rhs)
 {
-    return lhs.operation > rhs.operation || (lhs.operation == rhs.operation && lhs.count > rhs.count);
+    return lhs.operation > rhs.operation || (lhs.operation == rhs.operation && (lhs.count) > (rhs.count));
 }
 
 template <typename TOperation, typename TCount>
 inline bool operator<(CigarElement<TOperation, TCount> const & lhs,
                       CigarElement<TOperation, TCount> const & rhs)
 {
-    return lhs.operation < rhs.operation || (lhs.operation == rhs.operation && lhs.count < rhs.count);
+    return lhs.operation < rhs.operation || (lhs.operation == rhs.operation && (lhs.count) < (rhs.count));
 }
 
 template <typename TOperation, typename TCount>
 inline bool operator==(CigarElement<TOperation, TCount> const & lhs,
                        CigarElement<TOperation, TCount> const & rhs)
 {
-    return lhs.operation == rhs.operation && lhs.count == rhs.count;
+    return lhs.operation == rhs.operation && (lhs.count) == (rhs.count);
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
A name resolution problem arises on gcc when defining the global function seqan::count()

seqan/core/include/seqan/bam_io/cigar.h: In function 'bool seqan::operator<(const seqan::CigarElement<TOperation, TCount>&, const seqan::CigarElement<TOperation, TCount>&)':
seqan/core/include/seqan/bam_io/cigar.h:160:96: error: '.' cannot appear in a constant-expression
seqan/core/include/seqan/bam_io/cigar.h:160:84: error: parse error in template argument list
