### PR TITLE
Fix/index isa

### DIFF
--- a/core/include/seqan/index/index_shims.h
+++ b/core/include/seqan/index/index_shims.h
@@ -243,7 +243,7 @@ The size of $suffixArray$ must be at least $length(text)$ before calling this fu
                          FromSortedSa<TParallel> const &/*alg*/)
     {
         typedef typename Size<TSa>::Type                     TSize;
-        typedef typename MakeSigned<TSize>::Type			 TSignedSize;
+        typedef typename MakeSigned<TSize>::Type             TSignedSize;
         typedef typename StringSetLimits<TSa>::Type          TLimits;
         typedef typename Iterator<TSa const, Standard>::Type TIter;
 


### PR DESCRIPTION
Fixes compiler error on windows platforms using the VS compiler suite.
Tested for vs11.
