### PR TITLE
Dox fix 160

### DIFF
--- a/core/include/seqan/store/store_all.h
+++ b/core/include/seqan/store/store_all.h
@@ -2298,7 +2298,7 @@ void printAlignment(
  * 
  * @param[in,out] store The fragment store. Types: FragmentStore
  * @param[in]     score A score object used by @link globalAlignment @endlink in this function.
- * @param[in]      shrinkMatches States whether the matches should be shrinked. Types: True, False
+ * @param[in]     shrinkMatches States whether the matches should be shrinked. Types: True, False
  * 
  * @section Remarks
  * 


### PR DESCRIPTION
Added the missing third parameter of convertMatchesToGlobalAlignment in the dox docu.

Please close ticket 160 when merging
