### PR TITLE
[FIX] Compiler warnings on windows.

### DIFF
--- a/apps/snp_store/snp_store.cpp
+++ b/apps/snp_store/snp_store.cpp
@@ -63,8 +63,8 @@ using namespace seqan;
 
 
 // load entire genome into memory
-template <typename TGenomeSet, typename TGenomeNames>
-bool loadGenomes(TGenomeSet &genomes, StringSet<CharString> &fileNameList, ::std::map<CharString,unsigned> &gIdStringToIdNumMap, TGenomeNames & genomeNames)
+template <typename TGenomeSet, typename TGenomeSetSize, typename TGenomeNames>
+bool loadGenomes(TGenomeSet &genomes, StringSet<CharString> &fileNameList, ::std::map<CharString, TGenomeSetSize> &gIdStringToIdNumMap, TGenomeNames & genomeNames)
 {
     unsigned gSeqNo = 0;
     unsigned filecount = 0;
@@ -612,7 +612,8 @@ int detectSNPs(SNPCallingOptions<TSpec> &options)
 
     typedef String<String<TContigPos > >            TPositions;
     typedef typename Iterator<String<TContigPos > >::Type TPosIterator;
-    typedef ::std::map<CharString,unsigned>         TGenomeMap;
+    typedef typename Size<TGenomeSet>::Type         TGenomeSetSize;
+    typedef ::std::map<CharString, TGenomeSetSize>  TGenomeMap;
     //typedef typename TGenomeMap::iterator           TMapIter;
     typedef String<unsigned>                TReadCounts;
     typedef String<Pair<int,int> >              TReadClips;

--- a/apps/snp_store/snp_store.h
+++ b/apps/snp_store/snp_store.h
@@ -1739,9 +1739,9 @@ int readMatchesFromSamBam_Batch(
 
 ///////////////////////////////////////////////////////////////////////////////////////////////7
 // simple position stats analysis
-template <typename TPositions, typename TOptions>
+template <typename TPositions, typename TGenomeSetSize, typename TOptions>
 bool loadPositions(TPositions & positions,
-                   ::std::map<CharString,unsigned> &gIdStringToIdNumMap,
+                   ::std::map<CharString, TGenomeSetSize> &gIdStringToIdNumMap,
                    char const * filename,
                    TOptions & options)
 {
@@ -1753,7 +1753,7 @@ bool loadPositions(TPositions & positions,
     CharString chrId;
 
     int numPos = 0;
-    typename ::std::map<CharString,unsigned>::const_iterator it;
+    typename ::std::map<CharString, TGenomeSetSize>::const_iterator it;
     unsigned contigId;
     typename DirectionIterator<std::ifstream, Input>::Type fileIter = directionIterator(file, Input());
     while (!atEnd(fileIter))


### PR DESCRIPTION
Fixes compiler warning C4267 (convert size_t to unsigned int) on win x64.