### PR TITLE
[FIX] Fixing resource leak in tests system.

### DIFF
--- a/core/include/seqan/basic/debug_test_system.h
+++ b/core/include/seqan/basic/debug_test_system.h
@@ -917,6 +917,8 @@ int endTestSuite()
         }
 
         rmdir(StaticData::tempFileNames()[i].c_str());
+        if (closedir(dpdf) != 0)
+            std::cerr << "WARNING: Could not delete directory " << StaticData::tempFileNames()[i] << "\n";
 #endif  // #ifdef PLATFORM_WINDOWS
     }
 


### PR DESCRIPTION
Leak was not critical, occurred at the end of a test suite run.
