### PR TITLE
[DOX,FIX] Adding @val tag to dox documentation.

### DIFF
--- a/core/include/seqan/arg_parse/arg_parse_argument.h
+++ b/core/include/seqan/arg_parse/arg_parse_argument.h
@@ -84,22 +84,22 @@ inline std::string getFileExtension(ArgParseArgument const & me, unsigned pos);
  */
 
 /*!
- * @var ArgParseArgument::ArgumentType STRING
+ * @val ArgParseArgument::ArgumentType STRING
  * @brief Argument is a string.
  *
- * @var ArgParseArgument::ArgumentType ArgParseArgument::INTEGER;
+ * @val ArgParseArgument::ArgumentType ArgParseArgument::INTEGER;
  * @brief Argument is a signed 32 bit integer.
  *
- * @var ArgParseArgument::ArgumentType ArgParseArgument::INT64;
+ * @val ArgParseArgument::ArgumentType ArgParseArgument::INT64;
  * @brief Argument is a signed 64 bit integer.
  *
- * @var ArgParseArgument::ArgumentType ArgParseArgument::DOUBLE;
+ * @val ArgParseArgument::ArgumentType ArgParseArgument::DOUBLE;
  * @brief Argument is a floating point number stored as double.
  *
- * @var ArgParseArgument::ArgumentType ArgParseArgument::INPUTFILE;
+ * @val ArgParseArgument::ArgumentType ArgParseArgument::INPUTFILE;
  * @brief Argument is an input file.
  *
- * @var ArgParseArgument::ArgumentType ArgParseArgument::OUTPUTFILE;
+ * @val ArgParseArgument::ArgumentType ArgParseArgument::OUTPUTFILE;
  * @brief Argument is an output file.
  */
 

--- a/core/include/seqan/arg_parse/argument_parser.h
+++ b/core/include/seqan/arg_parse/argument_parser.h
@@ -123,22 +123,22 @@ inline ArgParseArgument & getArgument(ArgumentParser & me, unsigned position);
  *
  * @signature enum ArgumentParser::ParseResult;
  *
- * @var ArgumentParser::ParseResult ArgumentParser::PARSE_OK;
+ * @val ArgumentParser::ParseResult ArgumentParser::PARSE_OK;
  * @brief Parsing the program's arguments was successful and no builtin command was triggered.
  *
- * @var ArgumentParser::ParseResult ArgumentParser::PARSE_ERROR;
+ * @val ArgumentParser::ParseResult ArgumentParser::PARSE_ERROR;
  * @brief There were errors parsing the arguments.
  *
- * @var ArgumentParser::ParseResult ArgumentParser::PARSE_HELP;
+ * @val ArgumentParser::ParseResult ArgumentParser::PARSE_HELP;
  * @brief Parsing was successful, built-in <tt>--help</tt> option was used.
  *
- * @var ArgumentParser::ParseResult ArgumentParser::PARSE_VERSION;
+ * @val ArgumentParser::ParseResult ArgumentParser::PARSE_VERSION;
  * @brief Parsing was successful, built-in <tt>--version</tt> option was used.
  *
- * @var ArgumentParser::ParseResult ArgumentParser::PARSE_WRITE_CTD;
+ * @val ArgumentParser::ParseResult ArgumentParser::PARSE_WRITE_CTD;
  * @brief Parsing was successful, built-in <tt>--write-ctd</tt> option was used.
  *
- * @var ArgumentParser::ParseResult ArgumentParser::PARSE_EXPORT_HELP;
+ * @val ArgumentParser::ParseResult ArgumentParser::PARSE_EXPORT_HELP;
  * @brief Parsing was successful, built-in <tt>--export-help</tt> option was used.
  */
 

--- a/core/include/seqan/bam_io/bam_alignment_record.h
+++ b/core/include/seqan/bam_io/bam_alignment_record.h
@@ -57,37 +57,37 @@ inline void clear(BamAlignmentRecord & record);
  *
  * @signature enum BamFlags;
  *
- * @var BamFlags BAM_FLAG_MULTIPLE = 0x0001;
+ * @val BamFlags BAM_FLAG_MULTIPLE = 0x0001;
  * @brief Template has multiple fragments in sequencing.
  *
- * @var BamFlags BAM_FLAG_ALL_PROPER = 0x0002;
+ * @val BamFlags BAM_FLAG_ALL_PROPER = 0x0002;
  * @brief All fragments in the template are properly mapped.
  *
- * @var BamFlags BAM_FLAG_UNMAPPED = 0x0004;
+ * @val BamFlags BAM_FLAG_UNMAPPED = 0x0004;
  * @brief This fragment is unmapped.
  *
- * @var BamFlags BAM_FLAG_NEXT_UNMAPPED = 0x0008;
+ * @val BamFlags BAM_FLAG_NEXT_UNMAPPED = 0x0008;
  * @brief Next fragment in template is unmapped.
  *
- * @var BamFlags BAM_FLAG_RC = 0x0010;
+ * @val BamFlags BAM_FLAG_RC = 0x0010;
  * @brief Fragment is reverse-complemented.
  *
- * @var BamFlags BAM_FLAG_NEXT_RC = 0x0020;
+ * @val BamFlags BAM_FLAG_NEXT_RC = 0x0020;
  * @brief Next fragment in template is reverse-complemented.
  *
- * @var BamFlags BAM_FLAG_FIRST = 0x0040;
+ * @val BamFlags BAM_FLAG_FIRST = 0x0040;
  * @brief This fragment is the first one in its template.
  *
- * @var BamFlags BAM_FLAG_LAST = 0x0080;
+ * @val BamFlags BAM_FLAG_LAST = 0x0080;
  * @brief This fragment is the last one in its template (second in case of paired sequencing).
  *
- * @var BamFlags BAM_FLAG_SECONDARY = 0x0100;
+ * @val BamFlags BAM_FLAG_SECONDARY = 0x0100;
  * @brief Secondary alignment.
  *
- * @var BamFlags BAM_FLAG_QC_NO_PASS = 0x0200;
+ * @val BamFlags BAM_FLAG_QC_NO_PASS = 0x0200;
  * @brief Does not pass quality controls.
  *
- * @var BamFlags BAM_FLAG_DUPLICATE = 0x0400;
+ * @val BamFlags BAM_FLAG_DUPLICATE = 0x0400;
  * @brief PCR or optical duplicate.
  */
 

--- a/core/include/seqan/bam_io/bam_header_record.h
+++ b/core/include/seqan/bam_io/bam_header_record.h
@@ -55,19 +55,19 @@ namespace seqan {
  *
  * @signature enum BamHeaderRecordType;
  *
- * @var BamHeaderRecordType BAM_HEADER_FIRST = 0;
+ * @val BamHeaderRecordType BAM_HEADER_FIRST = 0;
  * @brief Is the first header (HD).
  *
- * @var BamHeaderRecordType BAM_HEADER_REFERENCE = 1;
+ * @val BamHeaderRecordType BAM_HEADER_REFERENCE = 1;
  * @brief Is a reference (SQ) header.
  *
- * @var BamHeaderRecordType BAM_HEADER_READ_GROUP = 2;
+ * @val BamHeaderRecordType BAM_HEADER_READ_GROUP = 2;
  * @brief Is a read group (RG) header.
  *
- * @var BamHeaderRecordType BAM_HEADER_PROGRAM = 3;
+ * @val BamHeaderRecordType BAM_HEADER_PROGRAM = 3;
  * @brief Is a program (PG) header.
  *
- * @var BamHeaderRecordType BAM_HEADER_COMMENT = 4;
+ * @val BamHeaderRecordType BAM_HEADER_COMMENT = 4;
  * @brief Is a comment (CO) header.
  */
 
@@ -100,16 +100,16 @@ enum BamHeaderRecordType
  *
  * @signature enum BamSortOrder;
  *
- * @var BamSortOrder BAM_SORT_UNKNOWN = 0;
+ * @val BamSortOrder BAM_SORT_UNKNOWN = 0;
  * @brief BAM file sort order is unknown.
  *
- * @var BamSortOrder BAM_SORT_UNSORTED = 1;
+ * @val BamSortOrder BAM_SORT_UNSORTED = 1;
  * @brief BAM file is unsorted.
  *
- * @var BamSortOrder BAM_SORT_QUERYNAME = 2;
+ * @val BamSortOrder BAM_SORT_QUERYNAME = 2;
  * @brief BAM file is sorted by query name;
  *
- * @var BamSortOrder BAM_SORT_COORDINATE = 3;
+ * @val BamSortOrder BAM_SORT_COORDINATE = 3;
  * @brief BAM file is sorted by coordinate.
  */
 

--- a/core/include/seqan/bam_io/bam_stream.h
+++ b/core/include/seqan/bam_io/bam_stream.h
@@ -201,10 +201,10 @@ When writing, the $bamIOContext$ is automatically filled/reset when the first re
  *
  * @signature enum BamStream::OperationMode;
  *
- * @var BamStream::OperationMode BamStream::READ;
+ * @val BamStream::OperationMode BamStream::READ;
  * @brief Enum value for reading.
  *
- * @var BamStream::OperationMode BamStream::WRITE;
+ * @val BamStream::OperationMode BamStream::WRITE;
  * @brief Enum value for writing.
  */
 
@@ -217,14 +217,14 @@ When writing, the $bamIOContext$ is automatically filled/reset when the first re
  *
  * @see BamStream
  *
- * @var BamStream::Format BamStream::AUTO;
+ * @val BamStream::Format BamStream::AUTO;
  * @brief Auto-detect the format from file content on reading and from the file name on writing.  If auto-detection
  *        fails, SAM is used.
  *
- * @var BamStream::Format BamStream::SAM;
+ * @val BamStream::Format BamStream::SAM;
  * @brief Force reading/writing of SAM.
  *
- * @var BamStream::Format BamStream::BAM;
+ * @val BamStream::Format BamStream::BAM;
  * @brief Force reading/writing of BAM.
  */
 

--- a/core/include/seqan/file/file_interface.h
+++ b/core/include/seqan/file/file_interface.h
@@ -137,32 +137,32 @@ namespace seqan {
  *     // do something if opened in read-only mode
  * @endlink
  *
- * @var FileOpenMode OPEN_RDONLY
+ * @val FileOpenMode OPEN_RDONLY
  * @brief Open in read-only mode.
  *
- * @var FileOpenMode OPEN_WRONLY
+ * @val FileOpenMode OPEN_WRONLY
  * @brief Open in write-only mode.
  *
- * @var FileOpenMode OPEN_RDWR
+ * @val FileOpenMode OPEN_RDWR
  * @brief Open for reading and writing.
  *
- * @var FileOpenMode OPEN_CREATE
+ * @val FileOpenMode OPEN_CREATE
  * @brief Create the file if it does not yet exists.
  *
- * @var FileOpenMode OPEN_APPEND
+ * @val FileOpenMode OPEN_APPEND
  * @brief Keep the existing data.  If this flag is not given then the file is cleared in write mode.
  *
- * @var FileOpenMode OPEN_QUIET
+ * @val FileOpenMode OPEN_QUIET
  * @brief Don't print any warning message if the file could not be opened.
  *
- * @var FileOpenMode OPEN_MASK
+ * @val FileOpenMode OPEN_MASK
  * @brief (Internal) Bitmask to extract the read/write open mode.
  *
- * @var FileOpenMode OPEN_ASYNC
+ * @val FileOpenMode OPEN_ASYNC
  * @brief (Internal) Open the file for asynchronous file access.  For asynchronous file access, use the @link AsyncFile
  *                   @endlink.
  *
- * @var FileOpenMode OPEN_TEMPORARY
+ * @val FileOpenMode OPEN_TEMPORARY
  * @brief (Internal) Open automatically delete the file after close.  Use the <tt>openTemp</tt> methods to open
  *        temporary files.
  */

--- a/core/include/seqan/file/file_mapping.h
+++ b/core/include/seqan/file/file_mapping.h
@@ -58,16 +58,16 @@ namespace seqan {
  * The mapping mode must be compatible to the open mode of a @link FileMapping @endlink, e.g. <tt>MAP_RDWR</tt> is not
  * allowed if the file mapping was opened with <tt>OPEN_RDONLY</tt>.
  *
- * @var FileMappingMode MAP_RDONLY = 1;
+ * @val FileMappingMode MAP_RDONLY = 1;
  * @brief Map the segment in read-only mode.
  *
- * @var FileMappingMode MAP_WRONLY = 2;
+ * @val FileMappingMode MAP_WRONLY = 2;
  * @brief Map the segment in write-only mode.
  *
- * @var FileMappingMode MAP_RDWR = 3;
+ * @val FileMappingMode MAP_RDWR = 3;
  * @brief Map the segment for reading and writing.
  *
- * @var FileMappingMode MAP_COPYONWRITE = 4;
+ * @val FileMappingMode MAP_COPYONWRITE = 4;
  * @brief Write accesses are not written back to file and not shared among different mappings.
  */
 
@@ -99,19 +99,19 @@ enum FileMappingMode {
  *
  * @signature enum FileMappingAdvise;
  *
- * @var FileMappingAdvise MAP_NORMAL;
+ * @val FileMappingAdvise MAP_NORMAL;
  * @brief There is no advise on the given address range.
  *
- * @var FileMappingAdvise MAP_RANDOM;
+ * @val FileMappingAdvise MAP_RANDOM;
  * @brief The address range will be accessed with random access memory pattern.
  *
- * @var FileMappingAdvise MAP_SEQUENTIAL;
+ * @val FileMappingAdvise MAP_SEQUENTIAL;
  * @brief The address range will be accessed sequentially.
  *
- * @var FileMappingAdvise MAP_WILLNEED;
+ * @val FileMappingAdvise MAP_WILLNEED;
  * @brief The address range in the advise will be needed in the future.
  *
- * @var FileMappingAdvise MAP_DONTNEED;
+ * @val FileMappingAdvise MAP_DONTNEED;
  * @brief The address range in the advise will not be needed any more.
  */
 

--- a/core/include/seqan/gff_io/gff_stream.h
+++ b/core/include/seqan/gff_io/gff_stream.h
@@ -155,10 +155,10 @@ For writing, only GFF 3 and GTF are supported.
  * 
  * @see GffStream
  * 
- * @var GffStream::FileFormat GffStream::GFF
+ * @val GffStream::FileFormat GffStream::GFF
  * @brief GFF file format.
  * 
- * @var GffStream::FileFormat GffStream::GTF
+ * @val GffStream::FileFormat GffStream::GTF
  * @brief GTF file format.
  */
 
@@ -172,13 +172,13 @@ For writing, only GFF 3 and GTF are supported.
  * @see GffStream#open
  * @see GffStream::GffStream
  * 
- * @var GffStream::Mode GffStream::READ
+ * @val GffStream::Mode GffStream::READ
  * @brief Open in read mode.
  * 
- * @var GffStream::Mode GffStream::WRITE
+ * @val GffStream::Mode GffStream::WRITE
  * @brief Open in write mode.
  * 
- * @var GffStream::Mode GffStream::INVALID
+ * @val GffStream::Mode GffStream::INVALID
  * @brief Invalid open mode.
  */
 

--- a/core/include/seqan/seeds/seeds_extension.h
+++ b/core/include/seqan/seeds/seeds_extension.h
@@ -117,16 +117,16 @@ typedef Tag<GappedXDrop_> const GappedXDrop;
  *
  * @see Seed#extendSeed
  *
- * @var ExtensionDirection EXTEND_NONE = 0;
+ * @val ExtensionDirection EXTEND_NONE = 0;
  * @brief Perform no extension.
  *
- * @var ExtensionDirection EXTEND_LEFT = 1;
+ * @val ExtensionDirection EXTEND_LEFT = 1;
  * @brief Perform extension towards the left.
  *
- * @var ExtensionDirection EXTEND_RIGHT = 2;
+ * @val ExtensionDirection EXTEND_RIGHT = 2;
  * @brief Perform extension towards the right.
  *
- * @var ExtensionDirection EXTEND_BOTH = 3;
+ * @val ExtensionDirection EXTEND_BOTH = 3;
  * @brief Perform extension to both directions.
  */
 

--- a/core/include/seqan/seq_io/sequence_stream.h
+++ b/core/include/seqan/seq_io/sequence_stream.h
@@ -134,13 +134,13 @@ namespace seqan {
  *
  * @see SequenceStream
  * 
- * @var SequenceStream::OperationMode SequenceStream::READ;
+ * @val SequenceStream::OperationMode SequenceStream::READ;
  * @brief Open stream for reading.
  * 
- * @var SequenceStream::OperationMode SequenceStream::WRITE;
+ * @val SequenceStream::OperationMode SequenceStream::WRITE;
  * @brief Open stream for writing.
  * 
- * @var SequenceStream::OperationMode SequenceStream::READ_PERSISTENT;
+ * @val SequenceStream::OperationMode SequenceStream::READ_PERSISTENT;
  * @brief Open stream for reading, mark as "persistent reading".  See @link SequenceStream @endlink for more information
  *        on the difference between normal and persistent reading.
  */
@@ -156,18 +156,18 @@ namespace seqan {
  * 
  * @see SequenceStream
  * 
- * @var SequenceStream::FileType SequenceStream::AUTO_TYPE;
+ * @val SequenceStream::FileType SequenceStream::AUTO_TYPE;
  * 
  * @brief Auto-detect format from file content on reading and from the file name on writing.  If Auto-detection fails,
  *        <tt>PLAIN_TEXT</tt> is used.
  * 
- * @var SequenceStream::FileType SequenceStream::PLAIN_TEXT;
+ * @val SequenceStream::FileType SequenceStream::PLAIN_TEXT;
  * @brief Force reading/writing of plain text.
  * 
- * @var SequenceStream::FileType SequenceStream::BZ2;
+ * @val SequenceStream::FileType SequenceStream::BZ2;
  * @brief Force reading/writing with bzip compression.
  * 
- * @var SequenceStream::FileType SequenceStream::GZ;
+ * @val SequenceStream::FileType SequenceStream::GZ;
  * @brief Force reading/writing with gzip compression.
  */
 
@@ -182,14 +182,14 @@ namespace seqan {
  * 
  * @see SequenceStream
  * 
- * @var SequenceStream::FileFormat SequenceStream::AUTO_FORMAT;
+ * @val SequenceStream::FileFormat SequenceStream::AUTO_FORMAT;
  * @brief Auto-detect format from file content on reading and from the file name on writing.  If Auto-detection fails,
  *        FASTA is used.
  * 
- * @var SequenceStream::FileFormat SequenceStream::FASTA;
+ * @val SequenceStream::FileFormat SequenceStream::FASTA;
  * @brief Force reading/writing of FASTA.
  * 
- * @var SequenceStream::FileFormat SequenceStream::FASTQ;
+ * @val SequenceStream::FileFormat SequenceStream::FASTQ;
  * @brief Force reading/writing of FASTQ.
  */
 

--- a/core/include/seqan/store/store_all.h
+++ b/core/include/seqan/store/store_all.h
@@ -375,28 +375,28 @@ struct FragmentStoreConfig
  *
  * @signature enum FragmentStore::PredefinedAnnotationTypes;
  *
- * @var FragmentStore::PredefinedAnnotationTypes FragmentStore::ANNO_ROOT;
+ * @val FragmentStore::PredefinedAnnotationTypes FragmentStore::ANNO_ROOT;
  * @brief The root node ("&lt;node&gt;").
  *
- * @var FragmentStore::PredefinedAnnotationTypes FragmentStore::ANNO_GENE;
+ * @val FragmentStore::PredefinedAnnotationTypes FragmentStore::ANNO_GENE;
  * @brief A gene ("gene").
  *
- * @var FragmentStore::PredefinedAnnotationTypes FragmentStore::ANNO_MRNA;
+ * @val FragmentStore::PredefinedAnnotationTypes FragmentStore::ANNO_MRNA;
  * @brief An mRNA sequence, aka transcript ("mRNA").
  *
- * @var FragmentStore::PredefinedAnnotationTypes FragmentStore::ANNO_CDS;
+ * @val FragmentStore::PredefinedAnnotationTypes FragmentStore::ANNO_CDS;
  * @brief A coding region ("CDS");
  *
- * @var FragmentStore::PredefinedAnnotationTypes FragmentStore::ANNO_EXON;
+ * @val FragmentStore::PredefinedAnnotationTypes FragmentStore::ANNO_EXON;
  * @brief An exon ("exon").
  *
- * @var FragmentStore::PredefinedAnnotationTypes FragmentStore::ANNO_FIVE_PRIME_UTR;
+ * @val FragmentStore::PredefinedAnnotationTypes FragmentStore::ANNO_FIVE_PRIME_UTR;
  * @brief A 5' untranslated region ("five_prime_UTR").
  *
- * @var FragmentStore::PredefinedAnnotationTypes FragmentStore::ANNO_INTRON;
+ * @val FragmentStore::PredefinedAnnotationTypes FragmentStore::ANNO_INTRON;
  * @brief An intron ("intron").
  *
- * @var FragmentStore::PredefinedAnnotationTypes FragmentStore::ANNO_THREE_PRIME_UTR;
+ * @val FragmentStore::PredefinedAnnotationTypes FragmentStore::ANNO_THREE_PRIME_UTR;
  * @brief A 3' untranslated region ("three_prime_UTR").
  */
 

--- a/core/include/seqan/stream/tokenize.h
+++ b/core/include/seqan/stream/tokenize.h
@@ -58,13 +58,13 @@ namespace seqan {
  *
  * @signature enum TokenizeResult;
  *
- * @var TokenizeResult SUCCESS = 0;
+ * @val TokenizeResult SUCCESS = 0;
  * @brief Reading the specified data succeeded.
  *
- * @var TokenizeResult EOF_BEFORE_SUCCESS = 1024;
+ * @val TokenizeResult EOF_BEFORE_SUCCESS = 1024;
  * @brief End of file was reached before the read/skip operation succeeded.
  *
- * @var TokenizeResult NO_SUCCESS = 1025;
+ * @val TokenizeResult NO_SUCCESS = 1025;
  * @brief The pattern was not found but we are not at EOF (may be returned when tokenizing on limited scope.
  */
 

--- a/extras/include/seqan/bed_io/bed_stream.h
+++ b/extras/include/seqan/bed_io/bed_stream.h
@@ -123,18 +123,20 @@ namespace seqan {
  * @enum BedStream::Mode
  * @headerfile <seqan/bed_io.h>
  * @brief Open mode for the @link BedStream @endlink class.
+ *
+ * @signature enum BedStream::Mode;
  * 
  * @see BedStream
  * @see BedStream#open
  * @see BedStream::BedStream
  * 
- * @var BedStream::Mode READ;
+ * @val BedStream::Mode READ;
  * @brief Open in read mode.
  * 
- * @var BedStream::Mode WRITE;
+ * @val BedStream::Mode WRITE;
  * @brief Open in write mode.
  * 
- * @var BedStream::Mode INVALID;
+ * @val BedStream::Mode INVALID;
  * @brief Invalid open mode.
  */
 

--- a/extras/include/seqan/translation/translation.h
+++ b/extras/include/seqan/translation/translation.h
@@ -65,16 +65,16 @@ namespace seqan {
  *
  * @signature enum TranslationOptions;
  *
- * @var TranslationOptions SINGLE_FRAME = 0;
+ * @val TranslationOptions SINGLE_FRAME = 0;
  * @brief Translate the sequence(s) "as is", n input sequences result in n output sequences.
  *
- * @var TranslationOptions WITH_REV_COMP = 1;
+ * @val TranslationOptions WITH_REV_COMP = 1;
  * @brief Translate the sequence(s) as well as their reverse complements (n -> * 2n).
  *
- * @var TranslationOptions WITH_FRAME_SHIFT = 2;
+ * @val TranslationOptions WITH_FRAME_SHIFT = 2;
  * @brief Translate the sequence(s) as well as their shifted frames (n -> 3n).
  *
- * @var TranslationOptions SIX_FRAME = 3;
+ * @val TranslationOptions SIX_FRAME = 3;
  * @brief Equals (WITH_REV_COMP | WITH_FRAME_SHIFT); shifted frames of original and reverse complement are
  *        translated (n -> 6n).
  */

--- a/extras/include/seqan/vcf_io/vcf_stream.h
+++ b/extras/include/seqan/vcf_io/vcf_stream.h
@@ -87,13 +87,13 @@ namespace seqan {
  *
  * @signature enum VcfStream::Mode;
  *
- * @var VcfStream::Mode VcfStream::INVALID;
+ * @val VcfStream::Mode VcfStream::INVALID;
  * @brief Invalid open mode.
  *
- * @var VcfStream::Mode VcfStream::READ;
+ * @val VcfStream::Mode VcfStream::READ;
  * @brief Open file for reading.
  *
- * @var VcfStream::Mode VcfStream::WRITE;
+ * @val VcfStream::Mode VcfStream::WRITE;
  * @brief Open file for writing.
  */
 

--- a/util/py_lib/seqan/dox/dox_parser.py
+++ b/util/py_lib/seqan/dox/dox_parser.py
@@ -476,6 +476,7 @@ class TopLevelState(object):
                          'COMMAND_MAINPAGE':     'mainpage',
                          'COMMAND_DEFGROUP':     'group',
                          'COMMAND_VARIABLE':     'var',
+                         'COMMAND_VALUE':        'val',
                          'COMMAND_TAG':          'tag',
                          'COMMAND_TYPEDEF':      'typedef',
                          'COMMAND_ADAPTION':     'adaption',
@@ -750,8 +751,8 @@ class GroupState(GenericDocState):
 class VariableState(GenericDocState):
     """State for a variable."""
         
-    def __init__(self, parser):
-        GenericDocState.__init__(self, parser, raw_doc.RawVariable, 'var')
+    def __init__(self, parser, entry_class=raw_doc.RawVariable, state_name='var'):
+        GenericDocState.__init__(self, parser, entry_class, state_name)
         self.allowed_commands = set(['COMMAND_SIGNATURE', 'COMMAND_CODE', 'COMMAND_HTMLONLY',
                                      'COMMAND_SEE', 'COMMAND_BRIEF',
                                      'COMMAND_SECTION', 'COMMAND_SUBSECTION',
@@ -802,6 +803,14 @@ class VariableState(GenericDocState):
                     self.type_tokens.append(token)
         else:
             GenericDocState.handle(self, token)
+
+
+
+class EnumValueState(VariableState):
+    """State for an enum value."""
+
+    def __init__(self, parser):
+        VariableState.__init__(self, parser, raw_doc.RawEnumValue, 'val')
 
 
 
@@ -875,6 +884,7 @@ class Parser(object):
             'mainpage':     MainPageState(self),
             'group':        GroupState(self),
             'var':          VariableState(self),
+            'val':          EnumValueState(self),
             'tag':          TagState(self),
             'enum':         EnumState(self),
             'adaption':     AdaptionState(self),

--- a/util/py_lib/seqan/dox/dox_tokens.py
+++ b/util/py_lib/seqan/dox/dox_tokens.py
@@ -19,7 +19,8 @@ def escapeLiterals(s):
 WHITESPACE = set(['SPACE', 'EMPTYLINE', 'BREAK'])
 ITEM_STARTING = set(['COMMAND_CLASS', 'COMMAND_CONCEPT', 'COMMAND_FUNCTION', 'COMMAND_MACRO',
                      'COMMAND_METAFUNCTION', 'COMMAND_PAGE', 'COMMAND_MAINPAGE', 'COMMAND_DEFGROUP',
-                     'COMMAND_VARIABLE', 'COMMAND_TAG', 'COMMAND_ENUM', 'COMMAND_TYPEDEF', 'COMMAND_ADAPTION'])
+                     'COMMAND_VARIABLE', 'COMMAND_VALUE', 'COMMAND_TAG', 'COMMAND_ENUM',
+                     'COMMAND_TYPEDEF', 'COMMAND_ADAPTION'])
 CLAUSE_STARTING = set(['COMMAND_SIGNATURE', 'COMMAND_CODE', 'COMMAND_SEE', 'COMMAND_BRIEF',
                        'COMMAND_RETURN', 'COMMAND_PARAM', 'COMMAND_TPARAM',
                        'COMMAND_SECTION', 'COMMAND_SUBSECTION', 'COMMAND_INCLUDE',
@@ -38,6 +39,7 @@ LEXER_TOKENS = (
     ('COMMAND_MACRO',        r'@macro'),
     ('COMMAND_METAFUNCTION', r'@mfn'),
     ('COMMAND_VARIABLE',     r'@var'),
+    ('COMMAND_VALUE',        r'@val'),
     ('COMMAND_TAG',          r'@tag'),
     ('COMMAND_ENUM',         r'@enum'),
     ('COMMAND_PAGE',         r'@page'),

--- a/util/py_lib/seqan/dox/raw_doc.py
+++ b/util/py_lib/seqan/dox/raw_doc.py
@@ -142,7 +142,7 @@ class RawEntry(object):
     def entryTypes(cls):
         """RawReturns iterable with all entry types."""
         res = ('concept', 'class', 'function', 'metafunction', 'page', 'enum', 'var',
-               'tag', 'defgroup', 'macro')
+               'tag', 'defgroup', 'macro', 'enum_value')
         return res
 
     def addParagraph(self, p):
@@ -254,7 +254,7 @@ class RawCodeEntry(RawEntry):
 
 
 class RawVariable(RawCodeEntry):
-    """RawDoc for one variable or enum constant.
+    """RawDoc for one variable constant.
 
     @ivar type: The type of the variable as a RawText or None.
     """
@@ -305,6 +305,20 @@ class RawVariable(RawCodeEntry):
             res.append(x.getFormatted(formatter))
         res.append('\n')
         return ''.join(res)
+
+
+class RawEnumValue(RawVariable):
+    """RawDoc for one enum value.
+
+    @ivar type: The type of the variable as a RawText or None.
+    """
+
+    def __init__(self, first_token, briefs=[]):
+        RawCodeEntry.__init__(self, first_token, briefs=briefs, command='val')
+        self.type = None
+
+    def getType(self):
+        return 'enum_value'
 
 
 class RawTag(RawCodeEntry):

--- a/util/py_lib/seqan/dox/tpl/sections.html
+++ b/util/py_lib/seqan/dox/tpl/sections.html
@@ -68,23 +68,23 @@ Render the inheritance information of the given entr.
 
   {% if entry.extends %}
   <tr>
-	<th>Extends</th>
-	<td>
-	  {% for e in entry.extends|sort -%}
-		{{ e|translink }}{% if not loop.last %}, {% endif %}
-	  {% endfor %}
-	</td>
+    <th>Extends</th>
+    <td>
+      {% for e in entry.extends|sort -%}
+        {{ e|translink }}{% if not loop.last %}, {% endif %}
+      {% endfor %}
+    </td>
   </tr>
   {% endif %}
 
   {% if entry.implements %}
   <tr>
-  	<th>Implements</dt>
-  	<td>
+    <th>Implements</dt>
+    <td>
     {% for e in entry.implements|sort -%}
       {{ e|translink }}{% if not loop.last %}, {% endif %}
     {% endfor %}
-  	</td>
+    </td>
   </tr>
   {% endif %}
 
@@ -157,45 +157,45 @@ Render the inheritance information of the given class.
 <table class="overview">
   {% if concept.extends %}
   <tr>
-		<th>Extends</th>
-		<td>
-		{% for e in concept.extends|sort -%}
-			{{ e|translink }}{% if not loop.last %}, {% endif %}
-		{% endfor %}
-		</td>
+        <th>Extends</th>
+        <td>
+        {% for e in concept.extends|sort -%}
+            {{ e|translink }}{% if not loop.last %}, {% endif %}
+        {% endfor %}
+        </td>
   </tr>
   {% endif %}
 
   {% if concept.all_extended %}
   <tr>
-		<th>All Extended Concepts</th>
-		<td>
-		{% for e in concept.all_extended|sort -%}
-			{{ e|translink }}{% if not loop.last %}, {% endif %}
-		{% endfor %}
-		</td>
+        <th>All Extended Concepts</th>
+        <td>
+        {% for e in concept.all_extended|sort -%}
+            {{ e|translink }}{% if not loop.last %}, {% endif %}
+        {% endfor %}
+        </td>
   </tr>
   {% endif %}
 
   {% if concept.all_extending %}
   <tr>
-		<th>All Known Refinements</th>
-		<td>
-		{% for e in concept.all_extending|sort -%}
-			{{ e|translink }}{% if not loop.last %}, {% endif %}
-		{% endfor %}
-		</td>
+        <th>All Known Refinements</th>
+        <td>
+        {% for e in concept.all_extending|sort -%}
+            {{ e|translink }}{% if not loop.last %}, {% endif %}
+        {% endfor %}
+        </td>
   </tr>
   {% endif %}
 
   {% if concept.all_implementing %}
   <tr>
-		<th>All Implementing Classes</th>
-		<td>
-		{% for e in concept.all_implementing|sort -%}
-			{{ e|translink }}{% if not loop.last %}, {% endif %}
-		{% endfor %}
-		</td>
+        <th>All Implementing Classes</th>
+        <td>
+        {% for e in concept.all_implementing|sort -%}
+            {{ e|translink }}{% if not loop.last %}, {% endif %}
+        {% endfor %}
+        </td>
   </tr>
   {% endif %}
 </table>
@@ -622,14 +622,14 @@ Macro enum_values_ov(entry, doc)
 Render the member variables overview
 -->
 {% macro enum_values_ov(entry, doc) %}
-{% if entry.hasSubEntry('variables', doc) %}
+{% if entry.hasSubEntry('enum_value', doc) %}
 
 <div data-lang-entity-container="enum">
 <h2 data-lang-entity="enum">Enum Values Overview</h2>
 
-{% if entry.subentries['variable'] -%}
+{% if entry.subentries['enum_value'] -%}
 <ul class="summary">
-  {% for entry in entry.subentries['variable'] %}
+  {% for entry in entry.subentries['enum_value'] %}
   <li class="public">
     <span class="summary_signature"><code><a href="#{{ entry.name|escape_anchor|url_encode }}" title="#{{entry.name}} (interface function)" data-lang-entity="{{entry.kind}}">
         {{ entry.type|e }} {{ entry.name|e }}
@@ -642,7 +642,7 @@ Render the member variables overview
 
 </div>
 
-{% endif %}  {#{% if entry.hasSubEntry('variables', doc) %}#}
+{% endif %}  {#{% if entry.hasSubEntry('enum_value', doc) %}#}
 {% endmacro %}
 
 <!--
@@ -896,10 +896,10 @@ Render the interface functions details
   {% if subentry.tparams %}
   <h4>Template Parameters</h4>
   <table class="overview">
-  	{% for param in subentry.tparams %}
-  	<tr>
-  		<th><code>{{ param.type|e }}</code>&nbsp;</th>
-  		<td>{{ param.desc|transtext(False) }}</td>
+    {% for param in subentry.tparams %}
+    <tr>
+        <th><code>{{ param.type|e }}</code>&nbsp;</th>
+        <td>{{ param.desc|transtext(False) }}</td>
     </tr>
     {% endfor %}
   </table>
@@ -908,25 +908,25 @@ Render the interface functions details
   {% if subentry.params %}
   <h4>Parameters</h4>
   <table class="overview">
-  	{% for param in subentry.params %}
-  	<tr>
-  	  <th>
-		{% if param.in_out %}
-			{% if param.in_out == 'IN' %}
-				<code data-param-type="in" title="IN parameters are only read and not modified">{{ param.name|e }}</code>
-			{% elif param.in_out == 'OUT' %}
-				<code data-param-type="out" title="OUT parameters are modified and used as a means to return values">{{ param.name|e }}</code>
-			{% elif param.in_out == 'IN_OUT' %}
-				<code data-param-type="in_out" title="IN/OUT parameters are read and also modified by the called function">{{ param.name|e }}</code>
-			{% else %}
-				<code>{{ param.name|e }}</code>
-			{% endif %}
-		{% else %}
-			<code>{{ param.name|e }}</code>
-		{% endif %}
-  	  </th>
-  	  <td>{{ param.desc|transtext(False) }}</td>
-  	</tr>
+    {% for param in subentry.params %}
+    <tr>
+      <th>
+        {% if param.in_out %}
+            {% if param.in_out == 'IN' %}
+                <code data-param-type="in" title="IN parameters are only read and not modified">{{ param.name|e }}</code>
+            {% elif param.in_out == 'OUT' %}
+                <code data-param-type="out" title="OUT parameters are modified and used as a means to return values">{{ param.name|e }}</code>
+            {% elif param.in_out == 'IN_OUT' %}
+                <code data-param-type="in_out" title="IN/OUT parameters are read and also modified by the called function">{{ param.name|e }}</code>
+            {% else %}
+                <code>{{ param.name|e }}</code>
+            {% endif %}
+        {% else %}
+            <code>{{ param.name|e }}</code>
+        {% endif %}
+      </th>
+      <td>{{ param.desc|transtext(False) }}</td>
+    </tr>
     {% endfor %}
   </table>
   {% endif %}
@@ -934,10 +934,10 @@ Render the interface functions details
   {% if subentry.returns %}
   <h4>Returns</h4>
   <table class="overview">
-  	{% for ret in subentry.returns %}
-  	<tr>
-  		<th><code>{{ ret.type|e }}</code>&nbsp;</th>
-  		<td>{{ ret.desc|transtext(False) }}</td>
+    {% for ret in subentry.returns %}
+    <tr>
+        <th><code>{{ ret.type|e }}</code>&nbsp;</th>
+        <td>{{ ret.desc|transtext(False) }}</td>
     </tr>
     {% endfor %}
   </table>
@@ -954,7 +954,7 @@ Render the interface functions details
   <ul>
     {% for link in subentry.sees %}
     <li>{{ link|transtext(False)|translink }}</li>
-	{% endfor %}
+    {% endfor %}
   </ul>
   {% endif %}
   {% endfor %}
@@ -975,32 +975,32 @@ Render the member typedef details
   <h2 data-lang-entity="member_typedef">{{ qualifier }} Typedef Detail</h2>
 
   {% for subentry in entry.subentries[key] %}
-	  <div class="method_details{% if loop.first %} first{% endif %}">
-		<h3 data-toc="hidden" id="{{ subentry.name|escape_anchor }}" class="signature{% if loop.first %} first{% endif %}" data-lang-entity="{{key}}">
-		  <code>
-			  {%- for s in subentry.signatures: -%}
-			  {{ s|transtext(False) }}{% if not loop.last %}
-	{% endif -%}{%- endfor -%}
-		  </code>
-		</h3>
-	  </div>
-	  <div class="docstring">
-		<div class="discussion">
-		  {{ subentry.brief|transtext }}
-		  {{ body(subentry, start_heading=4) }}
-		</div>
-	  </div>
+      <div class="method_details{% if loop.first %} first{% endif %}">
+        <h3 data-toc="hidden" id="{{ subentry.name|escape_anchor }}" class="signature{% if loop.first %} first{% endif %}" data-lang-entity="{{key}}">
+          <code>
+              {%- for s in subentry.signatures: -%}
+              {{ s|transtext(False) }}{% if not loop.last %}
+    {% endif -%}{%- endfor -%}
+          </code>
+        </h3>
+      </div>
+      <div class="docstring">
+        <div class="discussion">
+          {{ subentry.brief|transtext }}
+          {{ body(subentry, start_heading=4) }}
+        </div>
+      </div>
 
-	  {% if subentry.sees %}
-	  <div class="tags">
-		<h4>See Also</h4>
-		<ul class="see">
-		  {% for link in subentry.sees %}
-		  	<li>{{ link|transtext(False)|translink }}</li>
-		  {% endfor %}
-		</ul>
-	  </div>
-	  {% endif %}
+      {% if subentry.sees %}
+      <div class="tags">
+        <h4>See Also</h4>
+        <ul class="see">
+          {% for link in subentry.sees %}
+            <li>{{ link|transtext(False)|translink }}</li>
+          {% endfor %}
+        </ul>
+      </div>
+      {% endif %}
   {% endfor %}
   
 </div>
@@ -1075,26 +1075,26 @@ Render the interface metafunctions details
 
   {% if subentry.tparams %}
   <h4>Template Parameters</h4>
-	<table class="overview">
-	{% for param in subentry.tparams %}
-		<tr>
-			<th><code>{{ param.type|e }}</code>&nbsp;</th>
-			<td>{{ param.desc|transtext(False) }}</td>
-		</tr>
-	{% endfor %}
-	</table>
+    <table class="overview">
+    {% for param in subentry.tparams %}
+        <tr>
+            <th><code>{{ param.type|e }}</code>&nbsp;</th>
+            <td>{{ param.desc|transtext(False) }}</td>
+        </tr>
+    {% endfor %}
+    </table>
   {% endif %}
 
   {% if subentry.returns %}
   <h4>Returns</h4>
-	<table class="overview">
-	{% for ret in subentry.returns %}
-		<tr>
-			<th><code>{{ ret.type|e }}</code>&nbsp;</th>
-			<td>{{ ret.desc|transtext(False) }}</td>
-		</tr>
-	{% endfor %}
-	</table>
+    <table class="overview">
+    {% for ret in subentry.returns %}
+        <tr>
+            <th><code>{{ ret.type|e }}</code>&nbsp;</th>
+            <td>{{ ret.desc|transtext(False) }}</td>
+        </tr>
+    {% endfor %}
+    </table>
   {% endif %}
 
   <div class="docstring">
@@ -1145,29 +1145,20 @@ Render the member enum details
 -->
 
 {% macro enum_values(entry, qualifier='Member') %}
-{% if entry.subentries['variable'] or entry.subentries['member_variable'] -%}
+{% if entry.subentries['enum_value'] -%}
 <div class="enum_value_details" data-lang-entity-container="enum">
 
   <h2 data-lang-entity="enum">Enum Values</h2>
 
   <table class="overview">
-  	{% for subentry in entry.subentries['member_variable'] %}
-		<tr>
-			<th><code>{{ subentry.local_name|e }}</code>&nbsp;</th>
-			<td>
-				{{ subentry.brief|transtext }}
-				{{ body(subentry, start_heading=3) }}
-			</td>
-		</tr>
-    {% endfor %}
-  	{% for subentry in entry.subentries['variable'] %}
-  	<tr>
-			<th><code>{{ subentry.name|e }}</code>&nbsp;</th>
-			<td>
-				{{ subentry.brief|transtext }}
-				{{ body(subentry, start_heading=3) }}
-			</td>
-		</tr>
+    {% for subentry in entry.subentries['enum_value'] %}
+         <tr>
+            <th><code>{{ subentry.local_name|e }}</code>&nbsp;</th>
+            <td>
+                {{ subentry.brief|transtext }}
+                {{ body(subentry, start_heading=3) }}
+            </td>
+        </tr>
     {% endfor %}
   </table>
 </div>
@@ -1188,24 +1179,24 @@ Render the parameter details.
 
 <table class="overview">
 {% for param in entry.params %}
-	<tr>
-		<th>
-		{% if param.in_out %}
-			{% if param.in_out == 'IN' %}
-				<code data-param-type="in" title="IN parameters are only read and not modified">{{ param.name|e }}</code>
-			{% elif param.in_out == 'OUT' %}
-				<code data-param-type="out" title="OUT parameters are modified and used as a means to return values">{{ param.name|e }}</code>
-			{% elif param.in_out == 'IN_OUT' %}
-				<code data-param-type="in_out" title="IN/OUT parameters are read and also modified by the called function">{{ param.name|e }}</code>
-			{% else %}
-				<code>{{ param.name|e }}</code>
-			{% endif %}
-		{% else %}
-		<code>{{ param.name|e }}</code>
-		{% endif %}
-		&nbsp;</th>
-		<td>{{ param.desc|transtext(False) }}</td>
-	</tr>
+    <tr>
+        <th>
+        {% if param.in_out %}
+            {% if param.in_out == 'IN' %}
+                <code data-param-type="in" title="IN parameters are only read and not modified">{{ param.name|e }}</code>
+            {% elif param.in_out == 'OUT' %}
+                <code data-param-type="out" title="OUT parameters are modified and used as a means to return values">{{ param.name|e }}</code>
+            {% elif param.in_out == 'IN_OUT' %}
+                <code data-param-type="in_out" title="IN/OUT parameters are read and also modified by the called function">{{ param.name|e }}</code>
+            {% else %}
+                <code>{{ param.name|e }}</code>
+            {% endif %}
+        {% else %}
+        <code>{{ param.name|e }}</code>
+        {% endif %}
+        &nbsp;</th>
+        <td>{{ param.desc|transtext(False) }}</td>
+    </tr>
 {% endfor %}
 </table>
 
@@ -1226,10 +1217,10 @@ Render the template parameter details.
 
 <table class="overview">
 {% for param in entry.tparams %}
-	<tr>
-		<th><code>{{ param.type|e }}</code>&nbsp;</th>
-		<td>{{ param.desc|transtext(False) }}</td>
-	</tr>
+    <tr>
+        <th><code>{{ param.type|e }}</code>&nbsp;</th>
+        <td>{{ param.desc|transtext(False) }}</td>
+    </tr>
 {% endfor %}
 </table>
 
@@ -1252,10 +1243,10 @@ Render the template parameter overview.
 
 <table class="overview">
 {% for param in entry.tparams %}
-	<tr>
-		<th><code><a href="#" data-lang-entity="template_parameter">{{ param.type|e }}</a></code>&nbsp;</th>
-		<td>{{ param.desc|transtext(False) }}</td>
-	</tr>
+    <tr>
+        <th><code><a href="#" data-lang-entity="template_parameter">{{ param.type|e }}</a></code>&nbsp;</th>
+        <td>{{ param.desc|transtext(False) }}</td>
+    </tr>
 {% endfor %}
 </table>
 </div>
@@ -1276,10 +1267,10 @@ Render the template parameter details.
 
 <table class="overview">
 {% for ret in entry.returns %}
-	<tr>
-		<th><code>{{ ret.type|e }}</code>&nbsp;</th>
-		<td>{{ ret.desc|transtext(False) }}</td>
-	</tr>
+    <tr>
+        <th><code>{{ ret.type|e }}</code>&nbsp;</th>
+        <td>{{ ret.desc|transtext(False) }}</td>
+    </tr>
 {% endfor %}
 </table>
 {% endif %}

--- a/util/py_lib/seqan/dox/validation.py
+++ b/util/py_lib/seqan/dox/validation.py
@@ -22,7 +22,7 @@ class MissingSignatureValidator(ProcDocValidator):
     def validate(self, proc_entry):
         IGNORED = ['variable', 'member_variable', 'tag', 'grouped_tag', 'typedef',
                    'grouped_typedef', 'signature', 'concept', 'member_typedef',
-                   'enum', 'grouped_enum']
+                   'enum', 'grouped_enum', 'enum_value']
         if not hasattr(proc_entry, 'signatures') or proc_entry.kind in IGNORED:
             return  # Skip if type has no signatures.
         if not proc_entry.signatures:


### PR DESCRIPTION
Enum values now have to be documented using the @val tag instead of the
@var tag.

The problem with using @var for both variables and enum values is that
we cannot have variables with enum types.  Doxygen can resolve the
ambiguity by interpreting the C++ source code but we cannot.

This patch also updates the library's @var documentation entries to @val
when required.

Also updated the Dox API documentation to reflect this:

  http://trac.seqan.de/wiki/StyleGuide/DoxApiDocs
