### PR TITLE
[FIX] Fixing problem with `<::`.

### DIFF
--- a/core/include/seqan/basic/debug_test_system.h
+++ b/core/include/seqan/basic/debug_test_system.h
@@ -1971,7 +1971,7 @@ SEQAN_CALL_TEST(test_name);
             (void) e;  /* Get rid of unused variable warning. */        \
         } catch (seqan::Exception const & e) {                          \
             ::std::cerr << "Unexpected exception of type "              \
-                        << toCString(::seqan::Demangler<::seqan::Exception>(e)) \
+                        << toCString(::seqan::Demangler< ::seqan::Exception>(e)) \
                         << "; message: " << e.what() << "\n";           \
             ::seqan::ClassTest::StaticData::thisTestOk() = false;       \
             ::seqan::ClassTest::StaticData::errorCount() += 1;          \

--- a/core/include/seqan/basic/test_system.h
+++ b/core/include/seqan/basic/test_system.h
@@ -162,7 +162,7 @@ public:
                 (void) e;  /* Get rid of unused variable warning. */
             } catch (::seqan::Exception const & e) {
                 ::std::cerr << "Unexpected exception of type "
-                            << toCString(::seqan::Demangler<::seqan::Exception>(e))
+                            << toCString(::seqan::Demangler< ::seqan::Exception>(e))
                             << "; message: " << e.what() << "\n";
                 ::seqan::ClassTest::StaticData::thisTestOk() = false;
                 ::seqan::ClassTest::StaticData::errorCount() += 1;


### PR DESCRIPTION
Fixing bug introduced with #632 
