### PR TITLE
[FIXES-#904] Fixes issue #904

### DIFF
--- a/include/seqan/stream/formatted_file.h
+++ b/include/seqan/stream/formatted_file.h
@@ -642,8 +642,9 @@ inline bool _open(FormattedFile<TFileFormat, TDirection, TSpec> & file,
 }
 
 template <typename TFileFormat, typename TDirection, typename TSpec, typename TStream>
-inline bool open(FormattedFile<TFileFormat, TDirection, TSpec> & file,
-                 TStream &stream)
+inline SEQAN_FUNC_ENABLE_IF(Is<StreamConcept<TStream> >, bool)
+open(FormattedFile<TFileFormat, TDirection, TSpec> & file,
+     TStream &stream)
 {
     return _open(file, stream, _mapFileFormatToCompressionFormat(file.format), False());
 }


### PR DESCRIPTION
Enables generic open function only if ```StreamConcept``` is fulfilled.
Otherwise ```char *``` are not converted to ```const char *``` as the generic ```TStream &``` is chosen by the compiler.