### PR TITLE
Disabled Fiona builds on 32 bit architectures

### DIFF
--- a/apps/fiona/CMakeLists.txt
+++ b/apps/fiona/CMakeLists.txt
@@ -32,6 +32,11 @@ if (MSVC)
     return ()
 endif()
 
+if (NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
+    message (STATUS "  Not building fiona on 32bit architectures.")
+    return ()
+endif()
+
 # ----------------------------------------------------------------------------
 # Build Setup
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
Tests fail, see e.g. http://cdash.seqan.de/viewTest.php?onlyfailed&buildid=120407.