### PR TITLE
[FIX] Fixes html name encoding.

### DIFF
--- a/util/py_lib/seqan/dox/write_html.py
+++ b/util/py_lib/seqan/dox/write_html.py
@@ -22,10 +22,11 @@ def escapeForXml(s):
 
 def escapeName(name):
     """Escape a name such that it is safe to use for files and anchors."""
+    """TODO(rmaerker): Encode special chars using urllib.quote(c.encode('utf8'))"""
     escape = '_'
     xs = []
     for c in name:
-        if c.isalpha() or c in ['-']:
+        if c.isalnum() or c in ['-']:
             xs.append(c)
         else:
             xs += [escape, str(ord(c))]


### PR DESCRIPTION
Hot fix to get correct escaping of html names containing numbers, e.g. ```Blosum62```
This does not solve the general problem as described here: #831, but will fix most issues with entities containing numbers in their name.
