### PR TITLE
Rabema accepts SAM files without CIGAR strings

### DIFF
--- a/core/apps/rabema/rabema_evaluate.cpp
+++ b/core/apps/rabema/rabema_evaluate.cpp
@@ -104,7 +104,7 @@ public:
     // target position.
     bool trustNM;
 
-    // If the CIGAR string is absent, this tag provides the position of the other end of the alignment. Implies trustNM.
+    // If the CIGAR string is absent, this tag provides the position of the other end of the alignment.
     CharString extraPosTag;
 
     // If enabled then all reads are treated as single-end mapped.  This is required for analyzing SOAP output that has
@@ -555,6 +555,10 @@ int benchmarkReadResult(RabemaStats & result,
         return 1;
     }
 
+    Dna5String readSeq;
+    Dna5String contigSeq;
+    String<unsigned> queryResult;
+
     // Try to hit intervals.
     bool mappedAny = false;  // Whether any valid alignment was found.
     for (unsigned i = 0; i < length(samRecords); ++i)
@@ -566,14 +570,31 @@ int benchmarkReadResult(RabemaStats & result,
         //
         // If we run in oracle mode then we ignore the actual alignment score and use the best alignment.  We only care
         // about the alignment's end position in this case.
-        Dna5String readSeq;
-        if (hasFlagFirst(samRecord) || (!hasFlagFirst(samRecord) && !hasFlagLast(samRecord)))
-            readSeq = readSeqL;
         if (hasFlagLast(samRecord))
             readSeq = readSeqR;
+        else
+            readSeq = readSeqL;
 
         // TODO(holtgrew): Remove const cast once we have const holders!
         BamTagsDict bamTags(const_cast<CharString &>(samRecord.tags));
+        unsigned idx = 0;
+
+        // If the CIGAR is not present, e.g. a * is present instead,
+        // we can still get the extra position from an user-defined tag.
+        unsigned endPos = samRecord.beginPos + getAlignmentLengthInRef(samRecord) - countPaddings(samRecord.cigar);
+        if (empty(samRecord.cigar))
+        {
+            if (empty(options.extraPosTag) ||
+                !(findTagKey(idx, bamTags, options.extraPosTag) && extractTagValue(endPos, bamTags, idx)))
+            {
+                // Simply try to guess the end position.
+                endPos = samRecord.beginPos + length(readSeq) + 1;
+                std::cerr << "WARNING: Unknown alignment end position for read " << samRecord.qName << ".\n";
+            }
+            // The extra position tag must be 1-based.
+            SEQAN_ASSERT_GT(endPos, 0u);
+            endPos--;
+        }
 
         int bestDistance = minValue<int>();  // Marker for "not set yet".
         // Note that bestDistance expresses the distance in percent error, relative to the read length, ceiled up
@@ -581,27 +602,25 @@ int benchmarkReadResult(RabemaStats & result,
         if (!options.oracleMode)
         {
             // Get best distance from NM tag if set and we are to trust it.
-            if (options.trustNM)
+            if (options.trustNM && findTagKey(idx, bamTags, "NM") && extractTagValue(bestDistance, bamTags, idx))
             {
-                unsigned idx = 0;
-                if (findTagKey(idx, bamTags, "NM") && extractTagValue(bestDistance, bamTags, idx))
-                {
-                    // Convert from count to rate.
-                    bestDistance = static_cast<int>(ceil(100.0 * bestDistance / length(readSeq)));
-                }
+                // Convert from count to rate.
+                bestDistance = static_cast<int>(ceil(100.0 * bestDistance / length(readSeq)));
             }
             // Otherwise, perform a realignment.
             else
             {
-                int bandwidth = static_cast<int>(ceil(0.01 * options.maxError * length(readSeq)));
-                __int32 beginPos = samRecord.beginPos - bandwidth;
-                __int32 endPos = (beginPos + getAlignmentLengthInRef(samRecord) -
-                                  countPaddings(samRecord.cigar) + 2 * bandwidth);
-                if (beginPos < 0)
-                    beginPos = 0;
-                if (endPos > (int)length(refSeqs[seqId]))
-                    endPos = length(refSeqs[seqId]);
-                Dna5String contigSeq = infix(refSeqs[seqId], beginPos, endPos);
+                unsigned bandwidth = static_cast<int>(ceil(0.01 * options.maxError * length(readSeq)));
+
+                unsigned intervalBegin = samRecord.beginPos;
+                if (intervalBegin > bandwidth)
+                    intervalBegin -= bandwidth;
+
+                unsigned intervalEnd = endPos;
+                if (intervalEnd < length(refSeqs[seqId]) - 2 * bandwidth)
+                    intervalEnd += 2 * bandwidth;
+
+                contigSeq = infix(refSeqs[seqId], intervalBegin, intervalEnd);
                 if (hasFlagRC(samRecord))
                     reverseComplement(contigSeq);
                 Finder<Dna5String> finder(contigSeq);
@@ -609,7 +628,8 @@ int benchmarkReadResult(RabemaStats & result,
                 _patternMatchNOfPattern(pattern, options.matchN);
                 _patternMatchNOfFinder(pattern, options.matchN);
                 bool ret = setEndPosition(finder, pattern, length(contigSeq) - bandwidth);
-                (void) ret;  // When run without assertions.
+                ignoreUnusedVariableWarning(ret);
+//                write2(std::cerr, samRecord, bamIOContext, Sam());
                 SEQAN_CHECK(ret, "setEndPosition() must not fail!");
                 bestDistance = static_cast<int>(ceil(-100.0 * getScore(pattern) / length(readSeq)));
             }
@@ -617,43 +637,14 @@ int benchmarkReadResult(RabemaStats & result,
 
         // Get sequence id and last position of alignment.  We try to hit the interval with the last position (not
         // C-style end) of the read.
-        unsigned lastPos = 0;
-        if (!hasFlagRC(samRecord))
-        {
-            lastPos = samRecord.beginPos + getAlignmentLengthInRef(samRecord) - countPaddings(samRecord.cigar) - 1;
-
-            // If the CIGAR is not present, e.g. a * is present instead,
-            // we can still get the extra position from an user-defined tag.
-            if (empty(samRecord.cigar))
-            {
-                unsigned idx = 0;
-                unsigned extraPos = 0;
-
-                if (!empty(options.extraPosTag) &&
-                    findTagKey(idx, bamTags, options.extraPosTag) &&
-                    extractTagValue(extraPos, bamTags, idx))
-                {
-                    lastPos = extraPos - 2;
-                }
-                else
-                {
-                    lastPos = samRecord.beginPos + length(readSeq) - 2;
-
-                    std::cerr << "WARNING: Unknown alignment end position for read " << samRecord.qName << ".\n";
-                }
-            }
-        }
-        else
-        {
-            lastPos = length(refSeqs[seqId]) - samRecord.beginPos - 1;
-        }
+        unsigned lastPos = hasFlagRC(samRecord) ? length(refSeqs[seqId]) - samRecord.beginPos - 1 : endPos - 1;
 
         if (options.showTryHitIntervals)
             std::cerr << "TRY HIT\tchr=" << refSeqNames[seqId] << "\tlastPos=" << lastPos << "\tqName="
                       << samRecord.qName << "\n";
 
         // Try to hit any interval.
-        String<unsigned> queryResult;
+        clear(queryResult);
         findIntervals(intervalTrees[seqId], lastPos, queryResult);
         mappedAny = mappedAny || !empty(queryResult);
 #if DEBUG_RABEMA
@@ -1121,7 +1112,7 @@ parseCommandLine(RabemaEvaluationOptions & options, int argc, char const ** argv
                                             "realignment is performed.  Off by default."));
     addOption(parser, seqan::ArgParseOption("", "extra-pos-tag",
                                             "If the CIGAR string is absent, the missing alignment end position can be "
-                                            "provided by this BAM tag. This implies trust-NM.",
+                                            "provided by this BAM tag.",
                                             seqan::ArgParseOption::STRING));
 
     addOption(parser, seqan::ArgParseOption("", "ignore-paired-flags",
@@ -1234,7 +1225,6 @@ parseCommandLine(RabemaEvaluationOptions & options, int argc, char const ** argv
         options.distanceMetric = HAMMING_DISTANCE;
     options.trustNM = isSet(parser, "trust-NM");
     getOptionValue(options.extraPosTag, parser, "extra-pos-tag");
-    if (!empty(options.extraPosTag)) options.trustNM = true;
     options.ignorePairedFlags = isSet(parser, "ignore-paired-flags");
     options.dontPanic = isSet(parser, "DONT-PANIC");
 


### PR DESCRIPTION
The missing end of alignments can be provided through an arbitrary SAM tag. Such tag has to be signaled to Rabema through the command line option --extra-pos-tag.
