### PR TITLE
Fixes issues with bgzf stream

### DIFF
--- a/include/seqan/stream/zipstream/bgzfstream.h
+++ b/include/seqan/stream/zipstream/bgzfstream.h
@@ -320,7 +320,7 @@ public:
         istream_reference   istream;
         Mutex               lock;
         IOError             *error;
-        off_t               fileOfs;
+        off_type            fileOfs;
 
         Serializer(istream_reference istream) :
             istream(istream),
@@ -343,7 +343,7 @@ public:
 
         TInputBuffer    inputBuffer;
         TBuffer         buffer;
-        off_t           fileOfs;
+        off_type        fileOfs;
         int             size;
 
         CriticalSection cs;
@@ -644,7 +644,7 @@ public:
                 std::streampos destFileOfs = ofs >> 16;
 
                 // are we in the same block?
-                if (currentJobId >= 0 && jobs[currentJobId].fileOfs == (off_t)destFileOfs)
+                if (currentJobId >= 0 && jobs[currentJobId].fileOfs == (off_type)destFileOfs)
                 {
                     DecompressionJob &job = jobs[currentJobId];
 
@@ -671,7 +671,7 @@ public:
                     {
                         popFront(currentJobId, runningQueue);
 
-                        if (jobs[currentJobId].fileOfs == (off_t)destFileOfs)
+                        if (jobs[currentJobId].fileOfs == (off_type)destFileOfs)
                             break;
 
                         // push back useless job
@@ -707,7 +707,7 @@ public:
                             waitFor(job.readyEvent);
                     }
 
-                    SEQAN_ASSERT_EQ(job.fileOfs, (off_t)destFileOfs);
+                    SEQAN_ASSERT_EQ(job.fileOfs, (off_type)destFileOfs);
 
                     // reset buffer pointers
                     this->setg( 

--- a/include/seqan/stream/zipstream/bgzfstream.h
+++ b/include/seqan/stream/zipstream/bgzfstream.h
@@ -666,6 +666,12 @@ public:
                     if (currentJobId >= 0)
                         appendValue(todoQueue, currentJobId);
 
+                    // Note that if we are here the current job does not represent the sought block.
+                    // Hence if the running queue is empty we need to explicitly unset the jobId,
+                    // otherwise we would not update the serializers istream pointer to the correct position.
+                    if (empty(runningQueue))
+                        currentJobId = -1;
+
                     // empty is thread-safe in serializer.lock
                     while (!empty(runningQueue))
                     {

--- a/tests/bam_io/test_bam_file.h
+++ b/tests/bam_io/test_bam_file.h
@@ -480,14 +480,14 @@ SEQAN_DEFINE_TEST(test_bam_io_bam_file_bam_file_seek)
     seqan::BamHeader header;
     readHeader(header, bamFile);
 
-    seqan::String<seqan::Pair<off_t, int> > recs;
+    seqan::String<seqan::Pair<uint64_t, int> > recs;
 
     seqan::BamAlignmentRecord record;
     while (!atEnd(bamFile))
     {
-        off_t ofs = position(bamFile);
+        uint64_t ofs = position(bamFile);
         readRecord(record, bamFile);
-        appendValue(recs, seqan::Pair<off_t, int>(ofs, record.beginPos));
+        appendValue(recs, seqan::Pair<uint64_t, int>(ofs, record.beginPos));
     }
 
     for (size_t j = 0; j < length(recs); ++j)

--- a/tests/bam_io/test_bam_file.h
+++ b/tests/bam_io/test_bam_file.h
@@ -471,6 +471,8 @@ SEQAN_DEFINE_TEST(test_bam_io_bam_file_bam_file_size)
 
 SEQAN_DEFINE_TEST(test_bam_io_bam_file_bam_file_seek)
 {
+    typedef seqan::Position<seqan::BamFileIn>::Type TPosition;
+
     std::string filePath = (std::string)SEQAN_PATH_TO_ROOT() + "/apps/ngs_roi/example/example.bam";
 
     seqan::BamFileIn bamFile(filePath.c_str());
@@ -480,14 +482,14 @@ SEQAN_DEFINE_TEST(test_bam_io_bam_file_bam_file_seek)
     seqan::BamHeader header;
     readHeader(header, bamFile);
 
-    seqan::String<seqan::Pair<uint64_t, int> > recs;
+    seqan::String<seqan::Pair<TPosition, int> > recs;
 
     seqan::BamAlignmentRecord record;
     while (!atEnd(bamFile))
     {
-        uint64_t ofs = position(bamFile);
+        TPosition ofs = position(bamFile);
         readRecord(record, bamFile);
-        appendValue(recs, seqan::Pair<uint64_t, int>(ofs, record.beginPos));
+        appendValue(recs, seqan::Pair<TPosition, int>(ofs, record.beginPos));
     }
 
     for (size_t j = 0; j < length(recs); ++j)


### PR DESCRIPTION
Changes:
   * Changes off_t to off_type the offset type used by the bgzf stream. (They are different types on Windows)
   * Fixes seekoff if running queue is empty and current job does not encode the right block.