### PR TITLE
Feature/dp modifications

### DIFF
--- a/core/include/seqan/align/dp_algorithm_impl.h
+++ b/core/include/seqan/align/dp_algorithm_impl.h
@@ -159,7 +159,7 @@ namespace seqan {
 template <typename TSequenceH, typename TSequenceV, typename TAlignmentProfile>
 inline bool _checkBandProperties(TSequenceH const & /*seqH*/,
                                  TSequenceV const & /*seqV*/,
-                                 DPBand_<BandOff> const & /*band*/,
+                                 DPBandConfig<BandOff> const & /*band*/,
                                  TAlignmentProfile const & /*alignProfile*/)
 {
     return true;
@@ -168,7 +168,7 @@ inline bool _checkBandProperties(TSequenceH const & /*seqH*/,
 template <typename TSequenceH, typename TSequenceV, typename TAlignmentProfile>
 inline bool _checkBandProperties(TSequenceH const & seqH,
                                  TSequenceV const & seqV,
-                                 DPBand_<BandOn> const & band,
+                                 DPBandConfig<BandOn> const & band,
                                  TAlignmentProfile const & /*alignProfile*/)
 {
     typedef typename MakeSigned<typename Size<TSequenceH>::Type>::Type TSignedSize;
@@ -238,7 +238,7 @@ inline bool _isValidDPSettings(TSequenceH const & seqH,
 // Returns true if a band is selected, otherwise false.
 template <typename TBandSpec>
 inline bool
-_isBandEnabled(DPBand_<TBandSpec> const & /*band*/)
+_isBandEnabled(DPBandConfig<TBandSpec> const & /*band*/)
 {
     return IsSameType<TBandSpec, BandOn>::VALUE;
 }
@@ -1361,7 +1361,7 @@ _computeAlignment(TTraceTarget & traceSegments,
                   TSequenceH const & seqH,
                   TSequenceV const & seqV,
                   TScoreScheme const & scoreScheme,
-                  DPBand_<TBandSwitch> const & band,
+                  DPBandConfig<TBandSwitch> const & band,
                   DPProfile_<TAlignmentAlgorithm, TGapCosts, TTraceFlag> const & dpProfile)
 {
     typedef typename Value<TScoreScheme>::Type TScoreValue;
@@ -1449,7 +1449,7 @@ _computeAlignment(TTraceTarget & traceSegments,
                   TSequenceH const & seqH,
                   TSequenceV const & seqV,
                   TScoreScheme const & scoreScheme,
-                  DPBand_<TBandSwitch> const & band,
+                  DPBandConfig<TBandSwitch> const & band,
                   DPProfile_<TAlignmentAlgorithm, TGapCosts, TTraceFlag> const & dpProfile)
 {
     DPScoutState_<Default> noState;

--- a/core/include/seqan/align/dp_band.h
+++ b/core/include/seqan/align/dp_band.h
@@ -35,12 +35,11 @@
 // whether a band was selected or not.
 // ==========================================================================
 
-// TODO(holtgrew): Documentation in this header necessary or internal only?
-
 #ifndef SEQAN_CORE_INCLUDE_SEQAN_ALIGN_DP_BAND_H_
 #define SEQAN_CORE_INCLUDE_SEQAN_ALIGN_DP_BAND_H_
 
-namespace seqan {
+namespace seqan
+{
 
 // ============================================================================
 // Forwards
@@ -49,6 +48,23 @@ namespace seqan {
 // ============================================================================
 // Tags, Classes, Enums
 // ============================================================================
+
+/*!
+ * @defgroup DPBandSwitch
+ * @brief Tags used to switch between banded and unbanded alignment.
+ *
+ * @tag DPBandSwitch#BandOn
+ * @brief Switches banded alignment on.
+ * @headerfile <seqan/align.h>
+ * @signature struct BandOn_;
+ * @signature typedef Tag<BandOn_> BandOn;
+ *
+ * @tag DPBandSwitch#BandOff
+ * @brief Switches banded alignment off.
+ * @headerfile <seqan/align.h>
+ * @signature struct BandOff_;
+ * @signature typedef Tag<BandOff_> BandOff;
+ */
 
 // ----------------------------------------------------------------------------
 // Tag BandOff
@@ -67,76 +83,149 @@ struct BandOn_;
 typedef Tag<BandOn_> BandOn;
 
 // ----------------------------------------------------------------------------
-// Class DPBand_
+// Class DPBandConfig
 // ----------------------------------------------------------------------------
+
+/*!
+ * @class DPBandConfig
+ * @headerfile <seqan/align.h>
+ * @brief Simple class to configure banded alignments.
+ *
+ * @signature template <typename TSwitch>
+ *            class DPBandConfig<TSwitch>;
+ *
+ * @tparam TSwitch Tag to switch between banded and unbanded alignments.
+ *              One of @link DPBandSwitch @endlink. Defaults to @link DPBandSwitch#BandOff @endlink.
+ *
+ * To compute banded alignments use @link DPBand @endlink as a shortcut for the <tt>DPBandConfig</tt> with
+ * band switched on.
+ */
 
 // Simple band class.
-template <typename TSpec>
-struct DPBand_ {};
+template <typename TSpec = BandOff>
+struct DPBandConfig {};
 
 // ----------------------------------------------------------------------------
-// Class DPBand_                                                      [BandOff]
+// Class DPBandConfig                                                  [BandOff]
 // ----------------------------------------------------------------------------
 
 // The specialization when using no band.
 // Per default the member variables _lowerDiagonal and _upperDiagonal are
 // always 0.
 template <>
-struct DPBand_<BandOff>
+struct DPBandConfig<BandOff>
 {
     typedef int TPosition;
 };
 
 // ----------------------------------------------------------------------------
-// Class DPBand_                                                       [BandOn]
+// Class DPBandConfig                                                  [BandOn]
 // ----------------------------------------------------------------------------
 
 // The specialization when using a band.
 // On construction the diagonals are set to 0.
 template <>
-struct DPBand_<BandOn>
+struct DPBandConfig<BandOn>
 {
     typedef int TPosition;
 
     int _lowerDiagonal;
     int _upperDiagonal;
 
-    DPBand_() :
+/*!
+ * @fn DPBandConfig::DPBandConfig
+ * @brief Constructor.
+ *
+ * @signature DPBandConfig<TSwitch>();
+ * @signature DPBandConfig<BandOn>(lowerDiag, upperDiag);
+ *
+ * @tparam TSwitch Tag to switch between banded and unbanded alignments. One of @link DPBandSwitch @endlink.
+ *              The second constructor is only supported when @link DPBandConfig @endlink is specialized with
+ *              @link DPBandSwitch#BandOn @endlink.
+ *
+ * @param lowerDiag The value for the lower diagonal of the band.
+ * @param upperDiag The value for the upper diagonal of the band.
+ *
+ * A negative value for the diagonals indicates an intersection of the diagonal with the vertical sequence (y-axis)
+ * and a positive value indicates an intersection with the horizontal sequence (x-axis).
+ * The value of the lower diagonal has to compare less or equal to the value of the upper diagonal.
+ */
+
+    DPBandConfig() :
         _lowerDiagonal(0), _upperDiagonal(0) {}
 
-    DPBand_(int lowerDiagonal, int upperDiagonal) :
-        _lowerDiagonal(lowerDiagonal), _upperDiagonal(upperDiagonal) {}
+    DPBandConfig(int lowerDiagonal, int upperDiagonal) :
+        _lowerDiagonal(lowerDiagonal), _upperDiagonal(upperDiagonal)
+    {
+        SEQAN_ASSERT_LEQ(lowerDiagonal, upperDiagonal);
+    }
 };
+
+/*!
+ * @typedef DPBand
+ * @headerfile <seqan/align.h>
+ * @brief Global typedef used for @link DPBandConfig @endlink specialized with @link DPBandSwitch#BandOn @endlink.
+ *
+ * @signature typedef DPBandConfig<BandOn> DPBand;
+ */
+
+// Typedef for Band.
+typedef DPBandConfig<BandOn> DPBand;
 
 // ============================================================================
 // Metafunctions
 // ============================================================================
+
+/*!
+ * @mfn DPBandConfig#Position
+ * @headerfile <seqan/align.h>
+ * @brief Metafunction returning the position type.
+ *
+ * @signature typename Position<T>::Type;
+ *
+ * @tparam T The type @link DPBandConfig @endlink to query the position type for.
+ * @return TPosition The position type.
+ */
 
 // ----------------------------------------------------------------------------
 // Metafunction Position
 // ----------------------------------------------------------------------------
 
 template <typename T>
-struct Position<DPBand_<T> >
+struct Position<DPBandConfig<T> >
 {
-    typedef typename DPBand_<T>::TPosition Type;
+    typedef typename DPBandConfig<T>::TPosition Type;
 };
 
 template <typename T>
-struct Position<DPBand_<T> const>:
-    Position<DPBand_<T> >{};
+struct Position<DPBandConfig<T> const>:
+    Position<DPBandConfig<T> >{};
 
 // ----------------------------------------------------------------------------
 // Metafunction Size
 // ----------------------------------------------------------------------------
 
-template <typename T>
-struct Size<DPBand_<T> >:
-    Position<DPBand_<T> >{};
+/*!
+ * @mfn DPBandConfig#Size
+ * @headerfile <seqan/align.h>
+ * @brief Metafunction returning the size type.
+ *
+ * @signature typename Size<T>::Type;
+ *
+ * @tparam T The type @link DPBandConfig @endlink to query the size type for.
+ * @return TSize The size type.
+ */
 
 template <typename T>
-struct Size<DPBand_<T> const>:
-    Size<DPBand_<T> >{};
+struct Size<DPBandConfig<T> >
+{
+    typedef unsigned Type;
+};
+
+
+template <typename T>
+struct Size<DPBandConfig<T> const>:
+    Size<DPBandConfig<T> >{};
 
 // ============================================================================
 // Functions
@@ -146,14 +235,27 @@ struct Size<DPBand_<T> const>:
 // Function setLowerDiagonal
 // ----------------------------------------------------------------------------
 
+/*!
+ * @fn DPBandConfig#setLowerDiagonal
+ * @headerfile <seqan/align.h>
+ * @brief Sets the value of the lower diagonal.
+ *
+ * @signature setLowerDiagonal(obj, val);
+ *
+ * @param obj The object of type @link DPBandConfig @endlink to set the lower diagonal for.
+ * @param val The new value for the lower diagonal.
+ *
+ * @note If the band is switched off, this function defaults to no-op.
+ */
+
 inline void
-setLowerDiagonal(DPBand_<BandOff> & /*dpBand*/, int /*newLowerDiagonal*/)
+setLowerDiagonal(DPBandConfig<BandOff> & /*dpBand*/, int /*newLowerDiagonal*/)
 {
     //no-op
 }
 
 inline void
-setLowerDiagonal(DPBand_<BandOn> & dpBand, int newLowerDiagonal)
+setLowerDiagonal(DPBandConfig<BandOn> & dpBand, int newLowerDiagonal)
 {
     dpBand._lowerDiagonal = newLowerDiagonal;
 }
@@ -162,15 +264,28 @@ setLowerDiagonal(DPBand_<BandOn> & dpBand, int newLowerDiagonal)
 // Function lowerDiagonal
 // ----------------------------------------------------------------------------
 
-inline int
-lowerDiagonal(DPBand_<BandOff> const & /*dpBand*/)
+/*!
+ * @fn DPBandConfig#lowerDiagonal
+ * @headerfile <seqan/align.h>
+ * @brief Returns the value of the lower diagonal.
+ *
+ * @signature TPosition lowerDiagonal(obj);
+ *
+ * @param obj The object of type @link DPBandConfig @endlink to query the lower diagonal for.
+ *
+ * @note If the band is switched off this function always returns 0.
+ * @return TPosition The value of the lower diagonal.
+ */
+
+inline Position<DPBandConfig<BandOff> >::Type
+lowerDiagonal(DPBandConfig<BandOff> const & /*dpBand*/)
 {
     return 0;
 }
 
-template <typename TBandSwitch>
-inline int
-lowerDiagonal(DPBand_<TBandSwitch> const & dpBand)
+template <typename TSwitch>
+inline typename Position<DPBandConfig<BandOff> >::Type
+lowerDiagonal(DPBandConfig<TSwitch> const & dpBand)
 {
     return dpBand._lowerDiagonal;
 }
@@ -179,14 +294,27 @@ lowerDiagonal(DPBand_<TBandSwitch> const & dpBand)
 // Function setUpperDiagonal
 // ----------------------------------------------------------------------------
 
+/*!
+ * @fn DPBandConfig#setUpperDiagonal
+ * @headerfile <seqan/align.h>
+ * @brief Sets the value of the upper diagonal.
+ *
+ * @signature setUpperDiagonal(obj, val);
+ *
+ * @param obj The object of type @link DPBandConfig @endlink to set the upper diagonal for.
+ * @param val The new value for the upper diagonal.
+ *
+ * @note If the band is switched off, this function defaults to no-op.
+ */
+
 inline void
-setUpperDiagonal(DPBand_<BandOff> & /*dpBand*/, int /*newUpperDiagonal*/)
+setUpperDiagonal(DPBandConfig<BandOff> & /*dpBand*/, int /*newUpperDiagonal*/)
 {
     //no-op
 }
 
 inline void
-setUpperDiagonal(DPBand_<BandOn> & dpBand, int newUpperDiagonal)
+setUpperDiagonal(DPBandConfig<BandOn> & dpBand, int newUpperDiagonal)
 {
     dpBand._upperDiagonal = newUpperDiagonal;
 }
@@ -195,14 +323,28 @@ setUpperDiagonal(DPBand_<BandOn> & dpBand, int newUpperDiagonal)
 // Function upperDiagonal
 // ----------------------------------------------------------------------------
 
-inline int
-upperDiagonal(DPBand_<BandOff> const & /*dpBand*/)
+/*!
+ * @fn DPBandConfig#upperDiagonal
+ * @headerfile <seqan/align.h>
+ * @brief Returns the value of the upper diagonal.
+ *
+ * @signature TPosition upperDiagonal(obj);
+ *
+ * @param obj The object of type @link DPBandConfig @endlink to query the upper diagonal for.
+ *
+ * @note If the band is switched off this function always returns 0.
+ * @return TPosition The value of the upper diagonal.
+ */
+
+inline Position<DPBandConfig<BandOff> >::Type
+upperDiagonal(DPBandConfig<BandOff> const & /*dpBand*/)
 {
     return 0;
 }
 
-inline int
-upperDiagonal(DPBand_<BandOn> const & dpBand)
+template <typename TSwitch>
+inline typename Position<DPBandConfig<BandOn> >::Type
+upperDiagonal(DPBandConfig<TSwitch> const & dpBand)
 {
     return dpBand._upperDiagonal;
 }
@@ -211,14 +353,28 @@ upperDiagonal(DPBand_<BandOn> const & dpBand)
 // Function bandSize()
 // ----------------------------------------------------------------------------
 
-inline unsigned int
-bandSize(DPBand_<BandOff> const &)
+/*!
+ * @fn DPBandConfig#bandSize
+ * @headerfile <seqan/align.h>
+ * @brief Returns the size of the band.
+ *
+ * @signature TSize bandSize(obj);
+ *
+ * @param obj The object of type @link DPBandConfig @endlink to query the band size for.
+ *
+ * @note If the band is switched off this function always returns 0.
+ * @return TSize The number of diagonals covered by the band.
+ */
+
+inline Size<DPBandConfig<BandOff> >::Type
+bandSize(DPBandConfig<BandOff> const &)
 {
     return 0;
 }
 
-inline unsigned int
-bandSize(DPBand_<BandOn> const & band)
+template <typename TSwitch>
+inline typename Size<DPBandConfig<TSwitch> >::Type
+bandSize(DPBandConfig<TSwitch> const & band)
 {
     return upperDiagonal(band) - lowerDiagonal(band) + 1;
 }

--- a/core/include/seqan/align/dp_matrix_navigator_score_matrix.h
+++ b/core/include/seqan/align/dp_matrix_navigator_score_matrix.h
@@ -102,7 +102,7 @@ template <typename TValue>
 inline void
 _init(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPScoreMatrix, NavigateColumnWise> & navigator,
       DPMatrix_<TValue, FullDPMatrix> & dpMatrix,
-      DPBand_<BandOff> const &)
+      DPBandConfig<BandOff> const &)
 {
     navigator._ptrDataContainer = &dpMatrix;
     navigator._activeColIterator = begin(dpMatrix, Standard());
@@ -115,7 +115,7 @@ template <typename TValue>
 inline void
 _init(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPScoreMatrix, NavigateColumnWise> & navigator,
       DPMatrix_<TValue, FullDPMatrix> & dpMatrix,
-      DPBand_<BandOn> const & band)
+      DPBandConfig<BandOn> const & band)
 {
     typedef typename Size<DPMatrix_<TValue, FullDPMatrix> >::Type TMatrixSize;
     typedef typename MakeSigned<TMatrixSize>::Type TSignedSize;

--- a/core/include/seqan/align/dp_matrix_navigator_score_matrix_sparse.h
+++ b/core/include/seqan/align/dp_matrix_navigator_score_matrix_sparse.h
@@ -101,7 +101,7 @@ template <typename TValue>
 inline void
 _init(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWise> & navigator,
       DPMatrix_<TValue, SparseDPMatrix> & dpMatrix,
-      DPBand_<BandOff> const &)
+      DPBandConfig<BandOff> const &)
 {
     navigator._ptrDataContainer = &dpMatrix;
     navigator._activeColIterator = begin(dpMatrix, Standard());
@@ -114,7 +114,7 @@ template <typename TValue>
 inline void
 _init(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWise> & navigator,
       DPMatrix_<TValue, SparseDPMatrix> & dpMatrix,
-      DPBand_<BandOn> const & band)
+      DPBandConfig<BandOn> const & band)
 {
     typedef DPMatrix_<TValue, SparseDPMatrix> TSparseDPMatrix;
     typedef typename Size<TSparseDPMatrix>::Type TSize;

--- a/core/include/seqan/align/dp_matrix_navigator_trace_matrix.h
+++ b/core/include/seqan/align/dp_matrix_navigator_trace_matrix.h
@@ -102,7 +102,7 @@ template <typename TValue, typename TTraceFlag>
 inline void
 _init(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, NavigateColumnWise> & navigator,
       DPMatrix_<TValue, FullDPMatrix> & dpMatrix,
-      DPBand_<BandOff> const &)
+      DPBandConfig<BandOff> const &)
 {
     if (IsSameType<TTraceFlag, TracebackOff>::VALUE)
         return;  // Leave navigator uninitialized because it is never used.
@@ -118,7 +118,7 @@ template <typename TValue, typename TTraceFlag>
 inline void
 _init(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, NavigateColumnWise> & navigator,
       DPMatrix_<TValue, FullDPMatrix> & dpMatrix,
-      DPBand_<BandOn> const & band)
+      DPBandConfig<BandOn> const & band)
 {
     typedef typename Size<DPMatrix_<TValue, FullDPMatrix> >::Type TMatrixSize;
     typedef typename MakeSigned<TMatrixSize>::Type TSignedSize;

--- a/core/include/seqan/align/dp_setup.h
+++ b/core/include/seqan/align/dp_setup.h
@@ -254,12 +254,12 @@ _setUpAndRunAlignment(String<TTraceSegment, TSpec> & traceSegments,
         scoreGapOpenVertical(scoringScheme, seqHEntry, seqVEntry))
     {
         typedef typename SetupAlignmentProfile_<TAlgoTag, AlignConfig<>, AffineGaps, TracebackOn<TGapsTag> >::Type TDPProfile;
-        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBand_<BandOff>(), TDPProfile());
+        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBandConfig<BandOff>(), TDPProfile());
     }
     else
     {
         typedef typename SetupAlignmentProfile_<TAlgoTag, AlignConfig<>, LinearGaps, TracebackOn<TGapsTag> >::Type TDPProfile;
-        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBand_<BandOff>(), TDPProfile());
+        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBandConfig<BandOff>(), TDPProfile());
     }
 }
 
@@ -334,12 +334,12 @@ _setUpAndRunAlignment(String<TTraceSegment, TSpec> & traceSegments,
         scoreGapOpenVertical(scoringScheme, seqHEntry, seqVEntry))
     {
         typedef typename SetupAlignmentProfile_<TAlgoTag, TAlignConfig, AffineGaps, TracebackOn<TGapsTag> >::Type TDPProfile;
-        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBand_<BandOff>(), TDPProfile());
+        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBandConfig<BandOff>(), TDPProfile());
     }
     else
     {
         typedef typename SetupAlignmentProfile_<TAlgoTag, TAlignConfig, LinearGaps, TracebackOn<TGapsTag> >::Type TDPProfile;
-        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBand_<BandOff>(), TDPProfile());
+        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBandConfig<BandOff>(), TDPProfile());
     }
 }
 
@@ -419,12 +419,12 @@ _setUpAndRunAlignment(DPScoutState_<TDPScoutStateSpec> & dpScoutState,
         scoreGapOpenVertical(scoringScheme, seqHEntry, seqVEntry))
     {
         typedef typename SetupAlignmentProfile_<TAlgoTag, AlignConfig<>, AffineGaps, TracebackOff>::Type TDPProfile;
-        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBand_<BandOff>(), TDPProfile());
+        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBandConfig<BandOff>(), TDPProfile());
     }
     else
     {
         typedef typename SetupAlignmentProfile_<TAlgoTag, AlignConfig<>, LinearGaps, TracebackOff>::Type TDPProfile;
-        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBand_<BandOff>(), TDPProfile());
+        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBandConfig<BandOff>(), TDPProfile());
     }
 }
 
@@ -497,12 +497,12 @@ _setUpAndRunAlignment(DPScoutState_<TDPScoutStateSpec> & dpScoutState,
         scoreGapOpenVertical(scoringScheme, seqHEntry, seqVEntry))
     {
         typedef typename SetupAlignmentProfile_<TAlgoTag, TAlignConfig, AffineGaps, TracebackOff>::Type TDPProfile;
-        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBand_<BandOff>(), TDPProfile());
+        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBandConfig<BandOff>(), TDPProfile());
     }
     else
     {
         typedef typename SetupAlignmentProfile_<TAlgoTag, TAlignConfig, LinearGaps, TracebackOff>::Type TDPProfile;
-        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBand_<BandOff>(), TDPProfile());
+        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBandConfig<BandOff>(), TDPProfile());
     }
 }
 
@@ -584,12 +584,12 @@ _setUpAndRunAlignment(String<TTraceSegment, TSpec> & traceSegments,
         scoreGapOpenVertical(scoringScheme, seqHEntry, seqVEntry))
     {
         typedef typename SetupAlignmentProfile_<TAlgoTag, AlignConfig<>, AffineGaps, TracebackOn<TGapsTag> >::Type TDPProfile;
-        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBand_<BandOn>(lowerDiagonal, upperDiagonal), TDPProfile());
+        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBandConfig<BandOn>(lowerDiagonal, upperDiagonal), TDPProfile());
     }
     else
     {
         typedef typename SetupAlignmentProfile_<TAlgoTag, AlignConfig<>, LinearGaps, TracebackOn<TGapsTag> >::Type TDPProfile;
-        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBand_<BandOn>(lowerDiagonal, upperDiagonal), TDPProfile());
+        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBandConfig<BandOn>(lowerDiagonal, upperDiagonal), TDPProfile());
     }
 }
 
@@ -672,12 +672,12 @@ _setUpAndRunAlignment(String<TTraceSegment, TSpec> & traceSegments,
         scoreGapOpenVertical(scoringScheme, seqHEntry, seqVEntry))
     {
         typedef typename SetupAlignmentProfile_<TAlgoTag, TAlignConfig, AffineGaps, TracebackOn<TGapsTag> >::Type TDPProfile;
-        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBand_<BandOn>(lowerDiagonal, upperDiagonal), TDPProfile());
+        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBandConfig<BandOn>(lowerDiagonal, upperDiagonal), TDPProfile());
     }
     else
     {
         typedef typename SetupAlignmentProfile_<TAlgoTag, TAlignConfig, LinearGaps, TracebackOn<TGapsTag> >::Type TDPProfile;
-        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBand_<BandOn>(lowerDiagonal, upperDiagonal), TDPProfile());
+        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBandConfig<BandOn>(lowerDiagonal, upperDiagonal), TDPProfile());
     }
 }
 
@@ -766,12 +766,12 @@ _setUpAndRunAlignment(DPScoutState_<TDPScoutStateSpec> & dpScoutState,
         scoreGapOpenVertical(scoringScheme, seqHEntry, seqVEntry))
     {
         typedef typename SetupAlignmentProfile_<TAlgoTag, AlignConfig<>, AffineGaps, TracebackOff>::Type TDPProfile;
-        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBand_<BandOn>(lowerDiagonal, upperDiagonal), TDPProfile());
+        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBandConfig<BandOn>(lowerDiagonal, upperDiagonal), TDPProfile());
     }
     else
     {
         typedef typename SetupAlignmentProfile_<TAlgoTag, AlignConfig<>, LinearGaps, TracebackOff>::Type TDPProfile;
-        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBand_<BandOn>(lowerDiagonal, upperDiagonal), TDPProfile());
+        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBandConfig<BandOn>(lowerDiagonal, upperDiagonal), TDPProfile());
     }
 }
 
@@ -841,12 +841,12 @@ _setUpAndRunAlignment(DPScoutState_<TDPScoutStateSpec> & dpScoutState,
         scoreGapOpenVertical(scoringScheme, seqHEntry, seqVEntry))
     {
         typedef typename SetupAlignmentProfile_<TAlgoTag, TAlignConfig, AffineGaps, TracebackOff>::Type TDPProfile;
-        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBand_<BandOn>(lowerDiagonal, upperDiagonal), TDPProfile());
+        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBandConfig<BandOn>(lowerDiagonal, upperDiagonal), TDPProfile());
     }
     else
     {
         typedef typename SetupAlignmentProfile_<TAlgoTag, TAlignConfig, LinearGaps, TracebackOff>::Type TDPProfile;
-        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBand_<BandOn>(lowerDiagonal, upperDiagonal), TDPProfile());
+        return _computeAlignment(traceSegments, dpScoutState, seqH, seqV, scoringScheme, DPBandConfig<BandOn>(lowerDiagonal, upperDiagonal), TDPProfile());
     }
 }
 

--- a/core/include/seqan/align/dp_traceback_impl.h
+++ b/core/include/seqan/align/dp_traceback_impl.h
@@ -69,7 +69,7 @@ public:
     template <typename TBandFlag, typename TSizeH, typename TSizeV>
     TracebackCoordinator_(TPosition currColumn,
                           TPosition currRow,
-                          DPBand_<TBandFlag> const & band,
+                          DPBandConfig<TBandFlag> const & band,
                           TSizeH seqHSize,
                           TSizeV seqVSize)
         : _currColumn(currColumn),
@@ -88,7 +88,7 @@ public:
                           TPosition currRow,
                           TPosition endColumn,
                           TPosition endRow,
-                          DPBand_<TBandFlag> const & band,
+                          DPBandConfig<TBandFlag> const & band,
                           TSizeH seqHSize,
                           TSizeV seqVSize)
         : _currColumn(currColumn),
@@ -144,11 +144,11 @@ _hasReachedEnd(TracebackCoordinator_<TPosition> const & coordinator)
 template <typename TPosition, typename TBandFlag, typename TSizeH, typename TSizeV>
 inline void
 _initTracebackCoordinator(TracebackCoordinator_<TPosition> & coordinator,
-                          DPBand_<TBandFlag> const & band,
+                          DPBandConfig<TBandFlag> const & band,
                           TSizeH seqHSize,
                           TSizeV seqVSize)
 {
-    typedef typename Position<DPBand_<TBandFlag> >::Type TBandPosition;
+    typedef typename Position<DPBandConfig<TBandFlag> >::Type TBandPosition;
     if (IsSameType<TBandFlag, BandOn>::VALUE)
     {
         // Adapt the current column value when the lower diagonal is positive (shift right in horizontal direction).
@@ -493,7 +493,7 @@ void _computeTraceback(TTarget & target,
                        unsigned  maxHostPosition,
                        TSequenceH const & seqH,
                        TSequenceV const & seqV,
-                       DPBand_<TBandFlag> const & band,
+                       DPBandConfig<TBandFlag> const & band,
                        DPProfile_<TAlgorithm, TGapCosts, TTracebackSpec> const & dpProfile)
 {
     typedef typename Container<TDPTraceMatrixNavigator>::Type TContainer;
@@ -561,7 +561,7 @@ void _computeTraceback(TTarget & target,
                        DPScout_<TDPCell, TScoutSpec> const & dpScout,
                        TSequenceH const & seqH,
                        TSequenceV const & seqV,
-                       DPBand_<TBandFlag> const & band,
+                       DPBandConfig<TBandFlag> const & band,
                        DPProfile_<TAlgorithm, TGapCosts, TTracebackSpec> const & dpProfile)
 {
     _computeTraceback(target, matrixNavigator, maxHostPosition(dpScout), seqH, seqV, band, dpProfile);

--- a/core/include/seqan/seeds/banded_chain_alignment_impl.h
+++ b/core/include/seqan/seeds/banded_chain_alignment_impl.h
@@ -749,7 +749,7 @@ _initializeBandedChain(TTraceSet & globalTraceSet,
     TSeedSize verticalNextGridOrigin = _max(0, static_cast<TSignedPosition>(beginPositionV(seed)) + 1 -
                                             static_cast<TSignedPosition>(bandExtension));
 
-    DPBand_<BandOn> band;
+    DPBandConfig<BandOn> band;
     // Determine coordinates of lower right corner of gap-area.
     setUpperDiagonal(band, static_cast<TSignedPosition>(_min(static_cast<TSignedSize>(length(seqH)),
         static_cast<TSignedPosition>(horizontalNextGridOrigin +  (bandExtension << 1) + horizontalBandShift +
@@ -782,7 +782,7 @@ _initializeBandedChain(TTraceSet & globalTraceSet,
                           1 - lowerDiagonal(band) - verticalNextGridOrigin);
 
         // Call the basic alignment function.
-        score = _computeAlignment(globalTraceSet, scoutState, infixH, infixV, scoreSchemeGap, DPBand_<BandOff>(),
+        score = _computeAlignment(globalTraceSet, scoutState, infixH, infixV, scoreSchemeGap, DPBandConfig<BandOff>(),
                                   DPProfile_<BandedChainAlignment_<TFreeEndGaps, BandedChainInitialDPMatrix>, TGaps,
                                              TracebackOn<TTracebackConfig> >());
     }
@@ -891,7 +891,7 @@ _computeGapArea(TTraceSet & globalTraceSet,
     typedef typename Position<TSeqH>::Type TPosH;
     typedef typename Position<TSeqV>::Type TPosV;
     typedef typename Position<TSeed const>::Type TPosition;
-    typedef DPBand_<BandOff> TBand;
+    typedef DPBandConfig<BandOff> TBand;
     typedef typename Value<TScoreScheme>::Type TScoreValue;
     typedef Pair<TPosition, TPosition> TGridPoint;
 
@@ -951,7 +951,7 @@ _computeAnchorArea(TTraceSet & globalTraceSet,
     typedef typename MakeSigned<TSize>::Type TSignedSize;
     typedef typename Position<TSeed const>::Type TPosition;
     typedef typename MakeSigned<TPosition>::Type TSignedPosition;
-    //typedef DPBand_<BandOn> TBand;
+    //typedef DPBandConfig<BandOn> TBand;
     typedef typename Value<TScoreScheme>::Type TScore;
     typedef Pair<TPosition, TPosition> TGridPoint;
 
@@ -973,7 +973,7 @@ _computeAnchorArea(TTraceSet & globalTraceSet,
     // Computing the start position of the band according to the start point.
     // TODO(rmaerker): Rename the function _verticalBandShift to _verticalBandShiftBeginPoint()
     // TODO(rmaerker): Rename the function _horiontalBandShift to _horizontalBandShiftBeginPoint()
-    DPBand_<BandOn> band(-static_cast<TSignedPosition>((bandExtension << 1)) -static_cast<TSignedPosition>(verticalBandShift),
+    DPBandConfig<BandOn> band(-static_cast<TSignedPosition>((bandExtension << 1)) -static_cast<TSignedPosition>(verticalBandShift),
                          static_cast<TSignedPosition>((bandExtension << 1) + horizontalBandShift));
 
     TPosition relativeVerticalNextGridOrigin = verticalNextGridOrigin;
@@ -1057,7 +1057,7 @@ _finishBandedChain(TTraceSet & globalTraceSet,
 
     // Compute the alignment.
     TTraceSet localTraceSet;
-    _computeAlignment(localTraceSet, dpScoutState, infixH, infixV, scoreSchemeGap, DPBand_<BandOff>(), dpProfile);
+    _computeAlignment(localTraceSet, dpScoutState, infixH, infixV, scoreSchemeGap, DPBandConfig<BandOff>(), dpProfile);
 
     // Adapt the local traces to match the positions of the  global grid.
     _adaptLocalTracesToGlobalGrid(localTraceSet, gridBegin);
@@ -1080,7 +1080,7 @@ _finishBandedChain(TTraceSet & globalTraceSet,
     // The last anchor is crossing the end of the global matrix in both directions.
     if(gridEnd.i1 == length(seqH) && gridEnd.i2 == length(seqV))
     {
-        DPBand_<BandOn> band(-static_cast<TSignedPosition>(gridEnd.i2 - gridBegin.i2), static_cast<TSignedPosition>(gridEnd.i1 - gridBegin.i1));
+        DPBandConfig<BandOn> band(-static_cast<TSignedPosition>(gridEnd.i2 - gridBegin.i2), static_cast<TSignedPosition>(gridEnd.i1 - gridBegin.i1));
         _reinitScoutState(dpScoutState, 0, 0, upperDiagonal(band)+ 1, 1 - lowerDiagonal(band),
                           upperDiagonal(band)+ 1, 1 - lowerDiagonal(band));
             // TODO(rmaerker): Should we not set the nextGridOrigin to 0 as it is the case for the last rectangle? We want to compute the last full path.
@@ -1094,7 +1094,7 @@ _finishBandedChain(TTraceSet & globalTraceSet,
         return score;   
     }
 
-    DPBand_<BandOn> band(-static_cast<TSignedPosition>((bandExtension << 1)) -static_cast<TSignedPosition>(verticalBandShift),
+    DPBandConfig<BandOn> band(-static_cast<TSignedPosition>((bandExtension << 1)) -static_cast<TSignedPosition>(verticalBandShift),
                          static_cast<TSignedPosition>((bandExtension << 1) + horizontalBandShift));
 
     // Compute the last anchor and the rectangle to fill the gap between the end of the global matrix and the last anchor.
@@ -1136,7 +1136,7 @@ _finishBandedChain(TTraceSet & globalTraceSet,
     // Compute the alignment.
     clear(localTraceSet);
     score = _computeAlignment(localTraceSet, dpScoutState, suffix(seqH, gridBegin.i1), suffix(seqV,gridBegin.i2),
-                              scoreSchemeGap, DPBand_<BandOff>(), DPProfile_<BandedChainAlignment_<TFreeEndGaps,
+                              scoreSchemeGap, DPBandConfig<BandOff>(), DPProfile_<BandedChainAlignment_<TFreeEndGaps,
                               BandedChainFinalDPMatrix>, TGaps, TracebackOn<TTracebackConfig> >());
 
     _adaptLocalTracesToGlobalGrid(localTraceSet, gridBegin);
@@ -1217,7 +1217,7 @@ _computeAlignment(TTraceSet & globalTraceSet,
             // compute the alignment
             TTraceSet localTraceSet;
             score = _computeAlignment(localTraceSet, scoutState, suffix(seqH, gridBeginH), suffix(seqV, gridBeginV),
-                              scoreSchemeGap, DPBand_<BandOff>(), DPProfile_<BandedChainAlignment_<TFreeEndGaps,
+                              scoreSchemeGap, DPBandConfig<BandOff>(), DPProfile_<BandedChainAlignment_<TFreeEndGaps,
                               BandedChainFinalDPMatrix>, TGapSpec, TracebackOn<TTracebackConfig> >());
             _adaptLocalTracesToGlobalGrid(localTraceSet, Pair<TPosH, TPosV>(gridBeginH, gridBeginV));
             _glueTracebacks(globalTraceSet, localTraceSet);

--- a/core/include/seqan/seeds/banded_chain_alignment_traceback.h
+++ b/core/include/seqan/seeds/banded_chain_alignment_traceback.h
@@ -235,7 +235,7 @@ void _computeTraceback(TTarget & target,
                        DPScout_<TDPCell, TScoutSpec> & dpScout,
                        TSequenceH const & seqH,
                        TSequenceV const & seqV,
-                       DPBand_<TBandFlag> const & band,
+                       DPBandConfig<TBandFlag> const & band,
                        DPProfile_<BandedChainAlignment_<TFreeEndGaps, TDPMatrixLocation>, TGapCosts, TTracebackSpec> const & dpProfile)
 {
     typedef DPScout_<TDPCell, TScoutSpec> TDPScout_;
@@ -355,7 +355,7 @@ void _computeTraceback(StringSet<TTarget> & targetSet,
                        TDPScout & dpScout,
                        TSequenceH const & seqH,
                        TSequenceV const & seqV,
-                       DPBand_<TBandFlag> const & band,
+                       DPBandConfig<TBandFlag> const & band,
                        DPProfile_<BandedChainAlignment_<TFreeEndGaps, TDPMatrixLocation>, TGapCosts, TTracebackSpec> const & dpProfile)
 {
     typedef typename TDPScout::TMaxHostPositionString TMaxHostPositions;

--- a/core/tests/align/test_align.cpp
+++ b/core/tests/align/test_align.cpp
@@ -180,7 +180,7 @@ SEQAN_BEGIN_TESTSUITE(test_align)
     SEQAN_CALL_TEST(test_alignment_dp_profile_is_free_end_gaps);
 
     // ----------------------------------------------------------------------------
-    // Test DPBand.
+    // Test DPBandConfig.
     // ----------------------------------------------------------------------------
 
     SEQAN_CALL_TEST(test_dp_band_on_constructor);

--- a/core/tests/align/test_alignment_algorithms_band_position.h
+++ b/core/tests/align/test_alignment_algorithms_band_position.h
@@ -59,7 +59,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case1)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
 
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-static_cast<int>(length(strV)) - 2, -static_cast<int>(length(strV)) - 1),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-static_cast<int>(length(strV)) - 2, -static_cast<int>(length(strV)) - 1),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -79,7 +79,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case1)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-static_cast<int>(length(strV)) - 2, -static_cast<int>(length(strV)) - 1),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-static_cast<int>(length(strV)) - 2, -static_cast<int>(length(strV)) - 1),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -117,7 +117,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case2)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-static_cast<int>(length(strV)) - 1, -static_cast<int>(length(strV))),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-static_cast<int>(length(strV)) - 1, -static_cast<int>(length(strV))),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -136,7 +136,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case2)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-static_cast<int>(length(strV)) - 1, -static_cast<int>(length(strV))),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-static_cast<int>(length(strV)) - 1, -static_cast<int>(length(strV))),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -173,7 +173,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case3)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-static_cast<int>(length(strV)) - 1, -3),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-static_cast<int>(length(strV)) - 1, -3),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -192,7 +192,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case3)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-static_cast<int>(length(strV)) - 1, -3),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-static_cast<int>(length(strV)) - 1, -3),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -229,7 +229,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case4)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-static_cast<int>(length(strV)) - 1, 0),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-static_cast<int>(length(strV)) - 1, 0),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -248,7 +248,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case4)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-static_cast<int>(length(strV)) - 1, 0),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-static_cast<int>(length(strV)) - 1, 0),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -285,7 +285,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case5)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-static_cast<int>(length(strV)) - 1, static_cast<int>(length(strH)) - static_cast<int>(length(strV))),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-static_cast<int>(length(strV)) - 1, static_cast<int>(length(strH)) - static_cast<int>(length(strV))),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -303,7 +303,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case5)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-static_cast<int>(length(strV)) - 1, static_cast<int>(length(strH)) - static_cast<int>(length(strV))),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-static_cast<int>(length(strV)) - 1, static_cast<int>(length(strH)) - static_cast<int>(length(strV))),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -340,7 +340,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case6)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-static_cast<int>(length(strV)) - 1, 6),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-static_cast<int>(length(strV)) - 1, 6),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -359,7 +359,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case6)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-static_cast<int>(length(strV)) - 1, 6),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-static_cast<int>(length(strV)) - 1, 6),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -397,7 +397,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case7)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-static_cast<int>(length(strV)) - 1, length(strH)),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-static_cast<int>(length(strV)) - 1, length(strH)),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -415,7 +415,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case7)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-static_cast<int>(length(strV)) - 1, length(strH)),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-static_cast<int>(length(strV)) - 1, length(strH)),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -452,7 +452,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case8)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-static_cast<int>(length(strV)) - 1, length(strH) + 1),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-static_cast<int>(length(strV)) - 1, length(strH) + 1),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -471,7 +471,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case8)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-static_cast<int>(length(strV)) - 1, length(strH) + 1),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-static_cast<int>(length(strV)) - 1, length(strH) + 1),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -509,7 +509,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case9)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-static_cast<int>(length(strV)), -3),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-static_cast<int>(length(strV)), -3),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -529,7 +529,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case9)
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
 
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-static_cast<int>(length(strV)), -3),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-static_cast<int>(length(strV)), -3),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -566,7 +566,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case10)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-static_cast<int>(length(strV)), 0),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-static_cast<int>(length(strV)), 0),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -585,7 +585,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case10)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-static_cast<int>(length(strV)), 0),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-static_cast<int>(length(strV)), 0),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -622,7 +622,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case11)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-static_cast<int>(length(strV)), length(strH) - length(strV)),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-static_cast<int>(length(strV)), length(strH) - length(strV)),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -641,7 +641,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case11)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-static_cast<int>(length(strV)), length(strH) - length(strV)),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-static_cast<int>(length(strV)), length(strH) - length(strV)),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -679,7 +679,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case12)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-static_cast<int>(length(strV)), 6),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-static_cast<int>(length(strV)), 6),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -698,7 +698,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case12)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-static_cast<int>(length(strV)), 6),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-static_cast<int>(length(strV)), 6),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -735,7 +735,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case13)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-static_cast<int>(length(strV)), length(strH)),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-static_cast<int>(length(strV)), length(strH)),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -754,7 +754,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case13)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-static_cast<int>(length(strV)), length(strH)),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-static_cast<int>(length(strV)), length(strH)),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -791,7 +791,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case14)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-static_cast<int>(length(strV)), length(strH) + 1),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-static_cast<int>(length(strV)), length(strH) + 1),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -810,7 +810,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case14)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-static_cast<int>(length(strV)), length(strH) + 1),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-static_cast<int>(length(strV)), length(strH) + 1),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -848,7 +848,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case15)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-3, 0),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-3, 0),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -867,7 +867,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case15)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-3, 0),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-3, 0),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -904,7 +904,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case16)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-3, length(strH) - length(strV)),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-3, length(strH) - length(strV)),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -923,7 +923,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case16)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-3, length(strH) - length(strV)),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-3, length(strH) - length(strV)),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -960,7 +960,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case17)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-3, 6),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-3, 6),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -979,7 +979,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case17)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-3, 6),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-3, 6),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1016,7 +1016,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case18)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-3, length(strH)),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-3, length(strH)),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1035,7 +1035,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case18)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-3, length(strH)),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-3, length(strH)),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1072,7 +1072,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case19)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-3, length(strH) + 1),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-3, length(strH) + 1),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1091,7 +1091,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case19)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-3, length(strH) + 1),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-3, length(strH) + 1),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1128,7 +1128,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case20)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(0, length(strH) - length(strV)),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(0, length(strH) - length(strV)),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1147,7 +1147,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case20)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(0, length(strH) - length(strV)),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(0, length(strH) - length(strV)),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1184,7 +1184,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case21)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(0, 6),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(0, 6),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1203,7 +1203,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case21)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(0, 6),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(0, 6),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1240,7 +1240,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case22)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(0, length(strH)),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(0, length(strH)),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1259,7 +1259,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case22)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(0, length(strH)),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(0, length(strH)),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1296,7 +1296,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case23)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(0, length(strH) + 1),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(0, length(strH) + 1),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1315,7 +1315,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case23)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(0, length(strH) + 1),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(0, length(strH) + 1),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1352,7 +1352,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case24)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(length(strH) - length(strV), 6),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(length(strH) - length(strV), 6),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1372,7 +1372,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case24)
         String<TraceSegment_<unsigned, unsigned> > traces;
 
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(length(strH) - length(strV), 6),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(length(strH) - length(strV), 6),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1410,7 +1410,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case25)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(length(strH) - length(strV), length(strH)),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(length(strH) - length(strV), length(strH)),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1430,7 +1430,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case25)
         String<TraceSegment_<unsigned, unsigned> > traces;
 
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(length(strH) - length(strV), length(strH)),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(length(strH) - length(strV), length(strH)),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1468,7 +1468,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case26)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(length(strH) - length(strV), length(strH) + 1),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(length(strH) - length(strV), length(strH) + 1),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1487,7 +1487,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case26)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(length(strH) - length(strV), length(strH) + 1),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(length(strH) - length(strV), length(strH) + 1),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1524,7 +1524,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case27)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(6, length(strH)),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(6, length(strH)),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1543,7 +1543,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case27)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(6, length(strH)),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(6, length(strH)),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1581,7 +1581,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case28)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(6, length(strH) + 1),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(6, length(strH) + 1),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1600,7 +1600,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case28)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(6, length(strH) + 1),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(6, length(strH) + 1),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1637,7 +1637,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case29)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(length(strH), length(strH) + 1),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(length(strH), length(strH) + 1),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1656,7 +1656,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case29)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(length(strH), length(strH) + 1),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(length(strH), length(strH) + 1),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1693,7 +1693,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case30)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(length(strH) + 1, length(strH) + 1),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(length(strH) + 1, length(strH) + 1),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1712,7 +1712,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case30)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(length(strH) + 1, length(strH) + 1),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(length(strH) + 1, length(strH) + 1),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1749,7 +1749,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case31)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(0, 0),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(0, 0),
                                       TDPProfile());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1768,7 +1768,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case31)
     {
         String<TraceSegment_<unsigned, unsigned> > traces;
         clearGaps(align);
-        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(0, 0),
+        int score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(0, 0),
                                       TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1787,7 +1787,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case31)
         clearGaps(align);
         clear(traces);
 
-        score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-3, -3),
+        score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-3, -3),
                                   TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1806,7 +1806,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case31)
         clearGaps(align);
         clear(traces);
 
-        score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(6, 6),
+        score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(6, 6),
                                   TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1825,7 +1825,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case31)
         clearGaps(align);
         clear(traces);
 
-        score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(-9, -9),
+        score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(-9, -9),
                                   TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 
@@ -1844,7 +1844,7 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_band_position_case31)
         clearGaps(align);
         clear(traces);
 
-        score = _computeAlignment(traces, strH, strV, scoringScheme, DPBand_<BandOn>(12, 12),
+        score = _computeAlignment(traces, strH, strV, scoringScheme, DPBandConfig<BandOn>(12, 12),
                                   TDPProfileOverlap());
         _adaptTraceSegmentsTo(row(align, 0), row(align, 1), traces);
 

--- a/core/tests/align/test_alignment_dp_band.h
+++ b/core/tests/align/test_alignment_dp_band.h
@@ -38,38 +38,38 @@
 #include <seqan/basic.h>
 #include <seqan/align.h>
 
-void testDPBandOffBandSize()
+void testDPBandConfigOffBandSize()
 {
     using namespace seqan;
 
-    DPBand_<BandOff> band;
+    DPBandConfig<BandOff> band;
 
     SEQAN_ASSERT_EQ(bandSize(band), 0u);
 }
 
-void testDPBandOnBandSize()
+void testDPBandConfigOnBandSize()
 {
     using namespace seqan;
 
-    SEQAN_ASSERT_EQ(bandSize(DPBand_<BandOn>(-3, 7)), 11u);
-    SEQAN_ASSERT_EQ(bandSize(DPBand_<BandOn>(3, 7)), 5u);
-    SEQAN_ASSERT_EQ(bandSize(DPBand_<BandOn>(-7, -3)), 5u);
-    SEQAN_ASSERT_EQ(bandSize(DPBand_<BandOn>(-7, 0)), 8u);
+    SEQAN_ASSERT_EQ(bandSize(DPBandConfig<BandOn>(-3, 7)), 11u);
+    SEQAN_ASSERT_EQ(bandSize(DPBandConfig<BandOn>(3, 7)), 5u);
+    SEQAN_ASSERT_EQ(bandSize(DPBandConfig<BandOn>(-7, -3)), 5u);
+    SEQAN_ASSERT_EQ(bandSize(DPBandConfig<BandOn>(-7, 0)), 8u);
 }
 
 SEQAN_DEFINE_TEST(test_dp_band_on_constructor)
 {
     using namespace seqan;
-    DPBand_<BandOn> dpBand;
+    DPBandConfig<BandOn> dpBand;
 
     SEQAN_ASSERT_EQ(dpBand._lowerDiagonal, 0);
     SEQAN_ASSERT_EQ(dpBand._upperDiagonal, 0);
 
-    DPBand_<BandOn> dpBand2(-2, 2);
+    DPBandConfig<BandOn> dpBand2(-2, 2);
     SEQAN_ASSERT_EQ(dpBand2._lowerDiagonal, -2);
     SEQAN_ASSERT_EQ(dpBand2._upperDiagonal, 2);
 
-    DPBand_<BandOn> dpBand3(dpBand2);
+    DPBandConfig<BandOn> dpBand3(dpBand2);
 
     SEQAN_ASSERT_EQ(dpBand3._lowerDiagonal, -2);
     SEQAN_ASSERT_EQ(dpBand3._upperDiagonal, 2);
@@ -78,7 +78,7 @@ SEQAN_DEFINE_TEST(test_dp_band_on_constructor)
 SEQAN_DEFINE_TEST(test_dp_band_on_lower_diagonal)
 {
     using namespace seqan;
-    DPBand_<BandOn> dpBand;
+    DPBandConfig<BandOn> dpBand;
     SEQAN_ASSERT_EQ(lowerDiagonal(dpBand), 0);
 
     dpBand._lowerDiagonal = -10;
@@ -88,7 +88,7 @@ SEQAN_DEFINE_TEST(test_dp_band_on_lower_diagonal)
 SEQAN_DEFINE_TEST(test_dp_band_on_upper_diagonal)
 {
     using namespace seqan;
-    DPBand_<BandOn> dpBand;
+    DPBandConfig<BandOn> dpBand;
     SEQAN_ASSERT_EQ(upperDiagonal(dpBand), 0);
 
     dpBand._upperDiagonal = 10;
@@ -98,7 +98,7 @@ SEQAN_DEFINE_TEST(test_dp_band_on_upper_diagonal)
 SEQAN_DEFINE_TEST(test_dp_band_on_set_lower_diagonal)
 {
     using namespace seqan;
-    DPBand_<BandOn> dpBand;
+    DPBandConfig<BandOn> dpBand;
 
     setLowerDiagonal(dpBand, -10);
     SEQAN_ASSERT_EQ(dpBand._lowerDiagonal, -10);
@@ -107,7 +107,7 @@ SEQAN_DEFINE_TEST(test_dp_band_on_set_lower_diagonal)
 SEQAN_DEFINE_TEST(test_dp_band_on_set_upper_diagonal)
 {
     using namespace seqan;
-    DPBand_<BandOn> dpBand;
+    DPBandConfig<BandOn> dpBand;
 
     setUpperDiagonal(dpBand, 10);
     SEQAN_ASSERT_EQ(dpBand._upperDiagonal, 10);
@@ -115,12 +115,12 @@ SEQAN_DEFINE_TEST(test_dp_band_on_set_upper_diagonal)
 
 SEQAN_DEFINE_TEST(test_dp_band_off_band_size)
 {
-    testDPBandOffBandSize();
+    testDPBandConfigOffBandSize();
 }
 
 SEQAN_DEFINE_TEST(test_dp_band_on_band_size)
 {
-    testDPBandOnBandSize();
+    testDPBandConfigOnBandSize();
 }
 
 #endif  // #ifndef SANDBOX_RMAERKER_TESTS_ALIGN2_TEST_ALIGNMENT_DP_BAND_H_

--- a/core/tests/align/test_alignment_dp_matrix_navigator.h
+++ b/core/tests/align/test_alignment_dp_matrix_navigator.h
@@ -144,7 +144,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixInitUnbanded()
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
     resize(dpMatrix, 0);
 
-    _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+    _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
     SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
     SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), -10);
@@ -169,7 +169,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixSparseInitUnbanded()
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
     resize(dpMatrix, 0);
 
-    _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+    _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
     SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
     SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
@@ -198,7 +198,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixInitBanded()
         setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 8);
         resize(dpMatrix, 0);
 
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOn>(-4, 3));
+        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOn>(-4, 3));
 
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 3);
@@ -216,7 +216,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixInitBanded()
         resize(dpMatrix2);
 
         value(host(dpMatrix2), 0) = 10;
-        _init(dpScoreMatrixNavigator, dpMatrix2, DPBand_<BandOn>(0, 7));
+        _init(dpScoreMatrixNavigator, dpMatrix2, DPBandConfig<BandOn>(0, 7));
 
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix2);
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix2, Standard()), 7);
@@ -234,7 +234,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixInitBanded()
         resize(dpMatrix3);
 
 
-        _init(dpScoreMatrixNavigator, dpMatrix3, DPBand_<BandOn>(-7, 0));
+        _init(dpScoreMatrixNavigator, dpMatrix3, DPBandConfig<BandOn>(-7, 0));
 
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix3);
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix3, Standard()), 0);
@@ -263,7 +263,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixSparseInitBanded()
         setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 8);
         resize(dpMatrix, 0);
 
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOn>(-4, 3));
+        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOn>(-4, 3));
 
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 3);
@@ -280,7 +280,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixSparseInitBanded()
         setLength(dpMatrix2, DPMatrixDimension_::VERTICAL, 8);
         resize(dpMatrix2);
 
-        _init(dpScoreMatrixNavigator, dpMatrix2, DPBand_<BandOn>(0, 7));
+        _init(dpScoreMatrixNavigator, dpMatrix2, DPBandConfig<BandOn>(0, 7));
 
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix2);
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix2, Standard()), 7);
@@ -297,7 +297,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixSparseInitBanded()
         setLength(dpMatrix3, DPMatrixDimension_::VERTICAL, 8);
         resize(dpMatrix3);
 
-        _init(dpScoreMatrixNavigator, dpMatrix3, DPBand_<BandOn>(-7, 0));
+        _init(dpScoreMatrixNavigator, dpMatrix3, DPBandConfig<BandOn>(-7, 0));
 
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix3);
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix3, Standard()), 0);
@@ -330,7 +330,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixGoNextCell()
     host(dpMatrix)[5] = 5;
 
     {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
         _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), FirstCell());
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
@@ -358,7 +358,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixGoNextCell()
     }
 
     {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
         _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnMiddle>(), FirstCell());
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
@@ -386,7 +386,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixGoNextCell()
     }
 
     {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
         _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom>(), FirstCell());
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
@@ -414,7 +414,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixGoNextCell()
     }
 
     {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
         _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, FullColumn>(), FirstCell());
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
@@ -442,7 +442,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixGoNextCell()
     }
 
     {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         dpScoreMatrixNavigator._activeColIterator += 2;
         dpScoreMatrixNavigator._prevColIterator += 2;
         ++dpScoreMatrixNavigator._laneLeap;  // For the test we simulate as if we were in a band.
@@ -473,7 +473,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixGoNextCell()
     }
 
     {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         dpScoreMatrixNavigator._activeColIterator += 2;
         dpScoreMatrixNavigator._prevColIterator += 2;
 
@@ -503,7 +503,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixGoNextCell()
     }
 
     {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         dpScoreMatrixNavigator._activeColIterator += 2;
         dpScoreMatrixNavigator._prevColIterator += 2;
 
@@ -533,7 +533,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixGoNextCell()
     }
 
     {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         dpScoreMatrixNavigator._activeColIterator += 2;
         dpScoreMatrixNavigator._prevColIterator += 2;
 
@@ -563,7 +563,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixGoNextCell()
     }
 
     {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         dpScoreMatrixNavigator._activeColIterator += 2;
         dpScoreMatrixNavigator._prevColIterator += 2;
         ++dpScoreMatrixNavigator._laneLeap;
@@ -594,7 +594,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixGoNextCell()
     }
 
     {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         dpScoreMatrixNavigator._activeColIterator += 2;
         dpScoreMatrixNavigator._prevColIterator += 2;
 
@@ -624,7 +624,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixGoNextCell()
     }
 
     {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         dpScoreMatrixNavigator._activeColIterator += 2;
         dpScoreMatrixNavigator._prevColIterator += 2;
 
@@ -654,7 +654,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixGoNextCell()
     }
 
     {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         dpScoreMatrixNavigator._activeColIterator += 2;
         dpScoreMatrixNavigator._prevColIterator += 2;
 
@@ -702,7 +702,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixSparseGoNext()
     host(dpMatrix)[2] = 2;
 
     {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         assignValue(dpScoreMatrixNavigator._activeColIterator, 0);
 
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
@@ -745,7 +745,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixSparseGoNext()
     }
 
     {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         assignValue(dpScoreMatrixNavigator._activeColIterator, 0);
 
         _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnMiddle>(), FirstCell());
@@ -780,7 +780,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixSparseGoNext()
     }
 
     {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         assignValue(dpScoreMatrixNavigator._activeColIterator, 0);
 
         _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom>(), FirstCell());
@@ -815,7 +815,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixSparseGoNext()
     }
 
     {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         assignValue(dpScoreMatrixNavigator._activeColIterator, 0);
 
         _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, FullColumn>(), FirstCell());
@@ -851,7 +851,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixSparseGoNext()
 
     {
 
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         assignValue(dpScoreMatrixNavigator._activeColIterator, 0);
 
         // Need to update iterator just for the test.
@@ -889,7 +889,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixSparseGoNext()
     }
 
     {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         assignValue(dpScoreMatrixNavigator._activeColIterator, 0);
 
         // Need to update Iterator just for the test.
@@ -927,7 +927,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixSparseGoNext()
     }
 
     {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         assignValue(dpScoreMatrixNavigator._activeColIterator, 0);
 
         // Need to update Iterator just for the test.
@@ -967,7 +967,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixSparseGoNext()
     }
 
     {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         assignValue(dpScoreMatrixNavigator._activeColIterator, 0);
 
         dpScoreMatrixNavigator._activeColIterator += 2;
@@ -1004,7 +1004,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixSparseGoNext()
     }
 
     {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         assignValue(dpScoreMatrixNavigator._activeColIterator, 0);
 
         dpScoreMatrixNavigator._activeColIterator += 3;
@@ -1041,7 +1041,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixSparseGoNext()
     }
 
     {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         assignValue(dpScoreMatrixNavigator._activeColIterator, 0);
 
         dpScoreMatrixNavigator._activeColIterator += 2;
@@ -1079,7 +1079,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixSparseGoNext()
     }
 
     {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         assignValue(dpScoreMatrixNavigator._activeColIterator, 0);
 
         dpScoreMatrixNavigator._activeColIterator += 2;
@@ -1118,7 +1118,7 @@ void testAlignmentDPMatrixNavigatorScoreMarixSparseGoNext()
     }
 
     {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         assignValue(dpScoreMatrixNavigator._activeColIterator, 0);
 
         dpScoreMatrixNavigator._activeColIterator += 2;
@@ -1169,7 +1169,7 @@ void testAlignmentDPScoreMatrixNavigatorAssignValue(TDPMatrixSpec const)
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
     resize(dpMatrix, 3);
 
-    _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+    _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
     assignValue(dpScoreMatrixNavigator, 20);
     SEQAN_ASSERT_EQ(value(dpScoreMatrixNavigator._activeColIterator), 20);
@@ -1189,7 +1189,7 @@ void testAlignmentDPScoreMatrixNavigatorValue(TDPMatrixSpec const)
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
     resize(dpMatrix, 3);
 
-    _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+    _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
     assignValue(dpScoreMatrixNavigator, 20);
     SEQAN_ASSERT_EQ(value(dpScoreMatrixNavigator), 20);
@@ -1213,7 +1213,7 @@ void testAlignmentDPScoreMatrixNavigatorPreviousCellDiagonal(TDPMatrixSpec const
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
     resize(dpMatrix, 3);
 
-    _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+    _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
     SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
 
     dpScoreMatrixNavigator._prevCellDiagonal = 20;
@@ -1238,7 +1238,7 @@ void testAlignmentDPScoreMatrixNavigatorPreviousCellHorizontal(TDPMatrixSpec con
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
     resize(dpMatrix, 3);
 
-    _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+    _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
     SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
 
     dpScoreMatrixNavigator._prevCellHorizontal = 20;
@@ -1263,7 +1263,7 @@ void testAlignmentDPScoreMatrixNavigatorPreviousCellVertical(TDPMatrixSpec const
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
     resize(dpMatrix, 3);
 
-    _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+    _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
     SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, TDPCell());
 
     dpScoreMatrixNavigator._prevCellVertical = 20;
@@ -1287,7 +1287,7 @@ void testAlignmentDPScoreMatrixNavigatorCoordinate(TDPMatrixSpec const)
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
     resize(dpMatrix, 3);
 
-    _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+    _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
     dpScoreMatrixNavigator._activeColIterator += 7;
     dpScoreMatrixNavigator._prevColIterator += 7;
@@ -1310,7 +1310,7 @@ void testAlignmentDPScoreMatrixNavigatorContainer(TDPMatrixSpec const)
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
     resize(dpMatrix, 3);
 
-    _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+    _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
     SEQAN_ASSERT_EQ(&container(dpScoreMatrixNavigator), &dpMatrix);
 
@@ -1472,7 +1472,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_init_u
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
     resize(dpMatrix);
 
-    _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+    _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
     SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._ptrDataContainer, &dpMatrix);
     SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
@@ -1492,7 +1492,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_disabled_init_
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
     resize(dpMatrix);
 
-    _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+    _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
     SEQAN_ASSERT_NEQ(dpTraceMatrixNavigator._ptrDataContainer, &dpMatrix);
     SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 0);
@@ -1512,7 +1512,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_init_b
         setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 8);
         resize(dpMatrix);
 
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOn>(-4, 3));
+        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOn>(-4, 3));
 
         SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._ptrDataContainer, &dpMatrix);
         SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 3);
@@ -1526,7 +1526,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_init_b
         resize(dpMatrix2);
 
         value(host(dpMatrix2), 0) = 10;
-        _init(dpTraceMatrixNavigator, dpMatrix2, DPBand_<BandOn>(0, 7));
+        _init(dpTraceMatrixNavigator, dpMatrix2, DPBandConfig<BandOn>(0, 7));
 
         SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._ptrDataContainer, &dpMatrix2);
         SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix2, Standard()), 7);
@@ -1540,7 +1540,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_init_b
         resize(dpMatrix3);
 
 
-        _init(dpTraceMatrixNavigator, dpMatrix3, DPBand_<BandOn>(-7, 0));
+        _init(dpTraceMatrixNavigator, dpMatrix3, DPBandConfig<BandOn>(-7, 0));
 
         SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._ptrDataContainer, &dpMatrix3);
         SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix3, Standard()), 0);
@@ -1562,7 +1562,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_disabled_init_
         setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 8);
         resize(dpMatrix);
 
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOn>(-4, 3));
+        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOn>(-4, 3));
 
         SEQAN_ASSERT_NEQ(dpTraceMatrixNavigator._ptrDataContainer, &dpMatrix);
         SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 0);
@@ -1575,7 +1575,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_disabled_init_
         resize(dpMatrix2);
 
         value(host(dpMatrix2), 0) = 10;
-        _init(dpTraceMatrixNavigator, dpMatrix2, DPBand_<BandOn>(0, 7));
+        _init(dpTraceMatrixNavigator, dpMatrix2, DPBandConfig<BandOn>(0, 7));
 
         SEQAN_ASSERT_NEQ(dpTraceMatrixNavigator._ptrDataContainer, &dpMatrix2);
         SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 0);
@@ -1588,7 +1588,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_disabled_init_
         resize(dpMatrix3);
 
 
-        _init(dpTraceMatrixNavigator, dpMatrix3, DPBand_<BandOn>(-7, 0));
+        _init(dpTraceMatrixNavigator, dpMatrix3, DPBandConfig<BandOn>(-7, 0));
 
         SEQAN_ASSERT_NEQ(dpTraceMatrixNavigator._ptrDataContainer, &dpMatrix3);
         SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 0);
@@ -1615,7 +1615,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_go_nex
     host(dpMatrix)[5] = 5;
 
     {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
         _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), FirstCell());
         SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
@@ -1632,7 +1632,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_go_nex
     }
 
     {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
         _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnMiddle>(), FirstCell());
         SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
@@ -1648,7 +1648,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_go_nex
     }
 
     {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
         _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom>(), FirstCell());
         SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
@@ -1664,7 +1664,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_go_nex
     }
 
     {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
         _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, FullColumn>(), FirstCell());
         SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
@@ -1680,7 +1680,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_go_nex
     }
 
     {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         dpTraceMatrixNavigator._activeColIterator += 2;
         ++dpTraceMatrixNavigator._laneLeap;  // For the test we simulate as if we were in a band.
 
@@ -1698,7 +1698,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_go_nex
     }
 
     {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         dpTraceMatrixNavigator._activeColIterator += 2;
 
         _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnMiddle>(), FirstCell());
@@ -1715,7 +1715,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_go_nex
     }
 
     {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         dpTraceMatrixNavigator._activeColIterator += 2;
 
         _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnBottom>(), FirstCell());
@@ -1732,7 +1732,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_go_nex
     }
 
     {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         dpTraceMatrixNavigator._activeColIterator += 2;
 
         _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, FullColumn>(), FirstCell());
@@ -1749,7 +1749,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_go_nex
     }
 
     {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         dpTraceMatrixNavigator._activeColIterator += 2;
         ++dpTraceMatrixNavigator._laneLeap;
 
@@ -1767,7 +1767,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_go_nex
     }
 
     {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         dpTraceMatrixNavigator._activeColIterator += 2;
 
         _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnMiddle>(), FirstCell());
@@ -1784,7 +1784,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_go_nex
     }
 
     {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         dpTraceMatrixNavigator._activeColIterator += 2;
 
         _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnBottom>(), FirstCell());
@@ -1801,7 +1801,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_go_nex
     }
 
     {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         dpTraceMatrixNavigator._activeColIterator += 2;
 
         _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, FullColumn>(), FirstCell());
@@ -1847,7 +1847,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_disabled_go_ne
     host(dpMatrix)[5] = 5;
 
     {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
         _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), FirstCell());
         _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), InnerCell());
@@ -1855,7 +1855,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_disabled_go_ne
     }
 
     {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
         _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnMiddle>(), FirstCell());
         _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnMiddle>(), InnerCell());
@@ -1863,7 +1863,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_disabled_go_ne
     }
 
     {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
         _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom>(), FirstCell());
         _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom>(), InnerCell());
@@ -1871,7 +1871,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_disabled_go_ne
     }
 
     {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
         _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, FullColumn>(), FirstCell());
         _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, FullColumn>(), InnerCell());
@@ -1879,7 +1879,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_disabled_go_ne
     }
 
     {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         dpTraceMatrixNavigator._activeColIterator += 2;
 
         _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnTop>(), FirstCell());
@@ -1888,14 +1888,14 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_disabled_go_ne
     }
 
     {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnMiddle>(), FirstCell());
         _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnMiddle>(), InnerCell());
         _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnMiddle>(), LastCell());
     }
 
     {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
         _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnBottom>(), FirstCell());
         _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnBottom>(), InnerCell());
@@ -1903,7 +1903,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_disabled_go_ne
     }
 
     {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
         _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, FullColumn>(), FirstCell());
         _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, FullColumn>(), InnerCell());
@@ -1911,7 +1911,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_disabled_go_ne
     }
 
     {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
         _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnTop>(), FirstCell());
         _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnTop>(), InnerCell());
@@ -1919,7 +1919,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_disabled_go_ne
     }
 
     {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
         _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnMiddle>(), FirstCell());
         _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnMiddle>(), InnerCell());
@@ -1927,7 +1927,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_disabled_go_ne
     }
 
     {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
         _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnBottom>(), FirstCell());
         _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnBottom>(), InnerCell());
@@ -1935,7 +1935,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_disabled_go_ne
     }
 
     {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
         _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, FullColumn>(), FirstCell());
         _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, FullColumn>(), InnerCell());
         _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, FullColumn>(), LastCell());
@@ -1955,7 +1955,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_assign
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
     resize(dpMatrix, 3);
 
-    _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+    _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
     assignValue(dpScoreMatrixNavigator, 20);
     SEQAN_ASSERT_EQ(value(dpScoreMatrixNavigator._activeColIterator), 20);
@@ -1975,7 +1975,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_value)
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
     resize(dpMatrix, 3);
 
-    _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+    _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
     assignValue(dpTraceMatrixNavigator, 20);
     SEQAN_ASSERT_EQ(value(dpTraceMatrixNavigator), 20);
@@ -1998,7 +1998,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_coordi
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
     resize(dpMatrix, 3);
 
-    _init(dpScoreMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+    _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
     dpScoreMatrixNavigator._activeColIterator += 7;
 
@@ -2019,7 +2019,7 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_contai
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
     resize(dpMatrix, 3);
 
-    _init(dpTraceMatrixNavigator, dpMatrix, DPBand_<BandOff>());
+    _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
 
     SEQAN_ASSERT_EQ(&container(dpTraceMatrixNavigator), &dpMatrix);
 

--- a/core/tests/align/test_alignment_dp_traceback.h
+++ b/core/tests/align/test_alignment_dp_traceback.h
@@ -78,20 +78,20 @@ SEQAN_DEFINE_TEST(test_align2_traceback_affine)
     value(traceMatrix, 3, 3) = +TraceBitMap_::DIAGONAL;
 
     TDPTraceNavigator navigator;
-    _init(navigator, traceMatrix, DPBand_<BandOff>());
+    _init(navigator, traceMatrix, DPBandConfig<BandOff>());
 
     DnaString str0 = "ACG";
     DnaString str1 = "ACG";
 
     DPScout_<int, Default> dpScout;
     dpScout._maxHostPosition = 15;
-    _computeTraceback(target, navigator, dpScout, str0, str1, DPBand_<BandOff>(), TDPProfile());
+    _computeTraceback(target, navigator, dpScout, str0, str1, DPBandConfig<BandOff>(), TDPProfile());
     SEQAN_ASSERT_EQ(length(target), 1u);
     SEQAN_ASSERT_EQ(target[0], TTraceSegment(0, 0, 3, +TraceBitMap_::DIAGONAL));
 
     clear(target);
     dpScout._maxHostPosition = 14;
-    _computeTraceback(target, navigator, dpScout, str0, str1, DPBand_<BandOff>(), TDPProfile());
+    _computeTraceback(target, navigator, dpScout, str0, str1, DPBandConfig<BandOff>(), TDPProfile());
     SEQAN_ASSERT_EQ(length(target), 3u);
     SEQAN_ASSERT_EQ(target[0], TTraceSegment(3, 2, 1, +TraceBitMap_::VERTICAL));
     SEQAN_ASSERT_EQ(target[1], TTraceSegment(0, 2, 3, +TraceBitMap_::HORIZONTAL));
@@ -99,7 +99,7 @@ SEQAN_DEFINE_TEST(test_align2_traceback_affine)
 
     clear(target);
     dpScout._maxHostPosition = 13;
-    _computeTraceback(target, navigator, dpScout, str0, str1, DPBand_<BandOff>(), TDPProfile());
+    _computeTraceback(target, navigator, dpScout, str0, str1, DPBandConfig<BandOff>(), TDPProfile());
     SEQAN_ASSERT_EQ(length(target), 4u);
     SEQAN_ASSERT_EQ(target[0], TTraceSegment(3, 1, 2, +TraceBitMap_::VERTICAL));
     SEQAN_ASSERT_EQ(target[1], TTraceSegment(2, 1, 1, +TraceBitMap_::HORIZONTAL));
@@ -108,14 +108,14 @@ SEQAN_DEFINE_TEST(test_align2_traceback_affine)
 
     clear(target);
     dpScout._maxHostPosition = 12;
-    _computeTraceback(target, navigator, dpScout, str0, str1, DPBand_<BandOff>(), TDPProfile());
+    _computeTraceback(target, navigator, dpScout, str0, str1, DPBandConfig<BandOff>(), TDPProfile());
     SEQAN_ASSERT_EQ(length(target), 2u);
     SEQAN_ASSERT_EQ(target[0], TTraceSegment(3, 0, 3, +TraceBitMap_::VERTICAL));
     SEQAN_ASSERT_EQ(target[1], TTraceSegment(0, 0, 3, +TraceBitMap_::HORIZONTAL));
 
     clear(target);
     dpScout._maxHostPosition = 11;
-    _computeTraceback(target, navigator, dpScout, str0, str1, DPBand_<BandOff>(), TDPProfile());
+    _computeTraceback(target, navigator, dpScout, str0, str1, DPBandConfig<BandOff>(), TDPProfile());
     SEQAN_ASSERT_EQ(length(target), 4u);
     SEQAN_ASSERT_EQ(target[0], TTraceSegment(2, 3, 1, +TraceBitMap_::HORIZONTAL));
     SEQAN_ASSERT_EQ(target[1], TTraceSegment(2, 1, 2, +TraceBitMap_::VERTICAL));
@@ -124,7 +124,7 @@ SEQAN_DEFINE_TEST(test_align2_traceback_affine)
 
     clear(target);
     dpScout._maxHostPosition = 7;
-    _computeTraceback(target, navigator, dpScout, str0, str1, DPBand_<BandOff>(), TDPProfile());
+    _computeTraceback(target, navigator, dpScout, str0, str1, DPBandConfig<BandOff>(), TDPProfile());
     SEQAN_ASSERT_EQ(length(target), 3u);
     SEQAN_ASSERT_EQ(target[0], TTraceSegment(1, 3, 2, +TraceBitMap_::HORIZONTAL));
     SEQAN_ASSERT_EQ(target[1], TTraceSegment(1, 1, 2, +TraceBitMap_::VERTICAL));
@@ -132,7 +132,7 @@ SEQAN_DEFINE_TEST(test_align2_traceback_affine)
 
     clear(target);
     dpScout._maxHostPosition = 3;
-    _computeTraceback(target, navigator, dpScout, str0, str1, DPBand_<BandOff>(), TDPProfile());
+    _computeTraceback(target, navigator, dpScout, str0, str1, DPBandConfig<BandOff>(), TDPProfile());
     SEQAN_ASSERT_EQ(length(target), 2u);
     SEQAN_ASSERT_EQ(target[0], TTraceSegment(0, 3, 3, +TraceBitMap_::HORIZONTAL));
     SEQAN_ASSERT_EQ(target[1], TTraceSegment(0, 0, 3, +TraceBitMap_::VERTICAL));
@@ -178,14 +178,14 @@ SEQAN_DEFINE_TEST(test_align2_traceback_linear_unbanded_alignment)
     value(traceMatrix, 3, 3) = +TraceBitMap_::DIAGONAL | +TraceBitMap_::VERTICAL  | +TraceBitMap_::HORIZONTAL;
 
     TDPTraceNavigator navigator;
-    _init(navigator, traceMatrix, DPBand_<BandOff>());
+    _init(navigator, traceMatrix, DPBandConfig<BandOff>());
 
     DnaString str0 = "ACG";
     DnaString str1 = "ACG";
 
     DPScout_<int, Default> dpScout;
     dpScout._maxHostPosition = 15;
-    _computeTraceback(target, navigator, dpScout, str0, str1, DPBand_<BandOff>(), TDPProfile());
+    _computeTraceback(target, navigator, dpScout, str0, str1, DPBandConfig<BandOff>(), TDPProfile());
 
     SEQAN_ASSERT_EQ(target[0], TTraceSegment(2, 2, 1, +TraceBitMap_::DIAGONAL));
     SEQAN_ASSERT_EQ(target[1], TTraceSegment(1, 2, 1, +TraceBitMap_::HORIZONTAL));
@@ -234,14 +234,14 @@ SEQAN_DEFINE_TEST(test_align2_traceback_linear_normal_banded_alignment)
 
 
     TDPTraceNavigator navigator;
-    _init(navigator, traceMatrix, DPBand_<BandOn>(-1, 1));
+    _init(navigator, traceMatrix, DPBandConfig<BandOn>(-1, 1));
 
     DnaString str0 = "ACGT";
     DnaString str1 = "ACGT";
 
     DPScout_<int, Default> dpScout;
     dpScout._maxHostPosition = 13;
-    _computeTraceback(target, navigator, dpScout, str0, str1, DPBand_<BandOn>(-1, 1), TDPProfile());
+    _computeTraceback(target, navigator, dpScout, str0, str1, DPBandConfig<BandOn>(-1, 1), TDPProfile());
 
     SEQAN_ASSERT_EQ(target[0], TTraceSegment(3, 3, 1, +TraceBitMap_::DIAGONAL));
     SEQAN_ASSERT_EQ(target[1], TTraceSegment(3, 2, 1, +TraceBitMap_::VERTICAL));
@@ -326,14 +326,14 @@ SEQAN_DEFINE_TEST(test_align2_traceback_linear_wide_banded_alignment)
     value(traceMatrix, 6, 6) = +TraceBitMap_::NONE;
 
     TDPTraceNavigator navigator;
-    _init(navigator, traceMatrix, DPBand_<BandOn>(-4, 4));
+    _init(navigator, traceMatrix, DPBandConfig<BandOn>(-4, 4));
 
     DnaString str0 = "ACGTAC";
     DnaString str1 = "ACGTAC";
 
     DPScout_<int, Default> dpScout;
     dpScout._maxHostPosition = 46;
-    _computeTraceback(target, navigator, dpScout, str0, str1, DPBand_<BandOn>(-4, 4), TDPProfile());
+    _computeTraceback(target, navigator, dpScout, str0, str1, DPBandConfig<BandOn>(-4, 4), TDPProfile());
 
     SEQAN_ASSERT_EQ(target[0], TTraceSegment(6, 3, 3, +TraceBitMap_::VERTICAL));
     SEQAN_ASSERT_EQ(target[1], TTraceSegment(1, 3, 5, +TraceBitMap_::HORIZONTAL));
@@ -369,14 +369,14 @@ SEQAN_DEFINE_TEST(test_align2_traceback_linear_small_banded_alignment)
     value(traceMatrix, 0, 3) = +TraceBitMap_::DIAGONAL;
 
     TDPTraceNavigator navigator;
-    _init(navigator, traceMatrix, DPBand_<BandOn>(0, 0));
+    _init(navigator, traceMatrix, DPBandConfig<BandOn>(0, 0));
 
     DnaString str0 = "ACG";
     DnaString str1 = "ACG";
 
     DPScout_<int, Default> dpScout;
     dpScout._maxHostPosition = 3;
-    _computeTraceback(target, navigator, dpScout, str0, str1, DPBand_<BandOn>(0, 0), TDPProfile());
+    _computeTraceback(target, navigator, dpScout, str0, str1, DPBandConfig<BandOn>(0, 0), TDPProfile());
 
     SEQAN_ASSERT_EQ(target[0], TTraceSegment(0, 0, 3, +TraceBitMap_::DIAGONAL));
 }
@@ -417,14 +417,14 @@ SEQAN_DEFINE_TEST(test_align2_traceback_gaps_left_linear_gaps)
 
 
     TDPTraceNavigator navigator;
-    _init(navigator, traceMatrix, DPBand_<BandOff>());
+    _init(navigator, traceMatrix, DPBandConfig<BandOff>());
 
     DnaString str0 = "AC";
     DnaString str1 = "CCC";
 
     DPScout_<int, Default> dpScout;
     dpScout._maxHostPosition = 11;
-    _computeTraceback(target, navigator, dpScout, str0, str1, DPBand_<BandOff>(), TDPProfile());
+    _computeTraceback(target, navigator, dpScout, str0, str1, DPBandConfig<BandOff>(), TDPProfile());
 
     SEQAN_ASSERT_EQ(target[0], TTraceSegment(0, 1, 2, +TraceBitMap_::DIAGONAL));
     SEQAN_ASSERT_EQ(target[1], TTraceSegment(0, 0, 1, +TraceBitMap_::VERTICAL));
@@ -466,14 +466,14 @@ SEQAN_DEFINE_TEST(test_align2_traceback_gaps_right_linear_gaps)
 
 
     TDPTraceNavigator navigator;
-    _init(navigator, traceMatrix, DPBand_<BandOff>());
+    _init(navigator, traceMatrix, DPBandConfig<BandOff>());
 
     DnaString str0 = "AC";
     DnaString str1 = "CCC";
 
     DPScout_<int, Default> dpScout;
     dpScout._maxHostPosition = 11;
-    _computeTraceback(target, navigator, dpScout, str0, str1, DPBand_<BandOff>(), TDPProfile());
+    _computeTraceback(target, navigator, dpScout, str0, str1, DPBandConfig<BandOff>(), TDPProfile());
 
     SEQAN_ASSERT_EQ(target[0], TTraceSegment(2, 2, 1, +TraceBitMap_::VERTICAL));
     SEQAN_ASSERT_EQ(target[1], TTraceSegment(0, 0, 2, +TraceBitMap_::DIAGONAL));
@@ -517,14 +517,14 @@ SEQAN_DEFINE_TEST(test_align2_traceback_gaps_left_affine_gaps)
 
 
         TDPTraceNavigator navigator;
-        _init(navigator, traceMatrix, DPBand_<BandOff>());
+        _init(navigator, traceMatrix, DPBandConfig<BandOff>());
 
         DnaString str0 = "AC";
         DnaString str1 = "CCC";
 
         DPScout_<int, Default> dpScout;
         dpScout._maxHostPosition = 11;
-        _computeTraceback(target, navigator, dpScout, str0, str1, DPBand_<BandOff>(), TDPProfile());
+        _computeTraceback(target, navigator, dpScout, str0, str1, DPBandConfig<BandOff>(), TDPProfile());
 
         // TODO(rmaerker): This is disabled by default for the affine gap costs.
         SEQAN_ASSERT_EQ(target[0], TTraceSegment(2, 2, 1, +TraceBitMap_::VERTICAL));
@@ -564,14 +564,14 @@ SEQAN_DEFINE_TEST(test_align2_traceback_gaps_left_affine_gaps)
         value(traceMatrix, 3, 4) = TraceBitMap_::DIAGONAL;
 
         TDPTraceNavigator navigator;
-        _init(navigator, traceMatrix, DPBand_<BandOff>());
+        _init(navigator, traceMatrix, DPBandConfig<BandOff>());
 
         DnaString str0 = "ACCA";
         DnaString str1 = "ACA";
 
         DPScout_<int, Default> dpScout;
         dpScout._maxHostPosition = 19;
-        _computeTraceback(target, navigator, dpScout, str0, str1, DPBand_<BandOff>(), TDPProfile());
+        _computeTraceback(target, navigator, dpScout, str0, str1, DPBandConfig<BandOff>(), TDPProfile());
 
         // TODO(rmaerker): This is disabled by default for the affine gap costs.
         SEQAN_ASSERT_EQ(target[0], TTraceSegment(2, 1, 2, +TraceBitMap_::DIAGONAL));
@@ -618,14 +618,14 @@ SEQAN_DEFINE_TEST(test_align2_traceback_gaps_right_affine_gaps)
 
 
         TDPTraceNavigator navigator;
-        _init(navigator, traceMatrix, DPBand_<BandOff>());
+        _init(navigator, traceMatrix, DPBandConfig<BandOff>());
 
         DnaString str0 = "AC";
         DnaString str1 = "CCC";
 
         DPScout_<int, Default> dpScout;
         dpScout._maxHostPosition = 11;
-        _computeTraceback(target, navigator, dpScout, str0, str1, DPBand_<BandOff>(), TDPProfile());
+        _computeTraceback(target, navigator, dpScout, str0, str1, DPBandConfig<BandOff>(), TDPProfile());
 
         SEQAN_ASSERT_EQ(target[0], TTraceSegment(2, 2, 1, +TraceBitMap_::VERTICAL));
         SEQAN_ASSERT_EQ(target[1], TTraceSegment(0, 0, 2, +TraceBitMap_::DIAGONAL));
@@ -664,14 +664,14 @@ SEQAN_DEFINE_TEST(test_align2_traceback_gaps_right_affine_gaps)
         value(traceMatrix, 3, 4) = TraceBitMap_::DIAGONAL;
 
         TDPTraceNavigator navigator;
-        _init(navigator, traceMatrix, DPBand_<BandOff>());
+        _init(navigator, traceMatrix, DPBandConfig<BandOff>());
 
         DnaString str0 = "ACCA";
         DnaString str1 = "ACA";
 
         DPScout_<int, Default> dpScout;
         dpScout._maxHostPosition = 19;
-        _computeTraceback(target, navigator, dpScout, str0, str1, DPBand_<BandOff>(), TDPProfile());
+        _computeTraceback(target, navigator, dpScout, str0, str1, DPBandConfig<BandOff>(), TDPProfile());
 
         // TODO(rmaerker): This is disabled by default for the affine gap costs.
         SEQAN_ASSERT_EQ(target[0], TTraceSegment(3, 2, 1, +TraceBitMap_::DIAGONAL));


### PR DESCRIPTION
Changes the `DPBand_` interface to a global interface called `DPBandConfig`. 
This new interface is public and should be adapted by the banded alignment interfaces in the future. 
This would reduce the complexity of the alignment interfaces and the band parameters can be passed in their own context instead of using built-in integers. Thus, ambiguities with other parameters that might be added in the future (e.g. the current extendAlignment code) can be resolved.
The API is documented as well.
