### PR TITLE
[FIX] Disabling Mason2 in Visual Studio <10

### DIFF
--- a/extras/apps/mason2/CMakeLists.txt
+++ b/extras/apps/mason2/CMakeLists.txt
@@ -23,6 +23,11 @@ if (NOT ZLIB_FOUND)
   return ()
 endif (NOT ZLIB_FOUND)
 
+# Mason2 does not work correctly with Visual Studio Version <10 on 64 bit systems.
+if (MSVC AND MSVC_VERSION LESS 1600)
+  message (STATUS "  Visual Studio Version <10: MASON2 will not be built."
+endif (MSVC AND MSVC_VERSION LESS 1600)
+
 # Enable C++11 in GCC and/or CLANG.
 #if (CMAKE_COMPILER_IS_GNUCXX OR COMPILER_IS_CLANG)
 #    add_definitions ("-std=c++0x")
@@ -161,4 +166,3 @@ if (SEQAN_BUILD_SYSTEM STREQUAL "APP:mason2")
 
   seqan_configure_cpack_app (mason2 "mason2")
 endif (SEQAN_BUILD_SYSTEM STREQUAL "APP:mason2")
-


### PR DESCRIPTION
Somehow copy constructors are not properly called with 64 bit binaries.  32 bit binaries are fine.
