### PR TITLE
[FIXED-#866] Tokenization: Disabled chunking for std::string.

### DIFF
--- a/include/seqan/basic/basic_stream.h
+++ b/include/seqan/basic/basic_stream.h
@@ -62,6 +62,10 @@ template <typename TChar, typename TCharTraits, typename TAlloc>
 inline typename std::basic_string<TChar, TCharTraits, TAlloc>::size_type
 length(std::basic_string<TChar, TCharTraits, TAlloc> const & me);
 
+// Needed for std::basic_string.
+template <typename TContainer, typename TValue>
+inline void appendValue(TContainer SEQAN_FORWARD_ARG me, TValue SEQAN_FORWARD_CARG val);
+
 /*!
  * @macro SEQAN_HAS_ZLIB
  * @headerfile <seqan/stream.h>

--- a/include/seqan/sequence/adapt_std_string.h
+++ b/include/seqan/sequence/adapt_std_string.h
@@ -163,6 +163,21 @@ struct DefaultOverflowImplicit< std::basic_string<TChar, TCharTraits, TAlloc> >
 template <typename TChar, typename TCharTraits, typename TAlloc>
 struct IsSequence<std::basic_string<TChar, TCharTraits, TAlloc> > : True {};
 
+// ----------------------------------------------------------------------------
+// Metafunction Chunk
+// ----------------------------------------------------------------------------
+
+// Chunk interface for std::basic strings.
+template <typename TChar, typename TCharTraits, typename TAlloc, typename TSpec>
+struct Chunk<Iter<std::basic_string<TChar, TCharTraits, TAlloc>, AdaptorIterator<TChar*, TSpec> > >
+{
+    typedef typename Chunk<std::basic_string<TChar, TCharTraits, TAlloc> >::Type Type;
+};
+
+template <typename TChar, typename TCharTraits, typename TAlloc, typename TSpec>
+struct Chunk<Iter<std::basic_string<TChar, TCharTraits, TAlloc> const, AdaptorIterator<TChar*, TSpec> > > :
+    Chunk<Iter<std::basic_string<TChar, TCharTraits, TAlloc>, AdaptorIterator<TChar*, TSpec> > > {};
+
 // ===========================================================================
 // Functions
 // ===========================================================================

--- a/tests/seq_io/test_sequence_file.h
+++ b/tests/seq_io/test_sequence_file.h
@@ -107,7 +107,8 @@ SEQAN_DEFINE_TEST(test_seq_io_sequence_file_recognize_file_format_text_fastq)
 // Test reading with different interfaces.
 // ---------------------------------------------------------------------------
 
-SEQAN_DEFINE_TEST(test_seq_io_sequence_file_read_record_text_fasta)
+template <typename TId, typename TSeq>
+void testSeqIOSequenceFileReadRecordTextFasta()
 {
     // Build path to file.
     seqan::CharString filePath = SEQAN_PATH_TO_ROOT();
@@ -117,8 +118,8 @@ SEQAN_DEFINE_TEST(test_seq_io_sequence_file_read_record_text_fasta)
     SeqFileIn seqIO(toCString(filePath));
 
     // Check that the file type and format are set correctly.
-    seqan::CharString id;
-    seqan::Dna5String seq;
+    TId id;
+    TSeq seq;
 
     readRecord(id, seq, seqIO);
     SEQAN_ASSERT_EQ(id, "seq1");
@@ -133,6 +134,14 @@ SEQAN_DEFINE_TEST(test_seq_io_sequence_file_read_record_text_fasta)
     SEQAN_ASSERT_EQ(seq, "CCCCCCCC");
 
     SEQAN_ASSERT(atEnd(seqIO));
+}
+
+SEQAN_DEFINE_TEST(test_seq_io_sequence_file_read_record_text_fasta)
+{
+    testSeqIOSequenceFileReadRecordTextFasta<seqan::CharString, seqan::Dna5String>();
+    testSeqIOSequenceFileReadRecordTextFasta<std::string, std::string>();
+    testSeqIOSequenceFileReadRecordTextFasta<std::string, seqan::Dna5String>();
+    testSeqIOSequenceFileReadRecordTextFasta<seqan::CharString, std::string>();
 }
 
 SEQAN_DEFINE_TEST(test_seq_io_sequence_file_read_all_text_fasta)


### PR DESCRIPTION
Changes are:
   * Overloads the ```Chunk``` metafunction for ```std::basic_string``` to disable chunking when reading a file into this type.
   * Adds forward declaration for basic append value.
   * Adapts test.