### PR TITLE
[FIXED-#699] Fixes error with std::vector adaption in clang.

### DIFF
--- a/include/seqan/seeds/banded_chain_alignment_impl.h
+++ b/include/seqan/seeds/banded_chain_alignment_impl.h
@@ -86,11 +86,11 @@ struct BandedChainTracking
 
 template <typename TSeedSet>
 inline bool
-_isLastSeed(typename Iterator<TSeedSet const>::Type iter,
+_isLastSeed(typename Iterator<TSeedSet const, Standard>::Type iter,
             TSeedSet const & seedSet)
 {
     typedef typename Iterator<TSeedSet const>::Type TSeedIterator;
-    TSeedIterator itEnd = end(seedSet);
+    TSeedIterator itEnd = end(seedSet, Standard());
     return iter == --itEnd;
 }
 
@@ -588,8 +588,8 @@ _findFirstAnchor(TSeedSet const & seedSet, int bandExtension)
 
     SEQAN_ASSERT_GT_MSG(length(seedSet), 0u, "SeedSet is empty!");
 
-    TIterator it = begin(seedSet);
-    TIterator itEnd = end(seedSet);
+    TIterator it = begin(seedSet, Standard());
+    TIterator itEnd = end(seedSet, Standard());
     --itEnd;
 
     while (it != itEnd)
@@ -601,7 +601,7 @@ _findFirstAnchor(TSeedSet const & seedSet, int bandExtension)
             continue;
         else
         { // found seed which is not crossing the begin.
-            SEQAN_ASSERT(it != static_cast<TIterator>(begin(seedSet)));
+            SEQAN_ASSERT(it != static_cast<TIterator>(begin(seedSet, Standard())));
             return --it;
         }
     }
@@ -624,7 +624,7 @@ _findLastAnchor(typename Iterator<TSeedSet const, Standard>::Type & iterBegin,
 
     SEQAN_ASSERT_GT_MSG(length(seedSet), 0u, "SeedSet is empty!");
 
-    TIterator it = end(seedSet);
+    TIterator it = end(seedSet, Standard());
     --it;
 
     while (it != iterBegin)
@@ -1193,7 +1193,7 @@ _computeAlignment(TTraceSet & globalTraceSet,
 
     typedef typename Position<TSequenceH>::Type TPosH;
     typedef typename Position<TSequenceV>::Type TPosV;
-    typedef typename Iterator<TSeedSet const>::Type TSeedSetIterator;
+    typedef typename Iterator<TSeedSet const, Standard>::Type TSeedSetIterator;
 
     typedef DPCell_<TScoreValue, TGapSpec> TDPCell;
     typedef DPScoutState_<BandedChainAlignmentScoutState<TDPCell> > TScoutState;
@@ -1215,7 +1215,7 @@ _computeAlignment(TTraceSet & globalTraceSet,
     // Find the last anchor that is not covered by the region between the previous anchor and the end of the matrix.
     TSeedSetIterator itEnd = _findLastAnchor(it, seedSet, seqH, seqV, bandExtension);
 
-    SEQAN_ASSERT(itEnd != static_cast<TSeedSetIterator>(end(seedSet)));
+    SEQAN_ASSERT(itEnd != static_cast<TSeedSetIterator>(end(seedSet, Standard())));
     // The scout state stores the current state of the dp scout and is used to store the
     // initialization values for the next intersecting grid.
     TScoutState scoutState;

--- a/tests/seeds/test_banded_chain_alignment_interface.cpp
+++ b/tests/seeds/test_banded_chain_alignment_interface.cpp
@@ -34,6 +34,7 @@
 // Tests the different global interfaces of the banded chain alignment.
 // ==========================================================================
 
+#include <vector>
 #include <sstream>
 
 #include <seqan/basic.h>
@@ -699,7 +700,7 @@ SEQAN_DEFINE_TEST(test_banded_chain_alignment_gaps_linear_global_two_score)
 }
 SEQAN_DEFINE_TEST(test_banded_chain_alignment_gaps_linear_semi_one_score)
 {
-        using namespace seqan;
+    using namespace seqan;
 
     typedef Seed<Simple> TSeed;
     {
@@ -2428,6 +2429,58 @@ SEQAN_DEFINE_TEST(test_banded_chain_alignment_fragments_affine_overlap_two_score
     }
 }
 
+SEQAN_DEFINE_TEST(test_banded_chain_alignment_stl_vector_adaption)
+{
+	using namespace seqan;
+
+    typedef Seed<Simple> TSeed;
+    {
+        CharString sequenceV = "CGAATCCATCCCACACA";
+        Dna5String sequenceH = "GGCGATNNNCATGGCACA";
+        Score<int, Simple> scoringScheme(2, -1, -2);
+
+        std::vector<TSeed> seedChain;
+        appendValue(seedChain, TSeed(0,2,5,6));
+        appendValue(seedChain, TSeed(6,9,9,12));
+        appendValue(seedChain, TSeed(11,14,17,16));
+
+        Gaps<CharString, ArrayGaps> gapsHorizontal;
+        Gaps<Dna5String, ArrayGaps> gapsVertical;
+        assignSource(gapsHorizontal, sequenceV);
+        assignSource(gapsVertical, sequenceH);
+
+        int result = bandedChainAlignment(gapsHorizontal, gapsVertical, seedChain, scoringScheme, AlignConfig<true, false, false, true>(), 2);
+        SEQAN_ASSERT_EQ(result, 9);
+
+        // Compare alignment rows.
+        SEQAN_ASSERT_EQ(gapsHorizontal, "--CGAAT--CCATCCCACACA");
+        SEQAN_ASSERT_EQ(gapsVertical, "GGCG-ATNNNCATGGCACA--");
+    }
+
+    {
+        CharString sequenceV = "CGAATCCATCCCACACA";
+        Dna5String sequenceH = "GGCGATNNNCATGGCACA";
+        Score<int, Simple> scoringScheme(2, -1, -2);
+
+        std::vector<TSeed> seedChain;
+        appendValue(seedChain, TSeed(0,2,5,6));
+        appendValue(seedChain, TSeed(6,9,9,12));
+        appendValue(seedChain, TSeed(11,14,17,16));
+
+        Gaps<CharString, ArrayGaps> gapsHorizontal;
+        Gaps<Dna5String, ArrayGaps> gapsVertical;
+        assignSource(gapsHorizontal, sequenceV);
+        assignSource(gapsVertical, sequenceH);
+
+        int result = bandedChainAlignment(gapsHorizontal, gapsVertical, seedChain, scoringScheme, AlignConfig<false, true, true, false>(),  2);
+        SEQAN_ASSERT_EQ(result, 9);
+
+        // Compare alignment rows.
+        SEQAN_ASSERT_EQ(gapsHorizontal,  "--CGAAT--CCATCCCACACA");
+        SEQAN_ASSERT_EQ(gapsVertical, "GGCG-ATNNNCATGG--CACA");
+    }
+}
+
 SEQAN_BEGIN_TESTSUITE(test_banded_chain_alignment_interface)
 {
     SEQAN_CALL_TEST(test_banded_chain_alignment_align_linear_global_one_score);
@@ -2481,5 +2534,6 @@ SEQAN_BEGIN_TESTSUITE(test_banded_chain_alignment_interface)
     SEQAN_CALL_TEST(test_banded_chain_alignment_fragments_affine_semi_two_scores);
     SEQAN_CALL_TEST(test_banded_chain_alignment_fragments_affine_overlap_one_score);
     SEQAN_CALL_TEST(test_banded_chain_alignment_fragments_affine_overlap_two_scores);
+    SEQAN_CALL_TEST(test_banded_chain_alignment_stl_vector_adaption);
 }
 SEQAN_END_TESTSUITE


### PR DESCRIPTION
Fixes an issue when using std::vector for the seed chain passed to the banded-chain-aignment algorithm.