### PR TITLE
[FIX] Razers2 test on windows.

### DIFF
--- a/include/seqan/stream/virtual_stream.h
+++ b/include/seqan/stream/virtual_stream.h
@@ -517,7 +517,8 @@ open(VirtualStream<TValue, TDirection, TTraits> &stream, TStream &fileStream, TC
     typedef typename TVirtualStream::TBufferedStream TBufferedStream;
 
     // peek the first character to initialize the underlying streambuf (for in_avail)
-    fileStream.rdbuf()->sgetc();
+    if (IsSameType<TDirection, Input>::VALUE)  // Only getc if input stream.
+        fileStream.rdbuf()->sgetc();
 
     if (IsSameType<TDirection, Input>::VALUE &&
         !IsSameType<TStream, TBufferedStream>::VALUE &&


### PR DESCRIPTION
As a matter of fact calling the ```sgetc()``` on the ```output_stream``` on vsc++ causes the ```_IPCount``` of the ```basic_streambuf``` to be set to ```-1```. 
When calling the chunked ```write``` function, this leads to a chunk where the begin iterator is set to ```NULL``` and the end iterator to ```-1```. Hence the chunk is not recognised as empty, though it is pretty much deadly.
In the following the write method tries to put something to the begin iterator which is ```NULL``` and we get the segfault. However, specifically calling the ```sgetc()``` only for input streams leaves the  ```_IPCount``` value to ```0``` and everything works as expected. The empty buffer is reserved the first time it is called and then the buffer is instantiated and used through out the writing procedure.

@esiragusa @weese: So far this seems to work on all platforms. But maybe you have a look at this, in case I missed something.
   