### PR TITLE
[FIX] Enforcing minimal fragment length for Illumina reads.

### DIFF
--- a/extras/apps/mason2/mason_options.h
+++ b/extras/apps/mason2/mason_options.h
@@ -223,6 +223,10 @@ struct FragmentSamplerOptions
     };
     */
 
+    // Lower bound on fragment size to simulate, used for requiring minimal size when simulating Illumina reads.  A
+    // value of 0 indicates no bound.
+    int fragSizeLowerBound;
+
     // Smallest fragment size if uniformly distributed.
     int minFragmentSize;
     // Maximal fragment size if uniformly distributed.
@@ -245,8 +249,8 @@ struct FragmentSamplerOptions
     */
 
     FragmentSamplerOptions() :
-            verbosity(1), minFragmentSize(0), maxFragmentSize(0), meanFragmentSize(0), stdDevFragmentSize(0),
-            model(UNIFORM)
+            verbosity(1), fragSizeLowerBound(0), minFragmentSize(0), maxFragmentSize(0), meanFragmentSize(0),
+            stdDevFragmentSize(0), model(UNIFORM)
     {}
 
     // Add options to the argument parser.

--- a/extras/apps/mason2/mason_simulator.cpp
+++ b/extras/apps/mason2/mason_simulator.cpp
@@ -1174,6 +1174,10 @@ public:
         std::cerr << "\n____INITIALIZING______________________________________________________________\n"
                   << "\n";
 
+        // Set lower bound on fragment size in case of Illumina reads.
+        if (options.seqOptions.sequencingTechnology == SequencingOptions::ILLUMINA)
+            options.fragSamplerOptions.fragSizeLowerBound = 1.5 * options.illuminaOptions.readLength;
+
         // Initialize VCF materialization (reference FASTA and input VCF).
         std::cerr << "Opening reference and variants file ...";
         vcfMat.init();


### PR DESCRIPTION
Fixes seqan/seqan #420
