### PR TITLE
Feature/dps

### DIFF
--- a/extras/include/seqan/misc/misc_dynamic_prefix_sum.h
+++ b/extras/include/seqan/misc/misc_dynamic_prefix_sum.h
@@ -1,0 +1,697 @@
+// ==========================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ==========================================================================
+// Copyright (c) 2006-2013, Knut Reinert, FU Berlin
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ==========================================================================
+// Author: Rene Rahn <rene.rahn@fu-berlin.de>
+// ==========================================================================
+// Implements a dynamic prefix sum data structure.
+// ==========================================================================
+
+#ifndef EXTRAS_INCLUDE_SEQAN_MISC_MISC_DYNAMIC_PREFIX_SUM_H_
+#define EXTRAS_INCLUDE_SEQAN_MISC_MISC_DYNAMIC_PREFIX_SUM_H_
+
+namespace seqan
+{
+
+// ============================================================================
+// Forwards
+// ============================================================================
+
+// ============================================================================
+// Tags, Classes, Enums
+// ============================================================================
+
+template <unsigned B_FACTOR>
+struct DpsHelper_
+{
+    static const unsigned MAX_CHILD_NUMBER;
+    static const unsigned MAX_KEY_NUMBER;
+
+    static const unsigned MIN_CHILD_NUMBER;
+    static const unsigned MIN_KEY_NUMBER;
+};
+
+template <unsigned B_FACTOR>
+const unsigned DpsHelper_<B_FACTOR>::MAX_CHILD_NUMBER = B_FACTOR << 1;
+template <unsigned B_FACTOR>
+const unsigned DpsHelper_<B_FACTOR>::MAX_KEY_NUMBER = (B_FACTOR << 1) - 1;
+
+template <unsigned B_FACTOR>
+const unsigned DpsHelper_<B_FACTOR>::MIN_CHILD_NUMBER = B_FACTOR;
+template <unsigned B_FACTOR>
+const unsigned DpsHelper_<B_FACTOR>::MIN_KEY_NUMBER = B_FACTOR - 1;
+
+// ----------------------------------------------------------------------------
+// Class DpsTreeNode_
+// ----------------------------------------------------------------------------
+
+template <typename TValue, typename TCargo, unsigned B_FACTOR>
+class DpsTreeNode_
+{
+public:
+
+    typedef String<TValue>        TKeyTab;
+    typedef String<TCargo>        TCargoTab;
+    typedef String<DpsTreeNode_*> TChildTab;
+
+    TKeyTab   _keyTab;
+    TCargoTab _cargoTab;
+    TChildTab _childTab;
+    bool      _isLeaf;
+
+    DpsTreeNode_() : _keyTab(), _cargoTab(), _childTab(), _isLeaf(false)
+    {
+        // Set the capacities.
+        reserve(_keyTab, DpsHelper_<B_FACTOR>::MAX_KEY_NUMBER, Exact());
+        reserve(_cargoTab, DpsHelper_<B_FACTOR>::MAX_KEY_NUMBER, Exact());
+        reserve(_childTab, DpsHelper_<B_FACTOR>::MAX_CHILD_NUMBER, Exact());
+    }
+
+    // Copy Constructor
+    DpsTreeNode_(DpsTreeNode_ const & other) : _keyTab(other._keyTab),
+                                               _cargoTab(other._cargoTab),
+                                               _childTab(other._childTab),
+                                               _isLeaf(other._isLeaf)
+    {}
+
+    // Assignment Operator
+    DpsTreeNode_ &
+    operator=(DpsTreeNode_ const & other)
+    {
+        if (this != &other)
+        {
+            _keyTab   = other._keyTab;
+            _cargoTab = other._cargoTab;
+            _childTab = other._childTab;
+            _isLeaf   = other._isLeaf;
+        }
+        return *this;
+    }
+};
+
+// ----------------------------------------------------------------------------
+// Class DynamicPrefixSumTree
+// ----------------------------------------------------------------------------
+
+template <typename TKeyValue, typename TCargo, unsigned B_FACTOR = 64, typename TSpec = Default>
+class DynamicPrefixSumTree;
+
+template <typename TKeyValue, typename TCargo, unsigned B_FACTOR>
+class DynamicPrefixSumTree<TKeyValue, TCargo, B_FACTOR, Default>
+{
+public:
+
+    typedef typename Value<DynamicPrefixSumTree>::Type TNode;
+    typedef Allocator<SinglePool<sizeof(TNode)> > TNodeAllocator;
+
+    static const TNode* NIL;
+
+    TNodeAllocator _nodeAllocator;  // Allocator used to allocate/deallocate nodes.
+
+    TNode * rootPtr;
+
+    DynamicPrefixSumTree() : rootPtr(NULL)
+    {
+        rootPtr = _createNode(*this);
+        _makeLeaf(*rootPtr);
+    }
+
+    // Copy Constructor
+    DynamicPrefixSumTree(DynamicPrefixSumTree const & other) : rootPtr(other.rootPtr)
+    {}
+
+    // Assignment Operator
+    DynamicPrefixSumTree &
+    operator=(DynamicPrefixSumTree const & other)
+    {
+        if (this != &other)
+            rootPtr = other.rootPtr;
+        return *this;
+    }
+};
+
+template <typename TKeyValue, typename TCargo, unsigned B_FACTOR>
+const typename DynamicPrefixSumTree<TKeyValue, TCargo, B_FACTOR, Default>::TNode* DynamicPrefixSumTree<TKeyValue, TCargo, B_FACTOR, Default>::NIL = (typename DynamicPrefixSumTree<TKeyValue, TCargo, B_FACTOR, Default>::TNode *) 0;
+
+// ----------------------------------------------------------------------------
+// Class PrefixSumFunctor_
+// ----------------------------------------------------------------------------
+
+template <typename TNode>
+struct PrefixSumFunctor_{};
+
+template <typename TKey, typename TCargo, unsigned B_FACTOR>
+struct PrefixSumFunctor_<DpsTreeNode_<TKey, TCargo, B_FACTOR> >
+{
+    typedef DpsTreeNode_<TKey, TCargo, B_FACTOR> TNode;
+
+    TCargo currSum;
+
+    PrefixSumFunctor_() : currSum(0)
+    {}
+
+    template <typename TPos>
+    inline void
+    operator()(TNode const & node, TPos idx)
+    {
+        currSum += getCargo(node, idx);
+    }
+};
+
+// ============================================================================
+// Metafunctions
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// Metafunction Value
+// ----------------------------------------------------------------------------
+
+template <typename TValue, typename TCargo, unsigned B_FACTOR, typename TSpec>
+struct Value<DynamicPrefixSumTree<TValue, TCargo, B_FACTOR, TSpec> >
+{
+    typedef DpsTreeNode_<TValue, TCargo, B_FACTOR> Type;
+};
+
+template <typename TValue, typename TCargo, unsigned B_FACTOR, typename TSpec>
+struct Value<DynamicPrefixSumTree<TValue, TCargo, B_FACTOR, TSpec> const>
+{
+    typedef DpsTreeNode_<TValue, TCargo, B_FACTOR> const Type;
+};
+
+// ----------------------------------------------------------------------------
+// Metafunction Cargo
+// ----------------------------------------------------------------------------
+
+template <typename TKeyValue, typename TCargo, unsigned B_FACTOR, typename TSpec>
+struct Cargo<DynamicPrefixSumTree<TKeyValue, TCargo, B_FACTOR, TSpec> >
+{
+    typedef TCargo Type;
+};
+
+template <typename TKeyValue, typename TCargo, unsigned B_FACTOR, typename TSpec>
+struct Cargo<DynamicPrefixSumTree<TKeyValue, TCargo, B_FACTOR, TSpec> const>
+{
+    typedef TCargo const Type;
+};
+
+// ============================================================================
+// Functions
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// Function _createNode()
+// ----------------------------------------------------------------------------
+
+// Allocates new memory for an internal node and default constructs it.
+// Returns pointer to the newly constructed value.
+template <typename TKeyValue, typename TCargo, unsigned B_FACTOR, typename TSpec>
+inline typename Value<DynamicPrefixSumTree<TKeyValue, TCargo, B_FACTOR, TSpec> >::Type *
+_createNode(DynamicPrefixSumTree<TKeyValue, TCargo, B_FACTOR, TSpec> & tree)
+{
+    typedef DynamicPrefixSumTree<TKeyValue, TCargo, B_FACTOR, TSpec> TTree;
+    typedef typename Value<TTree>::Type TNode;
+
+    TNode *tmp;
+    allocate(tree._nodeAllocator, tmp, 1);
+    return new (tmp) TNode();
+}
+
+// ----------------------------------------------------------------------------
+// Function _leafState()
+// ----------------------------------------------------------------------------
+
+// Returns the isLeaf flag.
+template <typename TValue, typename TCargo, unsigned B_FACTOR>
+inline bool &
+_leafState(DpsTreeNode_<TValue, TCargo, B_FACTOR> & node)
+{
+    return node._isLeaf;
+}
+
+// Returns the isLeaf flag.
+template <typename TValue, typename TCargo, unsigned B_FACTOR>
+inline bool const &
+_leafState(DpsTreeNode_<TValue, TCargo, B_FACTOR> const & node)
+{
+    return node._isLeaf;
+}
+
+// ----------------------------------------------------------------------------
+// Function _makeLeaf()
+// ----------------------------------------------------------------------------
+
+// Sets the leaf flag of the node to true.
+template <typename TValue, typename TCargo, unsigned B_FACTOR>
+inline void
+_makeLeaf(DpsTreeNode_<TValue, TCargo, B_FACTOR> & node)
+{
+    node._isLeaf = true;
+}
+
+// ----------------------------------------------------------------------------
+// Function _makeInnerNode()
+// ----------------------------------------------------------------------------
+
+// Sets the leaf flag of the node to false.
+template <typename TValue, typename TCargo, unsigned B_FACTOR>
+inline void
+_makeInnerNode(DpsTreeNode_<TValue, TCargo, B_FACTOR> & node)
+{
+    node._isLeaf = false;
+}
+
+// ----------------------------------------------------------------------------
+// Function _getRoot()
+// ----------------------------------------------------------------------------
+
+template <typename TKey, typename TCargo, unsigned B_FACTOR, typename TSpec>
+inline typename Value<DynamicPrefixSumTree<TKey, TCargo, B_FACTOR, TSpec> >::Type &
+_getRoot(DynamicPrefixSumTree<TKey, TCargo, B_FACTOR, TSpec> & tree)
+{
+    return *tree.rootPtr;
+}
+
+template <typename TKey, typename TCargo, unsigned B_FACTOR, typename TSpec>
+inline typename Value<DynamicPrefixSumTree<TKey, TCargo, B_FACTOR, TSpec> const>::Type &
+_getRoot(DynamicPrefixSumTree<TKey, TCargo, B_FACTOR, TSpec> const & tree)
+{
+    return *tree.rootPtr;
+}
+
+// ----------------------------------------------------------------------------
+// Function _isFull()
+// ----------------------------------------------------------------------------
+
+template <typename TKey, typename TCargo, unsigned B_FACTOR>
+inline bool
+_isFull(DpsTreeNode_<TKey, TCargo, B_FACTOR> const & node)
+{
+    return length(_getKeyTable(node)) == DpsHelper_<B_FACTOR>::MAX_KEY_NUMBER;
+}
+
+// ----------------------------------------------------------------------------
+// Function _getKeyTable()
+// ----------------------------------------------------------------------------
+
+template <typename TKey, typename TCargo, unsigned B_FACTOR>
+inline String<TKey> &
+_getKeyTable(DpsTreeNode_<TKey, TCargo, B_FACTOR> & node)
+{
+    return node._keyTab;
+}
+
+template <typename TKey, typename TCargo, unsigned B_FACTOR>
+inline String<TKey> const &
+_getKeyTable(DpsTreeNode_<TKey, TCargo, B_FACTOR> const & node)
+{
+    return node._keyTab;
+}
+
+// ----------------------------------------------------------------------------
+// Function _getCargoTable()
+// ----------------------------------------------------------------------------
+
+template <typename TKey, typename TCargo, unsigned B_FACTOR>
+inline String<TCargo> &
+_getCargoTable(DpsTreeNode_<TKey, TCargo, B_FACTOR> & node)
+{
+    return node._cargoTab;
+}
+
+template <typename TKey, typename TCargo, unsigned B_FACTOR>
+inline String<TCargo> const &
+_getCargoTable(DpsTreeNode_<TKey, TCargo, B_FACTOR> const & node)
+{
+    return node._cargoTab;
+}
+
+// ----------------------------------------------------------------------------
+// Function _getChildTable()
+// ----------------------------------------------------------------------------
+
+template <typename TKey, typename TCargo, unsigned B_FACTOR>
+inline String<DpsTreeNode_<TKey, TCargo, B_FACTOR> *>  &
+_getChildTable(DpsTreeNode_<TKey, TCargo, B_FACTOR> & node)
+{
+    return node._childTab;
+}
+
+template <typename TKey, typename TCargo, unsigned B_FACTOR>
+inline String<DpsTreeNode_<TKey, TCargo, B_FACTOR> *> const &
+_getChildTable(DpsTreeNode_<TKey, TCargo, B_FACTOR> const & node)
+{
+    return node._childTab;
+}
+
+// ----------------------------------------------------------------------------
+// Function _splitChild()
+// ----------------------------------------------------------------------------
+
+template <typename TKey, typename TCargo, unsigned B_FACTOR, typename TSpec, typename TPos>
+inline void
+_splitChild(DynamicPrefixSumTree<TKey, TCargo, B_FACTOR, TSpec> & tree,
+            DpsTreeNode_<TKey, TCargo, B_FACTOR> & target,
+            DpsTreeNode_<TKey, TCargo, B_FACTOR> & parent,
+            TPos const & childIdx)
+{
+    typedef DpsTreeNode_<TKey, TCargo, B_FACTOR>                TNode;
+    typedef typename TNode::TCargoTab                           TCargoTab;
+    typedef typename Iterator<TCargoTab, Standard>::Type        TCargoIter;
+    typedef typename Size<TCargoTab>::Type                      TSize;
+
+    TNode* tmpPtr = _createNode(tree);  // Create new node in memory pool.
+    _leafState(*tmpPtr) = _leafState(target);
+
+    // We need to set the partial sum first.
+
+    // Move the right half of the target node to the beginning of the new split node.
+    resize(_getKeyTable(*tmpPtr), DpsHelper_<B_FACTOR>::MIN_KEY_NUMBER);
+    resize(_getCargoTable(*tmpPtr), DpsHelper_<B_FACTOR>::MIN_KEY_NUMBER);
+    arrayMoveForward(begin(_getKeyTable(target), Standard()) + B_FACTOR, end(_getKeyTable(target), Standard()),
+                     begin(_getKeyTable(*tmpPtr), Standard()));
+    arrayMoveForward(begin(_getCargoTable(target), Standard()) + B_FACTOR, end(_getCargoTable(target), Standard()),
+                     begin(_getCargoTable(*tmpPtr), Standard()));
+
+    // Update the prefix sums for the split node.
+    TCargo cargoBeforeSplit = _getCargoTable(target)[DpsHelper_<B_FACTOR>::MIN_KEY_NUMBER];
+    TCargoIter cargoItSplit = begin(_getCargoTable(*tmpPtr), Standard());
+    TCargoIter cargoItSplitEnd = end(_getCargoTable(*tmpPtr), Standard());
+
+    for (; cargoItSplit != cargoItSplitEnd; ++cargoItSplit)
+        *cargoItSplit -= cargoBeforeSplit;
+
+    // Move the right half of the target node's child table to the left half of the split node's child table.
+    if (!isLeaf(target))
+    {
+        resize(_getChildTable(*tmpPtr), DpsHelper_<B_FACTOR>::MIN_CHILD_NUMBER);
+        arrayMoveForward(begin(_getChildTable(target), Standard()) + B_FACTOR, end(_getChildTable(target), Standard()),
+                         begin(_getChildTable(*tmpPtr), Standard()));
+        resize(_getChildTable(target), DpsHelper_<B_FACTOR>::MIN_CHILD_NUMBER);
+    }
+
+    // Move the pivot element to the parent and update tables accordingly.
+    TSize oldLength = length(_getChildTable(parent));
+    resize(_getChildTable(parent), oldLength + 1);  // Make space for the new element.
+    arrayMoveBackward(begin(_getChildTable(parent), Standard()) + childIdx + 1,
+                      begin(_getChildTable(parent), Standard()) + oldLength,
+                      begin(_getChildTable(parent), Standard()) + childIdx + 2);
+
+    resize(_getKeyTable(parent), oldLength);  // Make space for the new element.
+    arrayMoveBackward(begin(_getKeyTable(parent), Standard()) + childIdx,
+                      begin(_getKeyTable(parent), Standard()) + oldLength - 1,
+                      begin(_getKeyTable(parent), Standard()) + childIdx + 1);
+
+    resize(_getCargoTable(parent), oldLength);  // Make space for the new element.
+    arrayMoveBackward(begin(_getCargoTable(parent), Standard()) + childIdx ,
+                      begin(_getCargoTable(parent), Standard()) + oldLength - 1,
+                      begin(_getCargoTable(parent), Standard()) + childIdx + 1);
+
+    _getKeyTable(parent)[childIdx] = _getKeyTable(target)[B_FACTOR - 1];
+    _getCargoTable(parent)[childIdx] = _getCargoTable(target)[B_FACTOR - 1];
+    _getChildTable(parent)[childIdx + 1] = tmpPtr;
+
+    // Shrink the elements of target.
+    resize(_getKeyTable(target), DpsHelper_<B_FACTOR>::MIN_KEY_NUMBER);
+    resize(_getCargoTable(target), DpsHelper_<B_FACTOR>::MIN_KEY_NUMBER);
+}
+
+// ----------------------------------------------------------------------------
+// Function _updateCargoRight()
+// ----------------------------------------------------------------------------
+
+template <typename TKey, typename TCargo, unsigned B_FACTOR, typename TPos, typename TCargo2>
+inline void
+_updateCargoRight(DpsTreeNode_<TKey, TCargo, B_FACTOR> & node,
+                  TPos const & idx,
+                  TCargo2 const & newCargo)
+{
+    typedef DpsTreeNode_<TKey, TCargo, B_FACTOR>         TNode;
+    typedef typename TNode::TCargoTab                    TCargoTab;
+    typedef typename Iterator<TCargoTab, Standard>::Type TCargoTabIter;
+
+    // Update the cargos of all right values in O(B_FACTOR) time.
+    TCargoTabIter itCargo = begin(_getCargoTable(node), Standard()) + idx;
+    for (; itCargo != end(_getCargoTable(node), Standard()); ++itCargo)
+        *itCargo += newCargo;
+}
+
+// ----------------------------------------------------------------------------
+// Function _insertNonFull()
+// ----------------------------------------------------------------------------
+
+template <typename TKey, typename TCargo, unsigned B_FACTOR, typename TSpec, typename TKey2, typename TCargo2>
+inline bool
+_insertNonFull(DynamicPrefixSumTree<TKey, TCargo, B_FACTOR, TSpec> & tree,
+               DpsTreeNode_<TKey, TCargo, B_FACTOR> & node,
+               TKey2 const & newKey,
+               TCargo2 const & newCargo)
+{
+    typedef DpsTreeNode_<TKey, TCargo, B_FACTOR>       TNode;
+    typedef typename TNode::TKeyTab                    TKeyTab;
+    typedef typename Size<TKeyTab>::Type               TSize;
+    typedef typename Iterator<TKeyTab, Standard>::Type TKeyTabIter;
+
+    // Found lower bound.
+    TKeyTabIter it = std::lower_bound(begin(_getKeyTable(node), Standard()), end(_getKeyTable(node), Standard()), newKey);
+
+    // Key exists already.
+    if (*it == static_cast<TKey>(newKey))
+        return false;
+
+    TSize foundPos = it - begin(_getKeyTable(node), Standard());
+
+    if (isLeaf(node))
+    {
+        _updateCargoRight(node, foundPos, newCargo);
+        insertValue(_getKeyTable(node), foundPos, newKey);  // Insert the new key in leaf.
+        if (foundPos == 0)
+            insertValue(_getCargoTable(node), foundPos, newCargo);  // Insert the new cargo.
+        else
+            insertValue(_getCargoTable(node), foundPos, newCargo + getCargo(node, foundPos - 1));  // Update with left neighbor before insertion.
+        return true;
+    }
+
+    TNode& child = getChild(node, foundPos);  // Get the child node affected by the insertion.
+    if (_isFull(child))  // If already full, we split the child.
+    {
+        _splitChild(tree, child, node, foundPos);
+        // We need to update the cargo here.
+        if (foundPos > 0)
+            _getCargoTable(node)[foundPos] += getCargo(node, foundPos -1);
+        if (getKey(node, foundPos) < static_cast<TKey>(newKey))
+            ++foundPos;
+        _updateCargoRight(node, foundPos, newCargo);
+        return _insertNonFull(tree, getChild(node, foundPos), newKey, newCargo);  // Go into subtree left of split.
+    }
+    _updateCargoRight(node, foundPos, newCargo);
+    return _insertNonFull(tree, getChild(node, foundPos), newKey, newCargo);  // Go into subtree left of split.
+}
+
+template <typename TFunctor, typename TKey, typename TCargo, unsigned B_FACTOR, typename TSpec, typename TKey2>
+inline bool
+_find(TFunctor & functor,
+      DynamicPrefixSumTree<TKey, TCargo, B_FACTOR, TSpec> const & tree,
+      TKey2 const & key)
+{
+    typedef DynamicPrefixSumTree<TKey, TCargo, B_FACTOR, TSpec> const TTree;
+    typedef typename Value<TTree>::Type                               TNode;
+    typedef typename TNode::TKeyTab                                   TKeyTab;
+    typedef typename Iterator<TKeyTab const, Standard>::Type          TKeyIterator;
+    typedef typename Size<TKeyTab>::Type                              TSize SEQAN_TYPEDEF_FOR_DEBUG;
+
+    SEQAN_ASSERT_NEQ(tree.rootPtr, (TNode*) 0);
+
+    TNode* currNodePtr = &_getRoot(tree);
+    TKeyIterator it;
+
+    while(true)
+    {
+        SEQAN_ASSERT_GT(length(_getKeyTable(*currNodePtr)) ,0u);
+        // Binary search on the keys.
+        it = std::upper_bound(begin(_getKeyTable(*currNodePtr), Standard()), end(_getKeyTable(*currNodePtr), Standard()), key);
+        if (it != begin(_getKeyTable(*currNodePtr), Standard()))
+        {
+            --it;
+            // Now either it compares equal to the value or it must be in the subtree right of the current it.
+            functor(*currNodePtr, it - begin(_getKeyTable(*currNodePtr), Standard()));
+            if (*it == key)
+                return true;
+
+            if (isLeaf(*currNodePtr))
+                return false;
+            SEQAN_ASSERT_LT(static_cast<TSize>((it - begin(_getKeyTable(*currNodePtr), Standard())) + 1), length(_getChildTable(*currNodePtr)));
+            currNodePtr = &getChild(*currNodePtr, (it - begin(_getKeyTable(*currNodePtr), Standard())) + 1);
+        }
+        else
+        {
+            if (isLeaf(*currNodePtr))
+                return false;
+            currNodePtr = &getChild(*currNodePtr, 0);
+        }
+    }
+}
+
+
+// ----------------------------------------------------------------------------
+// Function getKey()
+// ----------------------------------------------------------------------------
+
+template <typename TKey, typename TCargo, unsigned B_FACTOR, typename TPos>
+inline TKey const &
+getKey(DpsTreeNode_<TKey, TCargo, B_FACTOR> const & node,
+       TPos const & idx)
+{
+    SEQAN_ASSERT_GEQ(idx, static_cast<TPos>(0));
+    SEQAN_ASSERT_LT(idx, static_cast<TPos>(length(node._keyTab)));
+
+    return node._keyTab[idx];
+}
+
+// ----------------------------------------------------------------------------
+// Function getCargo()
+// ----------------------------------------------------------------------------
+
+template <typename TKey, typename TCargo, unsigned B_FACTOR, typename TPos>
+inline TCargo const &
+getCargo(DpsTreeNode_<TKey, TCargo, B_FACTOR> const & node,
+         TPos const & idx)
+{
+    SEQAN_ASSERT_GEQ(idx, static_cast<TPos>(0));
+    SEQAN_ASSERT_LT(idx, static_cast<TPos>(length(node._cargoTab)));
+
+    return node._cargoTab[idx];
+}
+
+// ----------------------------------------------------------------------------
+// Function getChild()
+// ----------------------------------------------------------------------------
+
+template <typename TKey, typename TCargo, unsigned B_FACTOR, typename TPos>
+inline DpsTreeNode_<TKey, TCargo, B_FACTOR> &
+getChild(DpsTreeNode_<TKey, TCargo, B_FACTOR>  & node,
+         TPos const & idx)
+{
+    SEQAN_ASSERT_GEQ(idx, static_cast<TPos>(0));
+    SEQAN_ASSERT_LT(idx, static_cast<TPos>(length(node._childTab)));
+
+    return *node._childTab[idx];
+}
+
+template <typename TKey, typename TCargo, unsigned B_FACTOR, typename TPos>
+inline DpsTreeNode_<TKey, TCargo, B_FACTOR> const &
+getChild(DpsTreeNode_<TKey, TCargo, B_FACTOR> const & node,
+         TPos const & idx)
+{
+    SEQAN_ASSERT_GEQ(idx, static_cast<TPos>(0));
+    SEQAN_ASSERT_LT(idx, static_cast<TPos>(length(node._childTab)));
+
+    return *node._childTab[idx];
+}
+
+// ----------------------------------------------------------------------------
+// Function isLeaf()
+// ----------------------------------------------------------------------------
+
+template <typename TValue, typename TCargo, unsigned B_FACTOR>
+inline bool
+isLeaf(DpsTreeNode_<TValue, TCargo, B_FACTOR> const & node)
+{
+    return node._isLeaf;
+}
+
+// ----------------------------------------------------------------------------
+// Function empty()
+// ----------------------------------------------------------------------------
+
+template <typename TKey, typename TCargo, unsigned B_FACTOR, typename TSpec>
+inline bool
+empty(DynamicPrefixSumTree<TKey, TCargo, B_FACTOR, TSpec> const & tree)
+{
+    typedef DynamicPrefixSumTree<TKey, TCargo, B_FACTOR, TSpec> TTree SEQAN_TYPEDEF_FOR_DEBUG;
+    typedef typename Value<TTree const>::Type                   TNode SEQAN_TYPEDEF_FOR_DEBUG;
+
+    SEQAN_ASSERT_NEQ(tree.rootPtr, (TNode *) 0);
+
+    return empty(tree.rootPtr->_keyTab) && empty(tree.rootPtr->_childTab);
+}
+
+// ----------------------------------------------------------------------------
+// Function insert()
+// ----------------------------------------------------------------------------
+
+template <typename TKey, typename TCargo, unsigned B_FACTOR, typename TSpec, typename TKey2, typename TCargo2>
+inline bool
+insert(DynamicPrefixSumTree<TKey, TCargo, B_FACTOR, TSpec> & tree,
+       TKey2 const & newKey,
+       TCargo2 const & newCargo)
+{
+    typedef DynamicPrefixSumTree<TKey, TCargo, B_FACTOR, TSpec> TTree;
+    typedef typename Value<TTree>::Type TNode;
+
+    if (empty(tree))
+    {
+        SEQAN_ASSERT_NEQ(tree.rootPtr, (TNode*) 0);
+
+        appendValue(_getKeyTable(_getRoot(tree)), newKey);
+        appendValue(_getCargoTable(_getRoot(tree)), newCargo);
+        return true;
+    }
+
+    if (_isFull(_getRoot(tree)))  // Increase tree by one level.
+    {
+        TNode* tmp = _createNode(tree);  // tmp is no leaf, and initialized with zero.
+        std::swap(tree.rootPtr, tmp);    // Swap the root and the new generated node.
+        appendValue(_getChildTable(_getRoot(tree)), tmp);  // Store pointer to child in child tab.
+        _splitChild(tree, getChild(_getRoot(tree), 0), _getRoot(tree), 0);  // Balance the tree.
+    }
+    return _insertNonFull(tree, _getRoot(tree), newKey, newCargo);
+}
+
+// ----------------------------------------------------------------------------
+// Function prefixSum()
+// ----------------------------------------------------------------------------
+
+template <typename TKey, typename TCargo, unsigned B_FACTOR, typename TSpec, typename TKey2>
+inline TCargo
+prefixSum(DynamicPrefixSumTree<TKey, TCargo, B_FACTOR, TSpec> const & tree,
+          TKey2 const & newKey)
+{
+    typedef DynamicPrefixSumTree<TKey, TCargo, B_FACTOR, TSpec> TTree;
+    typedef typename Value<TTree>::Type TNode;
+
+    PrefixSumFunctor_<TNode> func;
+
+    _find(func, tree, newKey);
+    return func.currSum;
+}
+
+}
+
+#endif // EXTRAS_INCLUDE_SEQAN_MISC_MISC_DYNAMIC_PREFIX_SUM_H_

--- a/extras/include/seqan/misc_dynamic_prefix_sum.h
+++ b/extras/include/seqan/misc_dynamic_prefix_sum.h
@@ -1,0 +1,54 @@
+// ==========================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ==========================================================================
+// Copyright (c) 2006-2013, Knut Reinert, FU Berlin
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ==========================================================================
+// Author: Rene Rahn <rene.rahn@fu-berlin.de>
+// ==========================================================================
+// Facade header for dynamic prefix sum tree.
+// ==========================================================================
+
+#ifndef EXTRAS_INCLUDE_SEQAN_MISC_DYNAMIC_PREFIX_SUM_H_
+#define EXTRAS_INCLUDE_SEQAN_MISC_DYNAMIC_PREFIX_SUM_H_
+
+// ============================================================================
+// Prerequisites.
+// ============================================================================
+
+#include <seqan/basic.h>
+#include <seqan/sequence.h>
+
+// ============================================================================
+// Data structure.
+// ============================================================================
+
+#include <seqan/misc/misc_dynamic_prefix_sum.h>
+
+
+#endif // EXTRAS_INCLUDE_SEQAN_MISC_DYNAMIC_PREFIX_SUM_H_

--- a/extras/tests/misc_dynamic_prefix_sum/CMakeLists.txt
+++ b/extras/tests/misc_dynamic_prefix_sum/CMakeLists.txt
@@ -1,0 +1,46 @@
+# ===========================================================================
+#                  SeqAn - The Library for Sequence Analysis
+# ===========================================================================
+# File: /extras/tests/misc_dynamic_prefix_sum/CMakeLists.txt
+#
+# CMakeLists.txt file for the misc_dynamic_prefix_sum module tests.
+# ===========================================================================
+
+cmake_minimum_required (VERSION 2.8.2)
+project (seqan_extras_tests_misc_dynamic_prefix_sum)
+message (STATUS "Configuring extras/tests/misc_dynamic_prefix_sum")
+
+# ----------------------------------------------------------------------------
+# Dependencies
+# ----------------------------------------------------------------------------
+
+# Search SeqAn and select dependencies.
+set (SEQAN_FIND_DEPENDENCIES NONE)
+find_package (SeqAn REQUIRED)
+
+# ----------------------------------------------------------------------------
+# Build Setup
+# ----------------------------------------------------------------------------
+
+# Add include directories.
+include_directories (${SEQAN_INCLUDE_DIRS})
+
+# Add definitions set by find_package (SeqAn).
+add_definitions (${SEQAN_DEFINITIONS})
+
+# Update the list of file names below if you add source files to your test.
+add_executable (test_misc_dynamic_prefix_sum
+                test_misc_dynamic_prefix_sum.cpp
+                test_misc_dynamic_prefix_sum.h)
+
+# Add dependencies found by find_package (SeqAn).
+target_link_libraries (test_misc_dynamic_prefix_sum ${SEQAN_LIBRARIES})
+
+# Add CXX flags found by find_package (SeqAn).
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SEQAN_CXX_FLAGS}")
+
+# ----------------------------------------------------------------------------
+# Register with CTest
+# ----------------------------------------------------------------------------
+
+add_test (NAME test_test_misc_dynamic_prefix_sum COMMAND $<TARGET_FILE:test_misc_dynamic_prefix_sum>)

--- a/extras/tests/misc_dynamic_prefix_sum/test_misc_dynamic_prefix_sum.cpp
+++ b/extras/tests/misc_dynamic_prefix_sum/test_misc_dynamic_prefix_sum.cpp
@@ -1,0 +1,51 @@
+// ==========================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ==========================================================================
+// Copyright (c) 2006-2013, Knut Reinert, FU Berlin
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ==========================================================================
+// Author: Rene Rahn <rene.rahn@fu-berlin.de>
+// ==========================================================================
+// Test suite for dynamic prefix sum tree.
+// ==========================================================================
+
+#include <seqan/basic.h>
+#include <seqan/file.h>
+
+#include "test_misc_dynamic_prefix_sum.h"
+
+
+SEQAN_BEGIN_TESTSUITE(test_misc_dynamic_prefix_sum)
+{
+    // Call tests.
+	SEQAN_CALL_TEST(test_misc_dynamic_prefix_sum_constructor);
+	SEQAN_CALL_TEST(test_misc_dynamic_prefix_sum_empty);
+	SEQAN_CALL_TEST(test_misc_dynamic_prefix_sum_insert);
+	SEQAN_CALL_TEST(test_misc_dynamic_prefix_sum_prefix_sum);
+}
+SEQAN_END_TESTSUITE

--- a/extras/tests/misc_dynamic_prefix_sum/test_misc_dynamic_prefix_sum.cpp
+++ b/extras/tests/misc_dynamic_prefix_sum/test_misc_dynamic_prefix_sum.cpp
@@ -39,7 +39,6 @@
 
 #include "test_misc_dynamic_prefix_sum.h"
 
-
 SEQAN_BEGIN_TESTSUITE(test_misc_dynamic_prefix_sum)
 {
     // Call tests.
@@ -47,5 +46,6 @@ SEQAN_BEGIN_TESTSUITE(test_misc_dynamic_prefix_sum)
 	SEQAN_CALL_TEST(test_misc_dynamic_prefix_sum_empty);
 	SEQAN_CALL_TEST(test_misc_dynamic_prefix_sum_insert);
 	SEQAN_CALL_TEST(test_misc_dynamic_prefix_sum_prefix_sum);
+	SEQAN_CALL_TEST(test_misc_dynamic_prefix_sum_find);
 }
 SEQAN_END_TESTSUITE

--- a/extras/tests/misc_dynamic_prefix_sum/test_misc_dynamic_prefix_sum.h
+++ b/extras/tests/misc_dynamic_prefix_sum/test_misc_dynamic_prefix_sum.h
@@ -642,5 +642,44 @@ SEQAN_DEFINE_TEST(test_misc_dynamic_prefix_sum_prefix_sum)
     }
 }
 
+SEQAN_DEFINE_TEST(test_misc_dynamic_prefix_sum_find)
+{
+    using namespace seqan;
+
+    typedef DynamicPrefixSumTree<unsigned, int, 3> TPrefixSumTree;
+
+    TPrefixSumTree tree;
+
+    SEQAN_ASSERT_EQ(find(tree, 0), false);
+    SEQAN_ASSERT_EQ(find(tree, 100), false);
+
+    insert(tree, 10, -2);
+    insert(tree, 20,  7);
+    insert(tree,  5,  4);
+    insert(tree, 25, -6);
+    insert(tree,  0,  1);
+    insert(tree, 19, -2);
+    insert(tree, 11,  7);
+    insert(tree,  7,  4);
+    insert(tree, 1, -6);
+    insert(tree,  25,  1);
+    insert(tree, 30, -2);
+    insert(tree, 75,  7);
+    insert(tree,  2,  4);
+    insert(tree, 18, -6);
+    insert(tree,  12,  1);
+
+    SEQAN_ASSERT_EQ(find(tree, 0), true);
+    SEQAN_ASSERT_EQ(find(tree, 8), false);
+    SEQAN_ASSERT_EQ(find(tree, 9), false);
+    SEQAN_ASSERT_EQ(find(tree, 10), true);
+    SEQAN_ASSERT_EQ(find(tree, 11), true);
+    SEQAN_ASSERT_EQ(find(tree, 12), true);
+    SEQAN_ASSERT_EQ(find(tree, 13), false);
+    SEQAN_ASSERT_EQ(find(tree, 20), true);
+    SEQAN_ASSERT_EQ(find(tree, 74), false);
+    SEQAN_ASSERT_EQ(find(tree, 75), true);
+    SEQAN_ASSERT_EQ(find(tree, 76), false);
+}
 
 #endif  // EXTRAS_TESTS_MISC_DYNAMIC_PREFIX_SUM_TEST_MISC_DYNAMIC_PREFIX_SUM_H_

--- a/extras/tests/misc_dynamic_prefix_sum/test_misc_dynamic_prefix_sum.h
+++ b/extras/tests/misc_dynamic_prefix_sum/test_misc_dynamic_prefix_sum.h
@@ -1,0 +1,646 @@
+// ==========================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ==========================================================================
+// Copyright (c) 2006-2013, Knut Reinert, FU Berlin
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ==========================================================================
+// Author: Rene Rahn <rene.rahn@fu-berlin.de>
+// ==========================================================================
+// Unit tests for dynamic prefix sums.
+// ==========================================================================
+
+#ifndef EXTRAS_TESTS_MISC_DYNAMIC_PREFIX_SUM_TEST_MISC_DYNAMIC_PREFIX_SUM_H_
+#define EXTRAS_TESTS_MISC_DYNAMIC_PREFIX_SUM_TEST_MISC_DYNAMIC_PREFIX_SUM_H_
+
+#include <seqan/basic.h>
+#include <seqan/sequence.h>
+#include <seqan/random.h>
+
+#include <seqan/misc_dynamic_prefix_sum.h>
+
+using namespace seqan;
+
+// Test constructor.
+SEQAN_DEFINE_TEST(test_misc_dynamic_prefix_sum_constructor)
+{
+    typedef DynamicPrefixSumTree<unsigned, int, 32> TPrefixSumTree;
+    typedef typename Value<TPrefixSumTree>::Type TNode;
+
+    TPrefixSumTree prefixSumTree;
+
+    SEQAN_ASSERT_NEQ(prefixSumTree.rootPtr, (TNode*) 0);
+    SEQAN_ASSERT_EQ(prefixSumTree.rootPtr->_isLeaf, true);
+
+    SEQAN_ASSERT_EQ(capacity(prefixSumTree.rootPtr->_keyTab), DpsHelper_<32>::MAX_KEY_NUMBER);
+    SEQAN_ASSERT_EQ(capacity(prefixSumTree.rootPtr->_cargoTab), DpsHelper_<32>::MAX_KEY_NUMBER);
+    SEQAN_ASSERT_EQ(capacity(prefixSumTree.rootPtr->_childTab), DpsHelper_<32>::MAX_CHILD_NUMBER);
+}
+
+SEQAN_DEFINE_TEST(test_misc_dynamic_prefix_sum_empty)
+{
+    typedef DynamicPrefixSumTree<unsigned, int> TPrefixSumTree;
+    typedef typename Value<TPrefixSumTree>::Type TNode;
+
+    TPrefixSumTree tree;
+
+    SEQAN_ASSERT_EQ(empty(tree), true);
+
+    appendValue(tree.rootPtr->_keyTab, 0);
+    appendValue(tree.rootPtr->_cargoTab, 1);
+    SEQAN_ASSERT_EQ(empty(tree), false);
+
+    appendValue(tree.rootPtr->_childTab, (TNode*) 0);
+    SEQAN_ASSERT_EQ(empty(tree), false);
+
+    clear(tree.rootPtr->_keyTab);
+    SEQAN_ASSERT_EQ(empty(tree), false);
+
+    clear(tree.rootPtr->_childTab);
+    SEQAN_ASSERT_EQ(empty(tree), true);
+}
+
+SEQAN_DEFINE_TEST(test_misc_dynamic_prefix_sum_insert)
+{
+    typedef DynamicPrefixSumTree<unsigned, int, 3> TPrefixSumTree;
+    typedef typename Value<TPrefixSumTree>::Type TNode;
+    typedef typename TNode::TKeyTab   TKeyTable;
+    typedef typename TNode::TCargoTab TCargoTable;
+    typedef typename TNode::TChildTab TChildTable;
+
+    TPrefixSumTree tree;
+
+    SEQAN_ASSERT_EQ(empty(tree), true);
+
+    insert(tree, 10, -2);
+
+    SEQAN_ASSERT_EQ(empty(tree), false);
+
+    {
+        TKeyTable & keyTab = tree.rootPtr->_keyTab;
+        TCargoTable & cargoTab = tree.rootPtr->_cargoTab;
+        TChildTable & childTab = tree.rootPtr->_childTab;
+
+        SEQAN_ASSERT_EQ(length(keyTab), 1u);
+        SEQAN_ASSERT_EQ(keyTab[0], 10u);
+
+        SEQAN_ASSERT_EQ(length(cargoTab), 1u);
+        SEQAN_ASSERT_EQ(cargoTab[0], -2);
+
+        SEQAN_ASSERT_EQ(length(childTab), 0u);
+
+        // Full Node.
+        insert(tree, 20,  7);
+        insert(tree,  5,  4);
+        insert(tree, 25, -6);
+        insert(tree,  0,  1);
+
+        SEQAN_ASSERT_EQ(length(keyTab), 5u);
+        SEQAN_ASSERT_EQ(keyTab[0], 0u);
+        SEQAN_ASSERT_EQ(keyTab[1], 5u);
+        SEQAN_ASSERT_EQ(keyTab[2], 10u);
+        SEQAN_ASSERT_EQ(keyTab[3], 20u);
+        SEQAN_ASSERT_EQ(keyTab[4], 25u);
+
+        SEQAN_ASSERT_EQ(length(cargoTab), 5u);
+        SEQAN_ASSERT_EQ(cargoTab[0], 1);    // 1
+        SEQAN_ASSERT_EQ(cargoTab[1], 5);    // 4
+        SEQAN_ASSERT_EQ(cargoTab[2], 3);    // -2
+        SEQAN_ASSERT_EQ(cargoTab[3], 10);    // 7
+        SEQAN_ASSERT_EQ(cargoTab[4], 4);    // -6
+
+        SEQAN_ASSERT_EQ(length(childTab), 0u);
+    }
+
+    // Split root and insert in right child.
+    insert(tree, 15, -3);
+
+    {
+        TKeyTable & keyTab = tree.rootPtr->_keyTab;
+        TCargoTable & cargoTab = tree.rootPtr->_cargoTab;
+        TChildTable & childTab = tree.rootPtr->_childTab;
+
+        SEQAN_ASSERT_EQ(length(keyTab), 1u);
+        SEQAN_ASSERT_EQ(keyTab[0], 10u);
+
+        SEQAN_ASSERT_EQ(length(cargoTab), 1u);
+        SEQAN_ASSERT_EQ(cargoTab[0], 3);
+
+        SEQAN_ASSERT_EQ(length(childTab), 2u);
+    }
+
+    // Check left child.
+    {
+        TNode& leftChild = getChild(*tree.rootPtr, 0);
+        TKeyTable & keyTab = leftChild._keyTab;
+        TCargoTable & cargoTab = leftChild._cargoTab;
+        TChildTable & childTab = leftChild._childTab;
+
+        SEQAN_ASSERT_EQ(length(keyTab), 2u);
+        SEQAN_ASSERT_EQ(keyTab[0], 0u);
+        SEQAN_ASSERT_EQ(keyTab[1], 5u);
+
+        SEQAN_ASSERT_EQ(length(cargoTab), 2u);
+        SEQAN_ASSERT_EQ(cargoTab[0], 1);
+        SEQAN_ASSERT_EQ(cargoTab[1], 5);
+
+        SEQAN_ASSERT_EQ(length(childTab), 0u);
+    }
+
+    // Check right child.
+    {
+        TNode& rightChild = getChild(*tree.rootPtr, 1);
+        TKeyTable & keyTab = rightChild._keyTab;
+        TCargoTable & cargoTab = rightChild._cargoTab;
+        TChildTable & childTab = rightChild._childTab;
+
+        SEQAN_ASSERT_EQ(length(keyTab), 3u);
+        SEQAN_ASSERT_EQ(keyTab[0], 15u);
+        SEQAN_ASSERT_EQ(keyTab[1], 20u);
+        SEQAN_ASSERT_EQ(keyTab[2], 25u);
+
+        SEQAN_ASSERT_EQ(length(cargoTab), 3u);
+        SEQAN_ASSERT_EQ(cargoTab[0], -3);
+        SEQAN_ASSERT_EQ(cargoTab[1], 4);
+        SEQAN_ASSERT_EQ(cargoTab[2], -2);
+
+        SEQAN_ASSERT_EQ(length(childTab), 0u);
+    }
+
+    // Fill left child.
+    {
+        insert(tree, 2, 2);
+        insert(tree, 8, 5);
+        insert(tree, 3, -8);
+
+        TNode leftChild = getChild(*tree.rootPtr, 0);
+        TKeyTable keyTab = leftChild._keyTab;
+        TCargoTable cargoTab = leftChild._cargoTab;
+        TChildTable childTab = leftChild._childTab;
+
+        SEQAN_ASSERT_EQ(length(keyTab), 5u);
+        SEQAN_ASSERT_EQ(keyTab[0], 0u);
+        SEQAN_ASSERT_EQ(keyTab[1], 2u);
+        SEQAN_ASSERT_EQ(keyTab[2], 3u);
+        SEQAN_ASSERT_EQ(keyTab[3], 5u);
+        SEQAN_ASSERT_EQ(keyTab[4], 8u);
+
+        SEQAN_ASSERT_EQ(length(cargoTab), 5u);
+        SEQAN_ASSERT_EQ(cargoTab[0], 1);  // 1
+        SEQAN_ASSERT_EQ(cargoTab[1], 3);  // 2
+        SEQAN_ASSERT_EQ(cargoTab[2], -5); // -8
+        SEQAN_ASSERT_EQ(cargoTab[3], -1); // 4
+        SEQAN_ASSERT_EQ(cargoTab[4], 4);  // 5
+
+        SEQAN_ASSERT_EQ(length(childTab), 0u);
+
+        TNode root = _getRoot(tree);
+
+        keyTab = root._keyTab;
+        cargoTab = root._cargoTab;
+        childTab = root._childTab;
+
+        SEQAN_ASSERT_EQ(length(keyTab), 1u);
+        SEQAN_ASSERT_EQ(keyTab[0], 10u);
+
+        SEQAN_ASSERT_EQ(length(cargoTab), 1u);
+        SEQAN_ASSERT_EQ(cargoTab[0], 2);
+
+        SEQAN_ASSERT_EQ(length(childTab), 2u);
+    }
+
+    // Split left child add to left half of split node.
+    {
+        insert(tree, 1, -100);
+
+        TNode root = _getRoot(tree);
+
+        TKeyTable   keyTab   = root._keyTab;
+        TCargoTable cargoTab = root._cargoTab;
+        TChildTable childTab = root._childTab;
+
+        SEQAN_ASSERT_EQ(length(keyTab), 2u);
+        SEQAN_ASSERT_EQ(keyTab[0], 3u);
+        SEQAN_ASSERT_EQ(keyTab[1], 10u);
+
+        SEQAN_ASSERT_EQ(length(cargoTab), 2u);
+        SEQAN_ASSERT_EQ(cargoTab[0], -105);  // -8
+        SEQAN_ASSERT_EQ(cargoTab[1], -98);   // -2
+
+        SEQAN_ASSERT_EQ(length(childTab), 3u);
+
+        TNode& leftChild = getChild(*tree.rootPtr, 0);
+        keyTab = leftChild._keyTab;
+        cargoTab = leftChild._cargoTab;
+        childTab = leftChild._childTab;
+
+        SEQAN_ASSERT_EQ(length(keyTab), 3u);
+        SEQAN_ASSERT_EQ(keyTab[0], 0u);  // 1
+        SEQAN_ASSERT_EQ(keyTab[1], 1u);  // -100
+        SEQAN_ASSERT_EQ(keyTab[2], 2u);  // 2
+
+        SEQAN_ASSERT_EQ(length(cargoTab), 3u);
+        SEQAN_ASSERT_EQ(cargoTab[0], 1);    // 1
+        SEQAN_ASSERT_EQ(cargoTab[1], -99);  // -100
+        SEQAN_ASSERT_EQ(cargoTab[2], -97);  // 2
+
+        SEQAN_ASSERT_EQ(length(childTab), 0u);
+
+        TNode splitChild = getChild(*tree.rootPtr, 1);
+        keyTab = splitChild._keyTab;
+        cargoTab = splitChild._cargoTab;
+        childTab = splitChild._childTab;
+
+        SEQAN_ASSERT_EQ(keyTab[0], 5u);
+        SEQAN_ASSERT_EQ(keyTab[1], 8u);
+
+        SEQAN_ASSERT_EQ(cargoTab[0], 4);  // 4
+        SEQAN_ASSERT_EQ(cargoTab[1], 9);  // 5
+
+        SEQAN_ASSERT_EQ(length(childTab), 0u);
+    }
+
+    // Fill right child.
+    {
+        insert(tree, 50, -2);
+        insert(tree, 11, -2);
+
+        TNode rightChild = getChild(*tree.rootPtr, 2);
+        TKeyTable keyTab = rightChild._keyTab;
+        TCargoTable cargoTab = rightChild._cargoTab;
+        TChildTable childTab = rightChild._childTab;
+
+        SEQAN_ASSERT_EQ(length(keyTab), 5u);
+        SEQAN_ASSERT_EQ(keyTab[0], 11u);  // -2
+        SEQAN_ASSERT_EQ(keyTab[1], 15u);  // -3
+        SEQAN_ASSERT_EQ(keyTab[2], 20u);  // 7
+        SEQAN_ASSERT_EQ(keyTab[3], 25u);  // -6
+        SEQAN_ASSERT_EQ(keyTab[4], 50u);  // -2
+
+        SEQAN_ASSERT_EQ(length(cargoTab), 5u);
+        SEQAN_ASSERT_EQ(cargoTab[0], -2);  // -2
+        SEQAN_ASSERT_EQ(cargoTab[1], -5);  // -3
+        SEQAN_ASSERT_EQ(cargoTab[2], 2); // 7
+        SEQAN_ASSERT_EQ(cargoTab[3], -4); // -6
+        SEQAN_ASSERT_EQ(cargoTab[4], -6);  // -2
+
+        SEQAN_ASSERT_EQ(length(childTab), 0u);
+
+        TNode root = _getRoot(tree);
+
+        keyTab = root._keyTab;
+        cargoTab = root._cargoTab;
+        childTab = root._childTab;
+
+        SEQAN_ASSERT_EQ(length(keyTab), 2u);
+        SEQAN_ASSERT_EQ(keyTab[0], 3u);
+        SEQAN_ASSERT_EQ(keyTab[1], 10u);
+
+        SEQAN_ASSERT_EQ(length(cargoTab), 2u);
+        SEQAN_ASSERT_EQ(cargoTab[0], -105);
+        SEQAN_ASSERT_EQ(cargoTab[1], -98);
+
+        SEQAN_ASSERT_EQ(length(childTab), 3u);
+    }
+
+    // Split right child and add to left split node.
+    {
+        insert(tree, 19, -2);
+
+        TNode root = _getRoot(tree);
+
+        TKeyTable keyTab = root._keyTab;
+        TCargoTable cargoTab = root._cargoTab;
+        TChildTable childTab = root._childTab;
+
+        SEQAN_ASSERT_EQ(length(keyTab), 3u);
+        SEQAN_ASSERT_EQ(keyTab[0], 3u);
+        SEQAN_ASSERT_EQ(keyTab[1], 10u);
+        SEQAN_ASSERT_EQ(keyTab[2], 20u);
+
+        SEQAN_ASSERT_EQ(length(cargoTab), 3u);
+        SEQAN_ASSERT_EQ(cargoTab[0], -105);
+        SEQAN_ASSERT_EQ(cargoTab[1], -98);
+        SEQAN_ASSERT_EQ(cargoTab[2], -98);
+
+        SEQAN_ASSERT_EQ(length(childTab), 4u);
+
+        TNode rightChild = getChild(*tree.rootPtr, 2);
+        keyTab = rightChild._keyTab;
+        cargoTab = rightChild._cargoTab;
+        childTab = rightChild._childTab;
+
+        SEQAN_ASSERT_EQ(length(keyTab), 3u);
+        SEQAN_ASSERT_EQ(keyTab[0], 11u);  // -2
+        SEQAN_ASSERT_EQ(keyTab[1], 15u);  // -3
+        SEQAN_ASSERT_EQ(keyTab[2], 19u);  // -3
+
+        SEQAN_ASSERT_EQ(length(cargoTab), 3u);
+        SEQAN_ASSERT_EQ(cargoTab[0], -2);  // -2
+        SEQAN_ASSERT_EQ(cargoTab[1], -5);  // -3
+        SEQAN_ASSERT_EQ(cargoTab[2], -7);  // -2
+
+        SEQAN_ASSERT_EQ(length(childTab), 0u);
+
+        TNode splitChild = getChild(*tree.rootPtr, 3);
+        keyTab = splitChild._keyTab;
+        cargoTab = splitChild._cargoTab;
+        childTab = splitChild._childTab;
+
+        SEQAN_ASSERT_EQ(keyTab[0], 25u);  // -6
+        SEQAN_ASSERT_EQ(keyTab[1], 50u);  // -2
+
+        SEQAN_ASSERT_EQ(cargoTab[0], -6);  // -6
+        SEQAN_ASSERT_EQ(cargoTab[1], -8);  // -2
+
+        SEQAN_ASSERT_EQ(length(childTab), 0u);
+    }
+
+    // Split root.
+    {
+        insert(tree, 100, 10);
+        insert(tree, 12, 10);
+        insert(tree, 150, 10);
+        insert(tree, 16, 10);
+        insert(tree, 200, 10);
+        insert(tree, 17, 10);
+        insert(tree, 250, 10);
+
+        TNode root = _getRoot(tree);
+        TKeyTable keyTab = root._keyTab;
+        TCargoTable cargoTab = root._cargoTab;
+        TChildTable childTab = root._childTab;
+
+        SEQAN_ASSERT_EQ(length(keyTab), 5u);
+        SEQAN_ASSERT_EQ(keyTab[0], 3u);
+        SEQAN_ASSERT_EQ(keyTab[1], 10u);
+        SEQAN_ASSERT_EQ(keyTab[2], 15u);
+        SEQAN_ASSERT_EQ(keyTab[3], 20u);
+        SEQAN_ASSERT_EQ(keyTab[4], 100u);
+
+        SEQAN_ASSERT_EQ(length(cargoTab), 5u);
+        SEQAN_ASSERT_EQ(cargoTab[0], -105);
+        SEQAN_ASSERT_EQ(cargoTab[1], -98);
+        SEQAN_ASSERT_EQ(cargoTab[2], -93);
+        SEQAN_ASSERT_EQ(cargoTab[3], -68);
+        SEQAN_ASSERT_EQ(cargoTab[4], -66);
+
+        SEQAN_ASSERT_EQ(length(childTab), 6u);
+
+        // Actually split the root.
+        insert(tree, 7, 10);
+        insert(tree, 9, 10);
+        insert(tree, 4, 10);
+        insert(tree, 6, 10);
+
+        root = _getRoot(tree);
+        keyTab = root._keyTab;
+        cargoTab = root._cargoTab;
+        childTab = root._childTab;
+
+        SEQAN_ASSERT_EQ(length(keyTab), 1u);
+        SEQAN_ASSERT_EQ(keyTab[0], 15u);
+
+        SEQAN_ASSERT_EQ(length(cargoTab), 1u);
+        SEQAN_ASSERT_EQ(cargoTab[0], -53);
+
+        SEQAN_ASSERT_EQ(length(childTab), 2u);
+
+        // New left child < 15
+
+        TNode leftChildL1 = getChild(_getRoot(tree), 0);
+        keyTab = leftChildL1._keyTab;
+        cargoTab = leftChildL1._cargoTab;
+        childTab = leftChildL1._childTab;
+
+        SEQAN_ASSERT_EQ(length(keyTab), 3u);
+        SEQAN_ASSERT_EQ(keyTab[0], 3u);
+        SEQAN_ASSERT_EQ(keyTab[1], 7u);
+        SEQAN_ASSERT_EQ(keyTab[2], 10u);
+        SEQAN_ASSERT_EQ(length(cargoTab), 3u);
+        SEQAN_ASSERT_EQ(cargoTab[0], -105);
+        SEQAN_ASSERT_EQ(cargoTab[1], -71);
+        SEQAN_ASSERT_EQ(cargoTab[2], -58);
+        SEQAN_ASSERT_EQ(length(childTab), 4u);
+
+        // Children of leftChild1
+        {  // Leaf 0
+            TNode l1Leaf0 = getChild(leftChildL1, 0);
+            keyTab = l1Leaf0._keyTab;
+            cargoTab = l1Leaf0._cargoTab;
+            childTab = l1Leaf0._childTab;
+
+            SEQAN_ASSERT_EQ(length(keyTab), 3u);
+            SEQAN_ASSERT_EQ(keyTab[0], 0u);
+            SEQAN_ASSERT_EQ(keyTab[1], 1u);
+            SEQAN_ASSERT_EQ(keyTab[2], 2u);
+            SEQAN_ASSERT_EQ(length(cargoTab), 3u);
+            SEQAN_ASSERT_EQ(cargoTab[0], 1);
+            SEQAN_ASSERT_EQ(cargoTab[1], -99);
+            SEQAN_ASSERT_EQ(cargoTab[2], -97);
+            SEQAN_ASSERT_EQ(length(childTab), 0u);
+
+            // Leaf 1
+            TNode l1Leaf1 = getChild(leftChildL1, 1);
+            keyTab = l1Leaf1._keyTab;
+            cargoTab = l1Leaf1._cargoTab;
+            childTab = l1Leaf1._childTab;
+
+            SEQAN_ASSERT_EQ(length(keyTab), 3u);
+            SEQAN_ASSERT_EQ(keyTab[0], 4u);
+            SEQAN_ASSERT_EQ(keyTab[1], 5u);
+            SEQAN_ASSERT_EQ(keyTab[2], 6u);
+            SEQAN_ASSERT_EQ(length(cargoTab), 3u);
+            SEQAN_ASSERT_EQ(cargoTab[0], 10);
+            SEQAN_ASSERT_EQ(cargoTab[1], 14);
+            SEQAN_ASSERT_EQ(cargoTab[2], 24);
+            SEQAN_ASSERT_EQ(length(childTab), 0u);
+
+            //Leaf 2
+            TNode l1Leaf2 = getChild(leftChildL1, 2);
+            keyTab = l1Leaf2._keyTab;
+            cargoTab = l1Leaf2._cargoTab;
+            childTab = l1Leaf2._childTab;
+
+            SEQAN_ASSERT_EQ(length(keyTab), 2u);
+            SEQAN_ASSERT_EQ(keyTab[0], 8u);
+            SEQAN_ASSERT_EQ(keyTab[1], 9u);
+            SEQAN_ASSERT_EQ(length(cargoTab), 2u);
+            SEQAN_ASSERT_EQ(cargoTab[0], 5);
+            SEQAN_ASSERT_EQ(cargoTab[1], 15);
+            SEQAN_ASSERT_EQ(length(childTab), 0u);
+
+            //Leaf 3
+            TNode l1Leaf3 = getChild(leftChildL1, 3);
+            keyTab = l1Leaf3._keyTab;
+            cargoTab = l1Leaf3._cargoTab;
+            childTab = l1Leaf3._childTab;
+
+            SEQAN_ASSERT_EQ(length(keyTab), 2u);
+            SEQAN_ASSERT_EQ(keyTab[0], 11u);
+            SEQAN_ASSERT_EQ(keyTab[1], 12u);
+            SEQAN_ASSERT_EQ(length(cargoTab), 2u);
+            SEQAN_ASSERT_EQ(cargoTab[0], -2);
+            SEQAN_ASSERT_EQ(cargoTab[1], 8);
+            SEQAN_ASSERT_EQ(length(childTab), 0u);
+        }
+
+        // New right child > 15
+        TNode rightChildL1 = getChild(_getRoot(tree), 1);
+        keyTab = rightChildL1._keyTab;
+        cargoTab = rightChildL1._cargoTab;
+        childTab = rightChildL1._childTab;
+
+        SEQAN_ASSERT_EQ(length(keyTab), 2u);
+        SEQAN_ASSERT_EQ(keyTab[0], 20u);
+        SEQAN_ASSERT_EQ(keyTab[1], 100u);
+        SEQAN_ASSERT_EQ(length(cargoTab), 2u);
+        SEQAN_ASSERT_EQ(cargoTab[0], 25);
+        SEQAN_ASSERT_EQ(cargoTab[1], 27);
+        SEQAN_ASSERT_EQ(length(childTab), 3u);
+
+        // Children of rightChildL1
+        {  // Leaf 0
+            TNode r1Leaf0 = getChild(rightChildL1, 0);
+            keyTab = r1Leaf0._keyTab;
+            cargoTab = r1Leaf0._cargoTab;
+            childTab = r1Leaf0._childTab;
+
+            SEQAN_ASSERT_EQ(length(keyTab), 3u);
+            SEQAN_ASSERT_EQ(keyTab[0], 16u);
+            SEQAN_ASSERT_EQ(keyTab[1], 17u);
+            SEQAN_ASSERT_EQ(keyTab[2], 19u);
+            SEQAN_ASSERT_EQ(length(cargoTab), 3u);
+            SEQAN_ASSERT_EQ(cargoTab[0], 10);
+            SEQAN_ASSERT_EQ(cargoTab[1], 20);
+            SEQAN_ASSERT_EQ(cargoTab[2], 18);
+            SEQAN_ASSERT_EQ(length(childTab), 0u);
+
+            // Leaf 1
+            TNode r1Leaf1 = getChild(rightChildL1, 1);
+            keyTab = r1Leaf1._keyTab;
+            cargoTab = r1Leaf1._cargoTab;
+            childTab = r1Leaf1._childTab;
+
+            SEQAN_ASSERT_EQ(length(keyTab), 2u);
+            SEQAN_ASSERT_EQ(keyTab[0], 25u);
+            SEQAN_ASSERT_EQ(keyTab[1], 50u);
+            SEQAN_ASSERT_EQ(length(cargoTab), 2u);
+            SEQAN_ASSERT_EQ(cargoTab[0], -6);
+            SEQAN_ASSERT_EQ(cargoTab[1], -8);
+            SEQAN_ASSERT_EQ(length(childTab), 0u);
+
+            //Leaf 2
+            TNode r1Leaf2 = getChild(rightChildL1, 2);
+            keyTab = r1Leaf2._keyTab;
+            cargoTab = r1Leaf2._cargoTab;
+            childTab = r1Leaf2._childTab;
+
+            SEQAN_ASSERT_EQ(length(keyTab), 3u);
+            SEQAN_ASSERT_EQ(keyTab[0], 150u);
+            SEQAN_ASSERT_EQ(keyTab[1], 200u);
+            SEQAN_ASSERT_EQ(keyTab[2], 250u);
+            SEQAN_ASSERT_EQ(length(cargoTab), 3u);
+            SEQAN_ASSERT_EQ(cargoTab[0], 10);
+            SEQAN_ASSERT_EQ(cargoTab[1], 20);
+            SEQAN_ASSERT_EQ(cargoTab[2], 30);
+            SEQAN_ASSERT_EQ(length(childTab), 0u);
+        }
+    }
+}
+
+
+struct TestCompareLess_
+{
+    template <typename T>
+    inline bool
+    operator()(T const & i, T const & j)
+    {
+        return i.i1 < j.i1;
+    }
+};
+
+template <typename TFreq, typename TPos>
+inline int
+_testComputePrefixSum(TFreq const & data, TPos const & pos)
+{
+    typedef typename Iterator<TFreq const, Standard>::Type TIterator;
+
+    int sum = 0;
+    Pair<unsigned, int> key(pos, 0);
+    TIterator itEnd = std::upper_bound(begin(data, Standard()), end(data, Standard()), key, TestCompareLess_());
+    for (TIterator it = begin(data, Standard()); it != itEnd; ++it)
+        sum += it->i2;
+    return sum;
+}
+
+SEQAN_DEFINE_TEST(test_misc_dynamic_prefix_sum_prefix_sum)
+{
+    typedef DynamicPrefixSumTree<unsigned, int, 64> TPrefixSumTree;
+
+    String<Pair<unsigned, int> > testData;
+    TPrefixSumTree tree;
+
+    Rng<MersenneTwister> rng(42);
+    Pdf<Uniform<int> > freqPdf(-10000, 10000);
+    Pdf<Uniform<unsigned> > posPdf(0, 1000000);
+    String<bool, Packed<> > bitVec;
+    resize(bitVec, 1000000, false, Exact());
+
+    const unsigned LENGTH = 100000;
+    resize(testData, LENGTH, Exact());
+    for (unsigned i = 0; i < LENGTH; ++i)
+    {
+        testData[i].i1 = pickRandomNumber(rng, posPdf);
+        if (bitVec[testData[i].i1])  // Do not pick the same number twice.
+        {
+            --i;
+            continue;
+        }
+        bitVec[testData[i].i1] = true;
+        testData[i].i2 = pickRandomNumber(rng, freqPdf);
+        insert(tree, testData[i].i1, testData[i].i2);
+    }
+
+    std::sort(begin(testData, Standard()), end(testData, Standard()));
+    int testSum = 0;
+    for (unsigned i = 0; i < LENGTH; ++i)
+    {
+        testSum += testData[i].i2;
+        SEQAN_ASSERT_EQ(prefixSum(tree, testData[i].i1), testSum);
+    }
+
+    // Find random positions.
+    for (unsigned i = 0; i < LENGTH; ++i)
+    {
+        unsigned pos = pickRandomNumber(rng, posPdf);
+        SEQAN_ASSERT_EQ(prefixSum(tree, pos), _testComputePrefixSum(testData, pos));
+    }
+}
+
+
+#endif  // EXTRAS_TESTS_MISC_DYNAMIC_PREFIX_SUM_TEST_MISC_DYNAMIC_PREFIX_SUM_H_


### PR DESCRIPTION
Initial commit of a dynamic data structure that can compute a prefix sum and supports insert/delete in O(b log_b(n)) time, where b is the branching factor of the underlying B-Tree implementation. The prefix sum can be computed in O(log(b)*log_b(n)) time by traversing the tree beginning in the root.
At the moment only insert is  implemented. Delete should be straight forward but is not needed yet.
This commit includes tests for the new data structure.
Documentation will be added soon.