### PR TITLE
Fix/finitealph value size type

### DIFF
--- a/include/seqan/basic/alphabet_residue.h
+++ b/include/seqan/basic/alphabet_residue.h
@@ -592,8 +592,7 @@ struct Finite;
 template <typename TValue, unsigned SIZE>
 struct ValueSize<SimpleType<TValue, Finite<SIZE> > >
 {
-    //TODO(meiers): this needs to be change to hold SIZE many values
-    typedef __uint8 Type;
+    typedef __uint64 Type;
     static const Type VALUE = SIZE;
 };
 

--- a/include/seqan/basic/alphabet_residue.h
+++ b/include/seqan/basic/alphabet_residue.h
@@ -592,7 +592,7 @@ struct Finite;
 template <typename TValue, unsigned SIZE>
 struct ValueSize<SimpleType<TValue, Finite<SIZE> > >
 {
-    typedef __uint64 Type;
+    typedef unsigned Type;
     static const Type VALUE = SIZE;
 };
 

--- a/include/seqan/basic/alphabet_residue.h
+++ b/include/seqan/basic/alphabet_residue.h
@@ -592,6 +592,7 @@ struct Finite;
 template <typename TValue, unsigned SIZE>
 struct ValueSize<SimpleType<TValue, Finite<SIZE> > >
 {
+    //TODO(meiers): this needs to be change to hold SIZE many values
     typedef __uint8 Type;
     static const Type VALUE = SIZE;
 };


### PR DESCRIPTION
finite alphabets may have bigger sizes than uint8 can hold. 
Note that this is the type of the ValueSize and not the type of Value (which is specified manully for SimpleType).