### PR TITLE
[fix] use std::abs instead of abs

### DIFF
--- a/include/seqan/consensus/consensus_builder.h
+++ b/include/seqan/consensus/consensus_builder.h
@@ -321,7 +321,7 @@ bool alignmentGraphToFragmentStore(TFragmentStore & store,
             if (DEBUG_INCONSISTENT_LEN)
                 std::cerr << "READ GAPS\t" << (it2 - begin(store.alignedReadStore, Standard())) << "\t>>>" << readGaps << "<<< (" << length(readGaps) << ")\n"
                           << "  beginPos == " << it2->beginPos << ", endPos == " << it2->endPos << ", gapCount == " << gapCount[it2->readId] << "\n";
-            if ((unsigned)abs(it2->endPos - it2->beginPos) != length(readGaps))
+            if ((unsigned)std::abs(it2->endPos - it2->beginPos) != length(readGaps))
             {
                 SEQAN_FAIL("Inconsistent begin/endPos");
             }


### PR DESCRIPTION
remove warning on `clang>=3.5` [-Wabsolute-value, http://llvm.org/releases/3.5.0/tools/clang/docs/ReleaseNotes.html]