### PR TITLE
[FIX] Fixing mason2 on Windows

### DIFF
--- a/extras/apps/mason2/genomic_variants.cpp
+++ b/extras/apps/mason2/genomic_variants.cpp
@@ -51,7 +51,7 @@ std::ostream & operator<<(std::ostream & out, SmallIndelRecord const & record)
 int StructuralVariantRecord::endPosition() const
 {
     if (pos == -1)
-        return seqan::maxValue<int>();
+        return seqan::MaxValue<int>::VALUE;
 
     switch (kind)
     {
@@ -783,7 +783,7 @@ void PositionMap::reinit(TJournalEntries const & journal)
     SEQAN_ASSERT_NEQ(it->segmentSource, seqan::SOURCE_NULL);
     SEQAN_ASSERT_EQ(it->virtualPosition, 0u);
 
-    unsigned lastRefPos = seqan::maxValue<unsigned>();  // Previous position from reference.
+    unsigned lastRefPos = seqan::MaxValue<unsigned>::VALUE;  // Previous position from reference.
     for (; it != end(journal, seqan::Standard()); ++it)
     {
         // std::cerr << *it << "\n";


### PR DESCRIPTION
The fix looks quite esoteric and I think that the problem is also a bit esoteric.
I am not sure yet whether we did something wrong in SeqAn, or the MSVC optimizer
is a bit too harsh in is optimization.  In any case, it appears to be related to
using seqan::maxValue<int>() instead of seqan::MaxValue<int>::VALUE.  Note that
we do not have to replace all occurences but one is enough for each int and unsigned.
