### PR TITLE
[FIX] Fixed one issues with "S" in cigar string.

### DIFF
--- a/core/include/seqan/bam_io/cigar.h
+++ b/core/include/seqan/bam_io/cigar.h
@@ -715,8 +715,11 @@ cigarToGapAnchorContig(TCigarString const & cigar, TGaps & gaps)
             case 'D':
             case 'M':
             case 'N':
-            case 'S':
                 it += cigar[i].count;
+                atBegin = false;
+                break;
+            case 'S':
+                beginGaps += cigar[i].count;
                 atBegin = false;
         }
     }

--- a/core/tests/bam_io/test_bam_cigar.h
+++ b/core/tests/bam_io/test_bam_cigar.h
@@ -1,0 +1,58 @@
+// ==========================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ==========================================================================
+// Copyright (c) 2006-2013, Knut Reinert, FU Berlin
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ==========================================================================
+// Author: Jochen Singer <jochen.singer@fu-berlin.de>
+// ==========================================================================
+
+#include <iostream>
+#include <seqan/file.h>
+#include <seqan/bam_io.h>
+
+using namespace seqan;
+
+SEQAN_DEFINE_TEST(test_bam_io_bam_record_to_alignment)
+{
+    std::string pathSam = "test.sam";
+
+    BamStream bamStreamIn(pathSam.c_str());
+
+    BamAlignmentRecord record;
+
+    Align<CharString, ArrayGaps> alignObj;
+    CharString ref = "AGCATGTTAGATAAGATAGCTGTGCTAGTAGGCAGTCAGCGCCAT";
+
+    readRecord(record, bamStreamIn);
+
+    bamRecordToAlignment(alignObj, ref, record);
+    std::cout << alignObj << std::endl;
+}
+
+

--- a/core/tests/bam_io/test_bam_io.cpp
+++ b/core/tests/bam_io/test_bam_io.cpp
@@ -48,6 +48,7 @@
 #include "test_bam_index.h"
 #endif  // #if SEQAN_HAS_ZLIB
 #include "test_bam_stream.h"
+#include "test_bam_cigar.h"
 
 SEQAN_BEGIN_TESTSUITE(test_bam_io)
 {
@@ -174,5 +175,8 @@ SEQAN_BEGIN_TESTSUITE(test_bam_io)
 
     // Issue 489
     SEQAN_CALL_TEST(test_bam_io_bam_stream_issue_489);
+
+    // Test BAM I/O.
+    SEQAN_CALL_TEST(test_bam_io_bam_record_to_alignment);
 }
 SEQAN_END_TESTSUITE


### PR DESCRIPTION
The "S" in the cigar string was treated wrongly. However, this commit does not fully fix the problem as can be seen in the output of the test. The second line of the alignment is shifted by one. Since I don't know how this problem should be fixed (remove the first character in the second row, insert an gap in the first row, ...) I did not finish the test.

Note that this problem is also related to https://lists.fu-berlin.de/htdig/seqan-dev/2014-September/msg00015.html 