### PR TITLE
Disabled CUDA Index

### DIFF
--- a/core/include/seqan/index.h
+++ b/core/include/seqan/index.h
@@ -194,9 +194,10 @@
 // ----------------------------------------------------------------------------
 
 #include <seqan/index/index_view.h>
-#ifdef PLATFORM_CUDA
-#include <seqan/index/index_device.h>
-#endif
+// NOTE(esiragusa): CUDA FM-index is broken.
+//#ifdef PLATFORM_CUDA
+//#include <seqan/index/index_device.h>
+//#endif
 
 // ==========================================================================
 // Finder interface.

--- a/core/tests/cuda/CMakeLists.txt
+++ b/core/tests/cuda/CMakeLists.txt
@@ -42,18 +42,21 @@ if (SEQAN_HAS_CUDA)
 endif ()
 
 # Add dependencies found by find_package (SeqAn).
+# NOTE(esiragusa): CUDA FM-index is broken.
+
 if (SEQAN_HAS_CUDA)
   target_link_libraries (test_cuda_basic ${SEQAN_LIBRARIES})
   target_link_libraries (test_cuda_sequence ${SEQAN_LIBRARIES})
-  target_link_libraries (test_cuda_index ${SEQAN_LIBRARIES})
+#  target_link_libraries (test_cuda_index ${SEQAN_LIBRARIES})
 endif ()
 
 # ----------------------------------------------------------------------------
 # Register with CTest
 # ----------------------------------------------------------------------------
+# NOTE(esiragusa): CUDA FM-index is broken.
 
 if (SEQAN_HAS_CUDA)
     add_test (NAME test_test_cuda_basic COMMAND $<TARGET_FILE:test_cuda_basic>)
     add_test (NAME test_test_cuda_sequence COMMAND $<TARGET_FILE:test_cuda_sequence>)
-    add_test (NAME test_test_cuda_index COMMAND $<TARGET_FILE:test_cuda_index>)
+#    add_test (NAME test_test_cuda_index COMMAND $<TARGET_FILE:test_cuda_index>)
 endif ()


### PR DESCRIPTION
Disabled corresponding headers from index.h and tests from CMakeLists.txt as CUDA Index is broken since #703.
