### PR TITLE
[FEATURE] Reboot of interval tree implementation.

### DIFF
--- a/demos/interval_tree_genome_region.cpp
+++ b/demos/interval_tree_genome_region.cpp
@@ -1,0 +1,66 @@
+// Demo for the updated interval trees with the GenomicRegion class
+// that implements the IntervalConcept.
+//
+// In this demo, we use Interval class with unsigned cargo and int position
+// type.
+
+#include <vector>
+
+#include <seqan/basic.h>
+#include <seqan/interval_tree.h>
+#include <seqan/sequence.h>
+#include <seqan/seq_io/genomic_region.h>
+#include <seqan/stream.h>
+
+using namespace seqan;
+
+int main()
+{
+    // Using vector here, but any container will do.
+    std::vector<GenomicRegion> intervals;
+    // Note that GenomicRegion parses 1-based coordinates.
+    intervals.push_back(GenomicRegion("chr1:10-20"));  // => [9,20)
+    intervals.push_back(GenomicRegion("chr1:15-25"));  // => [14,25)
+
+    // Build interval tree, not modifiable from here.
+    IntervalTree<GenomicRegion, Static> tree(intervals);
+
+    std::cout << "length(tree) == " << length(tree) << "\n\n";
+
+    // Query interval tree, results are iterators into the tree, each points at
+    // a TValue of the IntervalTree.  We are using vectors here, but any
+    // container will do.
+    typedef Iterator<IntervalTree<GenomicRegion, Static> const>::Type TIterator;
+
+    // point query
+    {
+        std::vector<TIterator> result;
+        findOverlappingWithPoint(tree, 15, result);
+        std::cout << "query for point 15\n"
+                  << "=>";
+        for (unsigned i = 0; i < result.size(); ++i)
+        {
+            CharString out;
+            result[i]->toString(out);
+            std::cout << " " << out;
+        }
+        std::cout << "\n\n";
+    }
+
+    // interval query
+    {
+        std::vector<TIterator> result;
+        findOverlappingWithInterval(tree, 20, 30, result);
+        std::cout << "query for interval [20, 30)\n"
+                  << "=>";
+        for (unsigned i = 0; i < result.size(); ++i)
+        {
+            CharString out;
+            result[i]->toString(out);
+            std::cout << " " << out;
+        }
+        std::cout << "\n\n";
+    }
+
+    return 0;
+}

--- a/demos/interval_tree_genome_region.cpp.stdout
+++ b/demos/interval_tree_genome_region.cpp.stdout
@@ -1,0 +1,8 @@
+length(tree) == 2
+
+query for point 15
+=> chr1:10-20 chr1:15-25
+
+query for interval [20, 30)
+=> chr1:15-25
+

--- a/demos/interval_tree_interval.cpp
+++ b/demos/interval_tree_interval.cpp
@@ -1,0 +1,57 @@
+// Demo for the updated interval trees with the Interval<> class.
+//
+// In this demo, we use Interval class with unsigned cargo and int position
+// type.
+
+#include <vector>
+
+#include <seqan/basic.h>
+#include <seqan/interval_tree.h>
+#include <seqan/sequence.h>
+#include <seqan/stream.h>
+
+using namespace seqan;
+
+int main()
+{
+    typedef Interval<unsigned, int> TInterval;
+
+    // Using vector here, but any container will do.
+    std::vector<TInterval > intervals;
+    intervals.push_back(TInterval(0, 10, 20));
+    intervals.push_back(TInterval(1, 15, 25));
+
+    // Build interval tree, not modifiable from here.
+    IntervalTree<Interval<unsigned, int>, Static> tree(intervals);
+
+    std::cout << "length(tree) == " << length(tree) << "\n\n";
+
+    // Query interval tree, results are iterators into the tree, each points at
+    // a TValue of the IntervalTree.  We are using vectors here, but any
+    // container will do.
+    typedef Iterator<IntervalTree<TInterval, Static> const>::Type TIterator;
+
+    // point query
+    {
+        std::vector<TIterator> result;
+        findOverlappingWithPoint(tree, 15, result);
+        std::cout << "query for point 15\n"
+                  << "=>";
+        for (unsigned i = 0; i < result.size(); ++i)
+            std::cout << " " << cargo(*result[i]);
+        std::cout << "\n\n";
+    }
+
+    // interval query
+    {
+        std::vector<TIterator> result;
+        findOverlappingWithInterval(tree, 20, 30, result);
+        std::cout << "query for interval [20, 30)\n"
+                  << "=>";
+        for (unsigned i = 0; i < result.size(); ++i)
+            std::cout << " " << cargo(*result[i]);
+        std::cout << "\n\n";
+    }
+
+    return 0;
+}

--- a/demos/interval_tree_interval.cpp
+++ b/demos/interval_tree_interval.cpp
@@ -14,10 +14,10 @@ using namespace seqan;
 
 int main()
 {
-    typedef Interval<unsigned, int> TInterval;
+    typedef IntervalWithCargo<unsigned, int> TInterval;
 
     // Using vector here, but any container will do.
-    std::vector<TInterval > intervals;
+    std::vector<TInterval> intervals;
     intervals.push_back(TInterval(0, 10, 20));
     intervals.push_back(TInterval(1, 15, 25));
 

--- a/demos/interval_tree_interval.cpp.stdout
+++ b/demos/interval_tree_interval.cpp.stdout
@@ -1,0 +1,8 @@
+length(tree) == 2
+
+query for point 15
+=> 0 1
+
+query for interval [20, 30)
+=> 1
+

--- a/include/seqan/align/gaps_iterator_array.h
+++ b/include/seqan/align/gaps_iterator_array.h
@@ -580,7 +580,7 @@ removeGaps(Iter<TGaps, GapsIterator<ArrayGaps> > const & it, TCount count)
     if (gaps._array[idx] == TArrayValue(0))
     {
         // No merging for leading and trailing gap.
-        if (idx == TArrayPos(0) || idx == TArrayPos(length(gaps._array) - 1))
+        if (idx != TArrayPos(0) && idx != TArrayPos(length(gaps._array) - 1))
         {
             gaps._array[idx - 1] += gaps._array[idx + 1];
             erase(gaps._array, idx, idx + 2);

--- a/include/seqan/align/normalize.h
+++ b/include/seqan/align/normalize.h
@@ -1,0 +1,378 @@
+// ==========================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ==========================================================================
+// Copyright (c) 2006-2015, Knut Reinert, FU Berlin
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ==========================================================================
+// Author: Manuel Holtgrewe <manuel.holtgrewe@fu-berlin.de>
+// ==========================================================================
+// Functions for the normalization of gaps in alignments.
+// ==========================================================================
+
+#ifndef SEQAN_INCLUDE_SEQAN_ALIGN_NORMALIZE_H_
+#define SEQAN_INCLUDE_SEQAN_ALIGN_NORMALIZE_H_
+
+#include <seqan/align.h>
+
+namespace seqan {
+
+// Helper type for normalizing pairwise alignments.
+
+template <typename TGapsH, typename TGapsV>
+class PairwiseAlignmentNormalizer_
+{
+    typedef typename Iterator<TGapsH, Standard>::Type TIteratorH;
+    typedef typename Iterator<TGapsV, Standard>::Type TIteratorV;
+
+public:
+    PairwiseAlignmentNormalizer_(TGapsH & gapsH, TGapsV & gapsV) :
+            gapsH(gapsH), gapsV(gapsV)
+    {
+        SEQAN_ASSERT_EQ(length(gapsH), length(gapsV));
+    }
+
+    bool run()
+    {
+        bool b1 = deleteAllGapsColumns();
+        bool b2 = removeNullifyingIndels();
+        bool b3 = leftAlignIndels();
+        return (b1 || b2 || b3);
+    }
+
+    // Remove columns that consist exclusively of gaps.
+    bool deleteAllGapsColumns()
+    {
+        bool anyChange = false;
+
+        // std::cerr << "GAPS H\t" << gapsH << "\n";
+        // std::cerr << "GAPS V\t" << gapsV << "\n";
+
+        unsigned posH = 0, posV = 0;
+        while (posH != length(gapsH))
+        {
+            if (isGap(gapsH, posH) && isGap(gapsV, posV))
+            {
+                anyChange = true;
+                unsigned n = std::min(countGaps(gapsH, posH), countGaps(gapsV, posV));
+                removeGaps(iter(gapsH, posH, Standard()), n);
+                removeGaps(iter(gapsV, posV, Standard()), n);
+            }
+            else
+            {
+                ++posH;
+                ++posV;
+            }
+        }
+
+        return anyChange;
+    }
+
+    // Remove consecutive columns having having an insertion XOR a deletion.
+    //
+    // Precondition: No all-gaps columns.
+    bool removeNullifyingIndels()
+    {
+        bool anyChange = false;
+        
+        // build list of operations (pseudo-CIGAR string)
+        std::vector<std::pair<char, unsigned> > ops;  // (op, num), op in ['I', 'D', 'M']
+        {
+            TIteratorH itH = begin(gapsH, Standard());
+            TIteratorV itV = begin(gapsV, Standard());
+
+            for (; itH != end(gapsH, Standard()); ++itH, ++itV)
+                if (!isGap(itH) && !isGap(itV))
+                {
+                    if (ops.empty() || ops.back().first != 'M')
+                        ops.push_back(std::make_pair('M', 1));
+                    else
+                        ops.back().second += 1;
+                }
+                else if (isGap(itH))
+                {
+                    if (ops.empty() || ops.back().first != 'I')
+                        ops.push_back(std::make_pair('I', 1));
+                    else
+                        ops.back().second += 1;
+                }
+                else if (isGap(itV))
+                {
+                    if (ops.empty() || ops.back().first != 'D')
+                        ops.push_back(std::make_pair('D', 1));
+                    else
+                        ops.back().second += 1;
+                }
+        }
+
+        // for (unsigned i = 0; i < ops.size(); ++i)
+        //     std::cerr << ops[i].first << "\t" << ops[i].second << "\n";
+
+        // Update ops to reflect the alignment we aim at.
+        for (unsigned i = 0, j = 1; j < ops.size(); ++i, ++j)
+        {
+            if ((ops[i].first == 'I' && ops[j].first == 'D') ||
+                (ops[i].first == 'D' && ops[j].first == 'I'))
+            {
+                if (ops[i].second == ops[j].second)
+                {
+                    anyChange = true;
+                    ops.erase(ops.begin() + j);
+                    ops[i].first = 'M';
+                }
+                else if (ops[i].second > ops[j].second)
+                {
+                    anyChange = true;
+                    ops[i].second -= ops[j].second;
+                    ops[j].first = 'M';
+                }
+                else
+                {
+                    anyChange = true;
+                    ops[j].second -= ops[i].second;
+                    ops[i].first = 'M';
+                }
+            }
+        }
+
+        // Apply ops to the alignment.
+        clearGaps(gapsH);
+        clearGaps(gapsV);
+        TIteratorH itH = begin(gapsH, Standard());
+        TIteratorV itV = begin(gapsV, Standard());
+
+        for (unsigned i = 0; i < ops.size(); ++i)
+        {
+            switch (ops[i].first)
+            {
+                case 'I':
+                    insertGaps(itH, ops[i].second);
+                    break;
+                case 'D':
+                    insertGaps(itV, ops[i].second);
+                    break;
+                case 'M':
+                    break;
+                default:
+                    SEQAN_FAIL("Invalid operation %c!", ops[i].first);
+            }
+            goFurther(itH, ops[i].second);
+            goFurther(itV, ops[i].second);
+        }
+
+        return anyChange;
+    }
+
+    // Shift indels to the left.
+    //
+    // Precondition: Normalized gaps.
+    //
+    // This is following the algorithm from
+    //
+    //   http://genome.sph.umich.edu/wiki/Variant_Normalization
+    bool leftAlignIndels()
+    {
+        bool anyChange = false;
+
+        unsigned minPos = 0;  // end pos of last gap
+        unsigned pos = 0;     // begin pos of next gap
+        unsigned posEnd = 0;  // end pos of next gap
+        while (minPos != length(gapsH))
+        {
+            // std::cerr << "H\t" << gapsH << "\n"
+            //           << "V\t" << gapsV << "\n"
+            //           << "length(gapsH) == " << length(gapsH) << "\n"
+            //           << "minPos == " << minPos << "\n"
+            //           << "\n";
+            
+            pos = minPos;
+
+            // forward to the next gap
+            while (pos < length(gapsH) && !isGap(gapsH, pos) && !isGap(gapsV, pos))
+                ++pos;
+            if (pos == length(gapsH))
+                break;
+            posEnd = pos;
+            if (isGap(gapsH, pos))
+            {
+                while (posEnd < length(gapsH) && isGap(gapsH, posEnd))
+                    ++posEnd;
+            }
+            else
+            {
+                while (posEnd < length(gapsV) && isGap(gapsV, posEnd))
+                    ++posEnd;
+            }
+            // shift gap to the left
+            unsigned sPos = pos, sPosEnd = posEnd;
+            if (isGap(gapsH, pos))
+            {
+                while (sPos > minPos && gapsV[sPos - 1] == gapsV[sPosEnd - 1])
+                {
+                    --sPos;
+                    --sPosEnd;
+                }
+                if (sPos != pos)  // any change
+                {
+                    anyChange = true;
+                    removeGaps(gapsH, pos, posEnd - pos);
+                    insertGaps(gapsH, sPos, posEnd - pos);
+                }
+            }
+            else
+            {
+                while (sPos > minPos && gapsH[sPos - 1] == gapsH[sPosEnd - 1])
+                {
+                    --sPos;
+                    --sPosEnd;
+                }
+                if (sPos != pos)  // any change
+                {
+                    anyChange = true;
+                    removeGaps(gapsV, pos, posEnd - pos);
+                    insertGaps(gapsV, sPos, posEnd - pos);
+                }
+            }
+            minPos = sPos + (posEnd - pos);
+        }
+
+        // Iterate until there is no change any more, but return indicator flag from first iteration.
+        if (anyChange)
+            leftAlignIndels();
+        return anyChange;
+    }
+
+private:
+    TGapsH & gapsH;
+    TGapsV & gapsV;
+};
+
+// ---------------------------------------------------------------------------
+// Function removeAllGapsColumns()
+// ---------------------------------------------------------------------------
+
+/*!
+ * @fn removeAllGapsColumns
+ * @headerfile <seqan/align/normalize.h>
+ * @brief Remove columns that only have gaps from pairwise alignments.
+ *
+ * @signature bool removeAllGapsColumns(gapsH, gapsV);
+ * @signature bool removeAllGapsColumns(align);
+ *
+ * @param[in,out] gapsH @link Gaps @endlink object for the first sequence.
+ * @param[in,out] gapsV @link Gaps @endlink object for the second sequence.
+ * @param[in,out] align @link Align @endlink object with the pairwise alignment.
+ * @return        bool  <tt>true</tt> if any columns were removed.
+ */
+
+template <typename TSeqH, typename TSpecH, typename TSeqV, typename TSpecV>
+bool removeAllGapsColumns(Gaps<TSeqH, TSpecH> & gapsH, Gaps<TSeqV, TSpecV> & gapsV)
+{
+    PairwiseAlignmentNormalizer_<Gaps<TSeqH, TSpecH>, Gaps<TSeqV, TSpecV> > normalizer(gapsH, gapsV);
+    return normalizer.deleteAllGapsColumns();
+}
+
+template <typename TSeq, typename TSpec>
+bool removeAllGapsColumns(Align<TSeq, TSpec> & align)
+{
+    return removeAllGapsColumns(row(align, 0), row(align, 1));
+}
+
+// ---------------------------------------------------------------------------
+// Function removeNullifyingIndels()
+// ---------------------------------------------------------------------------
+
+/*!
+ * @fn removeNullifyingIndels
+ * @headerfile <seqan/align/normalize.h>
+ * @brief Compactify alignment for adjacent insertion/deletion columns.
+ *
+ * @signature bool removeNullifyingIndels(gapsH, gapsV);
+ * @signature bool removeNullifyingIndels(align);
+ *
+ * @param[in,out] gapsH @link Gaps @endlink object for the first sequence.
+ * @param[in,out] gapsV @link Gaps @endlink object for the second sequence.
+ * @param[in,out] align @link Align @endlink object with the pairwise alignment.
+ * @return        bool  <tt>true</tt> if any shifting took place.
+ *
+ * A precondition for this function is that there are no all-gaps columns (see @link removeAllGapsColumns @endlink.
+ *
+ * The alignment is considered from the left to the right and in each case, the flanking insertion/deletion (or
+ * deletion/insertion) stretch is compressed as far as possible.
+ */
+
+template <typename TSeqH, typename TSpecH, typename TSeqV, typename TSpecV>
+bool removeNullifyingIndels(Gaps<TSeqH, TSpecH> & gapsH, Gaps<TSeqV, TSpecV> & gapsV)
+{
+    PairwiseAlignmentNormalizer_<Gaps<TSeqH, TSpecH>, Gaps<TSeqV, TSpecV> > normalizer(gapsH, gapsV);
+    return normalizer.removeNullifyingIndels();
+}
+
+template <typename TSeq, typename TSpec>
+bool removeNullifyingIndels(Align<TSeq, TSpec> & align)
+{
+    return removeNullifyingIndels(row(align, 0), row(align, 1));
+}
+
+// ---------------------------------------------------------------------------
+// Function leftAlignIndels()
+// ---------------------------------------------------------------------------
+
+/*!
+ * @fn leftAlignIndels
+ * @headerfile <seqan/align/normalize.h>
+ * @brief Left-shift indels in pairwise alignments.
+ *
+ * @signature bool leftAlignIndels(gapsH, gapsV);
+ * @signature bool leftAlignIndels(align);
+ *
+ * @param[in,out] gapsH @link Gaps @endlink object for the first sequence.
+ * @param[in,out] gapsV @link Gaps @endlink object for the second sequence.
+ * @param[in,out] align @link Align @endlink object with the pairwise alignment.
+ * @return        bool  <tt>true</tt> if any left-shifting took place.
+ *
+ * A precondition for this function is that there are no all-gaps columns (see @link removeAllGapsColumns @endlink.
+ *
+ * Note that this can lead to new leading and trailing gaps, thus analyze the resulting gapsH and gapsV.
+ */
+
+template <typename TSeqH, typename TSpecH, typename TSeqV, typename TSpecV>
+bool leftAlignIndels(Gaps<TSeqH, TSpecH> & gapsH, Gaps<TSeqV, TSpecV> & gapsV)
+{
+    PairwiseAlignmentNormalizer_<Gaps<TSeqH, TSpecH>, Gaps<TSeqV, TSpecV> > normalizer(gapsH, gapsV);
+    return normalizer.leftAlignIndels();
+}
+
+template <typename TSeq, typename TSpec>
+bool leftAlignIndels(Align<TSeq, TSpec> & align)
+{
+    return leftAlignIndels(row(align, 0), row(align, 1));
+}
+
+}  // namespace seqan
+
+#endif  // #ifndef SEQAN_INCLUDE_SEQAN_ALIGN_NORMALIZE_H_

--- a/include/seqan/interval_tree.h
+++ b/include/seqan/interval_tree.h
@@ -1,0 +1,46 @@
+// ==========================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ==========================================================================
+// Copyright (c) 2006-2015, Knut Reinert, FU Berlin
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ==========================================================================
+// Author: Manuel Holtgrewe <manuel.holtgrewe@fu-berlin.de>
+// ==========================================================================
+// Facade header for module interval_tree.
+// ==========================================================================
+
+#ifndef INCLUDE_SEQAN_INTERVAL_TREE_H_
+#define INCLUDE_SEQAN_INTERVAL_TREE_H_
+
+#include <seqan/interval_tree/base_interval_tree.h>
+#include <seqan/interval_tree/static_interval_tree.h>
+#include <seqan/interval_tree/static_interval_tree_iterator.h>
+#include <seqan/interval_tree/interval.h>
+#include <seqan/interval_tree/interval_tree_entry.h>
+
+#endif  // INCLUDE_SEQAN_INTERVAL_TREE_H_

--- a/include/seqan/interval_tree.h
+++ b/include/seqan/interval_tree.h
@@ -40,6 +40,8 @@
 #include <seqan/interval_tree/base_interval_tree.h>
 #include <seqan/interval_tree/static_interval_tree.h>
 #include <seqan/interval_tree/static_interval_tree_iterator.h>
+#include <seqan/interval_tree/base_genomic_interval_tree.h>
+#include <seqan/interval_tree/static_genomic_interval_tree.h>
 #include <seqan/interval_tree/interval.h>
 #include <seqan/interval_tree/interval_tree_entry.h>
 

--- a/include/seqan/interval_tree/base_genomic_interval_tree.h
+++ b/include/seqan/interval_tree/base_genomic_interval_tree.h
@@ -32,8 +32,8 @@
 // Author: Manuel Holtgrewe <manuel.holtgrewe@fu-berlin.de>
 // ==========================================================================
 
-#ifndef INCLUDE_SEQAN_INTERVAL_TREE_BASE_INTERVAL_TREE_H_
-#define INCLUDE_SEQAN_INTERVAL_TREE_BASE_INTERVAL_TREE_H_
+#ifndef INCLUDE_SEQAN_INTERVAL_TREE_BASE_GENOMIC_INTERVAL_TREE_H_
+#define INCLUDE_SEQAN_INTERVAL_TREE_BASE_GENOMIC_INTERVAL_TREE_H_
 
 #include <seqan/basic.h>
 
@@ -51,23 +51,25 @@ namespace seqan
 // ============================================================================
 
 // ----------------------------------------------------------------------------
-// Class IntervalTree
+// Class GenomicIntervalTree
 // ----------------------------------------------------------------------------
 
 /*!
- * @class IntervalTree
+ * @class GenomicIntervalTree
  * @implements ContainerConcept
  * @headerfile <seqan/interval_tree.h>
- * @brief Data structure for fast range queries on a set of intervals.
+ * @brief Data structure for fast range queries on a set of genomic intervals.
  *
  * @signature template <typename TValue, typename TSpec>
- *            class IntervalTree;
+ *            class GenomicIntervalTree;
  *
  * @tparam TValue Value to store in the tree.
  * @tparam TSpec  Specializing tag.
+ *
+ * @see IntervalTree
  */
 template <typename TValue, typename TSpec>
-class IntervalTree;
+class GenomicIntervalTree;
 
 // ============================================================================
 // Metafunctions
@@ -79,18 +81,18 @@ class IntervalTree;
 
 /**
  * @mfn IntervalTree#Position
- * @brief The position type of the <tt>IntervalTree</tt>, forwards to <tt>Position&lt;TValue&gt;</tt>.
+ * @brief The position type of the <tt>GenomicIntervalTree</tt>.
  */
 template <typename TValue, typename TSpec>
-struct Position<IntervalTree<TValue, TSpec> >
+struct Position<GenomicIntervalTree<TValue, TSpec> >
 {
-    typedef typename Position<TValue>::Type Type;
+    typedef Pair<int, typename Position<TValue>::Type> Type;
 };
 
 template <typename TValue, typename TSpec>
-struct Position<IntervalTree<TValue, TSpec> const>
+struct Position<GenomicIntervalTree<TValue, TSpec> const>
 {
-    typedef typename Position<TValue const>::Type Type;
+    typedef Pair<int, typename Position<TValue const>::Type> Type;
 };
 
 // ----------------------------------------------------------------------------
@@ -98,8 +100,8 @@ struct Position<IntervalTree<TValue, TSpec> const>
 // ----------------------------------------------------------------------------
 
 /**
- * @mfn IntervalTree#Value
- * @brief The value type of the <tt>IntervalTree</tt>.
+ * @mfn GenomicIntervalTree#Value
+ * @brief The value type of the <tt>GenomicIntervalTree</tt>.
  */
 // TODO(holtgrew): Redefined in legacy module.
 // template <typename TValue, typename TSpec>
@@ -120,4 +122,4 @@ struct Position<IntervalTree<TValue, TSpec> const>
 
 }  // namespace seqan
 
-#endif  // INCLUDE_SEQAN_INTERVAL_TREE_BASE_INTERVAL_TREE_H_
+#endif  // INCLUDE_SEQAN_INTERVAL_TREE_BASE_GENOMIC_INTERVAL_TREE_H_

--- a/include/seqan/interval_tree/base_interval_tree.h
+++ b/include/seqan/interval_tree/base_interval_tree.h
@@ -1,0 +1,125 @@
+// ==========================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ==========================================================================
+// Copyright (c) 2006-2015, Knut Reinert, FU Berlin
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ==========================================================================
+// Author: Manuel Holtgrewe <manuel.holtgrewe@fu-berlin.de>
+// ==========================================================================
+// Facade header for module interval_tree.
+// ==========================================================================
+
+#ifndef INCLUDE_SEQAN_INTERVAL_TREE_BASE_INTERVAL_TREE_H_
+#define INCLUDE_SEQAN_INTERVAL_TREE_BASE_INTERVAL_TREE_H_
+
+#include <seqan/basic.h>
+
+namespace seqan
+{
+
+// ============================================================================
+// Forwards
+// ============================================================================
+
+struct Static_;
+typedef Tag<Static_> Static;
+
+// ============================================================================
+// Tags, Classes, Enums
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// Class IntervalTree
+// ----------------------------------------------------------------------------
+
+/*!
+ * @class IntervalTree
+ * @implements ContainerConcept
+ * @headerfile <seqan/interval_tree.h>
+ * @brief Data structure for fast range queries on a set of intervals.
+ *
+ * @signature template <typename TValue, typename TSpec>
+ *            class IntervalTree;
+ *
+ * @tparam TValue Value to store in the tree.
+ * @tparam TSpec  Specializing tag.
+ */
+template <typename TValue, typename TSpec = Static>
+class IntervalTree;
+
+// ============================================================================
+// Metafunctions
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// Metafunction Position
+// ----------------------------------------------------------------------------
+
+/**
+ * @mfn IntervalTree#Position
+ * @brief The position type of the <tt>IntervalTree</tt>, forwards to <tt>Position&lt;TValue&gt;</tt>.
+ */
+template <typename TValue, typename TSpec>
+struct Position<IntervalTree<TValue, TSpec> >
+{
+    typedef typename Position<TValue>::Type Type;
+};
+
+template <typename TValue, typename TSpec>
+struct Position<IntervalTree<TValue, TSpec> const>
+{
+    typedef typename Position<TValue const>::Type Type;
+};
+
+// ----------------------------------------------------------------------------
+// Metafunction Value
+// ----------------------------------------------------------------------------
+
+/**
+ * @mfn IntervalTree#Value
+ * @brief The value type of the <tt>IntervalTree</tt>.
+ */
+template <typename TValue, typename TSpec>
+struct Value<IntervalTree<TValue, TSpec> >
+{
+    typedef TValue Type;
+};
+
+template <typename TValue, typename TSpec>
+struct Value<IntervalTree<TValue, TSpec> const>
+{
+    typedef TValue Type;
+};
+
+// ============================================================================
+// Functions
+// ============================================================================
+
+}  // namespace seqan
+
+#endif  // INCLUDE_SEQAN_INTERVAL_TREE_BASE_INTERVAL_TREE_H_

--- a/include/seqan/interval_tree/base_interval_tree.h
+++ b/include/seqan/interval_tree/base_interval_tree.h
@@ -39,15 +39,14 @@
 
 #include <seqan/basic.h>
 
+#include <seqan/misc/interval_tree.h>
+
 namespace seqan
 {
 
 // ============================================================================
 // Forwards
 // ============================================================================
-
-struct Static_;
-typedef Tag<Static_> Static;
 
 // ============================================================================
 // Tags, Classes, Enums
@@ -69,7 +68,7 @@ typedef Tag<Static_> Static;
  * @tparam TValue Value to store in the tree.
  * @tparam TSpec  Specializing tag.
  */
-template <typename TValue, typename TSpec = Static>
+template <typename TValue, typename TSpec>
 class IntervalTree;
 
 // ============================================================================
@@ -104,17 +103,18 @@ struct Position<IntervalTree<TValue, TSpec> const>
  * @mfn IntervalTree#Value
  * @brief The value type of the <tt>IntervalTree</tt>.
  */
-template <typename TValue, typename TSpec>
-struct Value<IntervalTree<TValue, TSpec> >
-{
-    typedef TValue Type;
-};
+// TODO(holtgrew): Redefined in legacy module.
+// template <typename TValue, typename TSpec>
+// struct Value<IntervalTree<TValue, TSpec> >
+// {
+//     typedef TValue Type;
+// };
 
-template <typename TValue, typename TSpec>
-struct Value<IntervalTree<TValue, TSpec> const>
-{
-    typedef TValue Type;
-};
+// template <typename TValue, typename TSpec>
+// struct Value<IntervalTree<TValue, TSpec> const>
+// {
+//     typedef TValue Type;
+// };
 
 // ============================================================================
 // Functions

--- a/include/seqan/interval_tree/interval.h
+++ b/include/seqan/interval_tree/interval.h
@@ -1,0 +1,175 @@
+// ==========================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ==========================================================================
+// Copyright (c) 2006-2015, Knut Reinert, FU Berlin
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ==========================================================================
+// Author: Manuel Holtgrewe <manuel.holtgrewe@fu-berlin.de>
+// ==========================================================================
+// Facade header for module interval_tree.
+// ==========================================================================
+
+#ifndef INCLUDE_SEQAN_INTERVAL_TREE_INTERVAL_H_
+#define INCLUDE_SEQAN_INTERVAL_TREE_INTERVAL_H_
+
+#include <seqan/basic.h>
+
+namespace seqan
+{
+
+// ============================================================================
+// Forwards
+// ============================================================================
+
+// ============================================================================
+// Tags, Classes, Enums
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// Class Interval
+// ----------------------------------------------------------------------------
+
+/*!
+ * @class IntervalConcept
+ * @brief Concept for half-open intervals.
+ */
+// beginPos()
+// endPos()
+// cargo()
+
+/*!
+ * @class Interval
+ * @headerfile <seqan/interval_tree.h>
+ * @implements IntervalConcept
+ * @brief Half-open interval.
+ *
+ * @signature template <typename TCargo, typename TPos>
+ *            class Interval;
+ *
+ * @tparam TCargo Type of the cargo  to store.
+ * @tparam TPos   Type to use for positions.
+ */
+template <typename TCargo, typename TPos>
+class Interval
+{
+public:
+    TCargo cargo;
+    TPos beginPos;
+    TPos endPos;
+
+    Interval() : cargo(), beginPos(), endPos()
+    {}
+
+    Interval(TCargo const & cargo, TPos beginPos, TPos endPos) :
+            cargo(cargo), beginPos(beginPos), endPos(endPos)
+    {}
+};
+
+// ============================================================================
+// Metafunctions
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// Metafunction Position
+// ----------------------------------------------------------------------------
+
+template <typename TCargo, typename TPos>
+struct Position<Interval<TCargo, TPos> >
+{
+    typedef TPos Type;
+};
+
+template <typename TCargo, typename TPos>
+struct Position<Interval<TCargo, TPos> const>
+{
+    typedef TPos Type;
+};
+
+// ----------------------------------------------------------------------------
+// Metafunction Value
+// ----------------------------------------------------------------------------
+
+template <typename TCargo, typename TPos>
+struct Value<Interval<TCargo, TPos> >
+{
+    typedef TCargo Type;
+};
+
+template <typename TCargo, typename TPos>
+struct Value<Interval<TCargo, TPos> const>
+{
+    typedef TCargo Type;
+};
+
+// ----------------------------------------------------------------------------
+// Metafunction Reference
+// ----------------------------------------------------------------------------
+
+template <typename TReference, typename TPos>
+struct Reference<Interval<TReference, TPos> >
+{
+    typedef TReference & Type;
+};
+
+template <typename TReference, typename TPos>
+struct Reference<Interval<TReference, TPos> const>
+{
+    typedef TReference const & Type;
+};
+
+// ============================================================================
+// Functions
+// ============================================================================
+
+template <typename TCargo, typename TPos>
+TPos beginPos(Interval<TCargo, TPos> const & interval)
+{
+    return interval.beginPos;
+}
+
+template <typename TCargo, typename TPos>
+TPos endPos(Interval<TCargo, TPos> const & interval)
+{
+    return interval.endPos;
+}
+
+template <typename TCargo, typename TPos>
+typename Reference<Interval<TCargo, TPos> const>::Type cargo(Interval<TCargo, TPos> const & interval)
+{
+    return interval.cargo;
+}
+
+template <typename TCargo, typename TPos>
+typename Reference<Interval<TCargo, TPos> >::Type cargo(Interval<TCargo, TPos> & interval)
+{
+    return interval.cargo;
+}
+
+}  // namespace seqan
+
+#endif  // INCLUDE_SEQAN_INTERVAL_TREE_INTERVAL_H_

--- a/include/seqan/interval_tree/interval.h
+++ b/include/seqan/interval_tree/interval.h
@@ -51,7 +51,7 @@ namespace seqan
 // ============================================================================
 
 // ----------------------------------------------------------------------------
-// Class Interval
+// Class IntervalWithCargo
 // ----------------------------------------------------------------------------
 
 /*!
@@ -63,29 +63,29 @@ namespace seqan
 // cargo()
 
 /*!
- * @class Interval
+ * @class IntervalWithCargo
  * @headerfile <seqan/interval_tree.h>
  * @implements IntervalConcept
  * @brief Half-open interval.
  *
  * @signature template <typename TCargo, typename TPos>
- *            class Interval;
+ *            class IntervalWithCargo;
  *
  * @tparam TCargo Type of the cargo  to store.
  * @tparam TPos   Type to use for positions.
  */
 template <typename TCargo, typename TPos>
-class Interval
+class IntervalWithCargo
 {
 public:
     TCargo cargo;
     TPos beginPos;
     TPos endPos;
 
-    Interval() : cargo(), beginPos(), endPos()
+    IntervalWithCargo() : cargo(), beginPos(), endPos()
     {}
 
-    Interval(TCargo const & cargo, TPos beginPos, TPos endPos) :
+    IntervalWithCargo(TCargo const & cargo, TPos beginPos, TPos endPos) :
             cargo(cargo), beginPos(beginPos), endPos(endPos)
     {}
 };
@@ -99,13 +99,13 @@ public:
 // ----------------------------------------------------------------------------
 
 template <typename TCargo, typename TPos>
-struct Position<Interval<TCargo, TPos> >
+struct Position<IntervalWithCargo<TCargo, TPos> >
 {
     typedef TPos Type;
 };
 
 template <typename TCargo, typename TPos>
-struct Position<Interval<TCargo, TPos> const>
+struct Position<IntervalWithCargo<TCargo, TPos> const>
 {
     typedef TPos Type;
 };
@@ -115,13 +115,13 @@ struct Position<Interval<TCargo, TPos> const>
 // ----------------------------------------------------------------------------
 
 template <typename TCargo, typename TPos>
-struct Value<Interval<TCargo, TPos> >
+struct Value<IntervalWithCargo<TCargo, TPos> >
 {
     typedef TCargo Type;
 };
 
 template <typename TCargo, typename TPos>
-struct Value<Interval<TCargo, TPos> const>
+struct Value<IntervalWithCargo<TCargo, TPos> const>
 {
     typedef TCargo Type;
 };
@@ -131,13 +131,13 @@ struct Value<Interval<TCargo, TPos> const>
 // ----------------------------------------------------------------------------
 
 template <typename TReference, typename TPos>
-struct Reference<Interval<TReference, TPos> >
+struct Reference<IntervalWithCargo<TReference, TPos> >
 {
     typedef TReference & Type;
 };
 
 template <typename TReference, typename TPos>
-struct Reference<Interval<TReference, TPos> const>
+struct Reference<IntervalWithCargo<TReference, TPos> const>
 {
     typedef TReference const & Type;
 };
@@ -147,25 +147,25 @@ struct Reference<Interval<TReference, TPos> const>
 // ============================================================================
 
 template <typename TCargo, typename TPos>
-TPos beginPos(Interval<TCargo, TPos> const & interval)
+TPos beginPos(IntervalWithCargo<TCargo, TPos> const & interval)
 {
     return interval.beginPos;
 }
 
 template <typename TCargo, typename TPos>
-TPos endPos(Interval<TCargo, TPos> const & interval)
+TPos endPos(IntervalWithCargo<TCargo, TPos> const & interval)
 {
     return interval.endPos;
 }
 
 template <typename TCargo, typename TPos>
-typename Reference<Interval<TCargo, TPos> const>::Type cargo(Interval<TCargo, TPos> const & interval)
+typename Reference<IntervalWithCargo<TCargo, TPos> const>::Type cargo(IntervalWithCargo<TCargo, TPos> const & interval)
 {
     return interval.cargo;
 }
 
 template <typename TCargo, typename TPos>
-typename Reference<Interval<TCargo, TPos> >::Type cargo(Interval<TCargo, TPos> & interval)
+typename Reference<IntervalWithCargo<TCargo, TPos> >::Type cargo(IntervalWithCargo<TCargo, TPos> & interval)
 {
     return interval.cargo;
 }

--- a/include/seqan/interval_tree/interval_tree_entry.h
+++ b/include/seqan/interval_tree/interval_tree_entry.h
@@ -72,7 +72,7 @@ public:
 
     template <typename TPos> bool _allLeftOf(TPos point) const
     {
-        return (maxEnd < (TPosition_)point);
+        return (maxEnd <= (TPosition_)point);
     }
 
     template <typename TPos> bool _isLeftOf(TPos point) const

--- a/include/seqan/interval_tree/interval_tree_entry.h
+++ b/include/seqan/interval_tree/interval_tree_entry.h
@@ -1,0 +1,133 @@
+// ==========================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ==========================================================================
+// Copyright (c) 2006-2015, Knut Reinert, FU Berlin
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ==========================================================================
+// Author: Manuel Holtgrewe <manuel.holtgrewe@fu-berlin.de>
+// ==========================================================================
+// Facade header for module interval_tree.
+// ==========================================================================
+
+#ifndef INCLUDE_SEQAN_INTERVAL_TREE_INTERVAL_TREE_ENTRY_H_
+#define INCLUDE_SEQAN_INTERVAL_TREE_INTERVAL_TREE_ENTRY_H_
+
+#include <seqan/basic.h>
+
+namespace seqan
+{
+
+// ============================================================================
+// Forwards
+// ============================================================================
+
+// ============================================================================
+// Tags, Classes, Enums
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// Class IntervalTreeEntry
+// ----------------------------------------------------------------------------
+
+template <typename TValue>
+class IntervalTreeEntry
+{
+    typedef typename Position<TValue>::Type TPosition_;
+
+public:
+
+    // The value wrapped in the entry. Must follow the IntervalConcept concept.
+    TValue value;
+    // The maximal end position of this nodes and all of its children.
+    TPosition_ maxEnd;
+
+    IntervalTreeEntry() : value(), maxEnd() {}
+
+    IntervalTreeEntry(TValue value, TPosition_ maxEnd) : value(value), maxEnd(maxEnd) {}
+
+    template <typename TPos> bool _allLeftOf(TPos point) const
+    {
+        return (maxEnd < (TPosition_)point);
+    }
+
+    template <typename TPos> bool _isLeftOf(TPos point) const
+    {
+        return (endPos(value) <= (TPosition_)point);
+    }
+
+    template <typename TPos> bool _isRightOf(TPos point) const
+    {
+        return ((TPosition_)point < beginPos(value));
+    }
+
+    template <typename TPos> bool _contains(TPos point) const
+    {
+        return (beginPos(value) <= (TPosition_)point && (TPosition_)point < endPos(value));
+    }
+
+    template <typename TPos> bool _overlapsWith(TPos posBegin, TPos posEnd) const
+    {
+        return ((TPosition_)posBegin < endPos(value) && beginPos(value) < (TPosition_)posEnd);
+    }
+};
+
+// ============================================================================
+// Metafunctions
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// Metafunction Position
+// ----------------------------------------------------------------------------
+
+/**
+ * @mfn IntervalTreeEntry#Position
+ * @brief The position type of the <tt>IntervalTreeEntry</tt>, forwards to <tt>Position&lt;TValue&gt;</tt>.
+ *
+ * @signature Position<TIntervalTreeEntry>::Type;
+ *
+ * @tparam TIntervalTreeEntry The IntervalTreeEntry to query for its position type.
+ */
+template <typename TValue>
+struct Position<IntervalTreeEntry<TValue> >
+{
+    typedef typename Position<TValue>::Type Type;
+};
+
+template <typename TValue>
+struct Position<IntervalTreeEntry<TValue> const>
+{
+    typedef typename Position<TValue const>::Type Type;
+};
+
+// ============================================================================
+// Functions
+// ============================================================================
+
+}  // namespace seqan
+
+#endif  // INCLUDE_SEQAN_INTERVAL_TREE_INTERVAL_TREE_ENTRY_H_

--- a/include/seqan/interval_tree/static_genomic_interval_tree.h
+++ b/include/seqan/interval_tree/static_genomic_interval_tree.h
@@ -1,0 +1,340 @@
+// ==========================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ==========================================================================
+// Copyright (c) 2006-2015, Knut Reinert, FU Berlin
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ==========================================================================
+// Author: Manuel Holtgrewe <manuel.holtgrewe@fu-berlin.de>
+// ==========================================================================
+// Static, immutable version of interval tree.
+// ==========================================================================
+
+// TODO(holtgrewe): Implement neighbor search in case of no overlapping intervals.
+
+#ifndef INCLUDE_SEQAN_INTERVAL_TREE_STATIC_GENOMIC_INTERVAL_TREE_H_
+#define INCLUDE_SEQAN_INTERVAL_TREE_STATIC_GENOMIC_INTERVAL_TREE_H_
+
+#include <algorithm>
+#include <vector>
+#include <utility>
+
+#include <seqan/basic.h>
+#include <seqan/sequence.h>
+
+#include "base_genomic_interval_tree.h"
+#include "interval_tree_entry.h"
+#include "static_interval_tree.h"
+#include "static_genomic_interval_tree_iterator.h"
+
+namespace seqan
+{
+
+// ============================================================================
+// Forwards
+// ============================================================================
+
+// ============================================================================
+// Tags, Classes, Enums
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// Class StaticGenomicGenomicIntervalTree
+// ----------------------------------------------------------------------------
+
+// Tags for specializing GenomicIntervalTree<>.
+
+struct Static_;
+typedef Tag<Static_> Static;
+
+/*!
+ * @class StaticGenomicGenomicIntervalTree
+ * @headerfile <seqan/interval_tree.h>
+ * @brief Static @link GenomicIntervalTree @endlink implementation.
+ *
+ * @signature template <typename TValue>
+ *            class GenomicIntervalTree<TValue, Static>;
+ *
+ * @tparam TValue Value to store in the tree.
+ * @tparam TSpec  Specializing tag.
+ *
+ * The implementation is based on Cormen's augmented binary search trees as described in <a
+ * href="http://en.wikipedia.org/wiki/Interval_tree#Augmented_tree">this Wikipedia article</a>.
+ */
+template <typename TValue>
+class GenomicIntervalTree<TValue, Static>
+{
+public:
+    GenomicIntervalTree() : totalSize(0) {}
+
+    template <typename TContainer>
+    GenomicIntervalTree(TContainer const & container)
+    {
+        initialize(container);
+    }
+
+    std::vector<IntervalTree<TValue, Static> > contigTrees;
+    size_t totalSize;
+
+    void updateTotalSize()
+    {
+        totalSize = 0;
+        for (unsigned i = 0; i < contigTrees.size(); ++i)
+            totalSize += length(contigTrees[i]);
+    }
+
+    template <typename TContainer> void initialize(TContainer const & container);
+};
+
+template <typename TValue>
+template <typename TContainer>
+void GenomicIntervalTree<TValue, Static>::initialize(TContainer const & container)
+{
+    contigTrees.resize(length(container));
+    for (unsigned i = 0; i < length(container); ++i)
+        contigTrees[i].initialize(container[i]);
+
+    updateTotalSize();
+}
+
+// ============================================================================
+// Metafunctions
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// Metafunction Size
+// ----------------------------------------------------------------------------
+
+/**
+ * @mfn GenomicIntervalTree#Size
+ * @brief The size type of the <tt>GenomicIntervalTree</tt>.
+ */
+
+template <typename TValue>
+struct Size<GenomicIntervalTree<TValue, Static> >
+{
+    typedef typename std::vector<TValue>::size_type Type;
+};
+
+template <typename TValue>
+struct Size<GenomicIntervalTree<TValue, Static> const>
+{
+    typedef typename std::vector<TValue>::size_type Type;
+};
+
+// ----------------------------------------------------------------------------
+// Metafunction Iterator
+// ----------------------------------------------------------------------------
+
+/**
+ * @mfn GenomicIntervalTree#Iterator
+ * @brief The iterator type of the <tt>GenomicIntervalTree</tt>.
+ */
+
+template <typename TValue, typename TIterSpec>
+struct Iterator<GenomicIntervalTree<TValue, Static>, TIterSpec>
+{
+    typedef Iter<GenomicIntervalTree<TValue, Static>, void> Type;
+};
+
+template <typename TValue, typename TIterSpec>
+struct Iterator<GenomicIntervalTree<TValue, Static> const, TIterSpec>
+{
+    typedef Iter<GenomicIntervalTree<TValue, Static> const, void> Type;
+};
+
+// ============================================================================
+// Functions
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// Function build()
+// ----------------------------------------------------------------------------
+
+template <typename TValue, typename TPos, typename TContainer>
+void build(GenomicIntervalTree<TValue, Static> & tree,
+           TContainer const & values)
+{
+    tree.initialize(values);
+    tree.updateTotalSize();
+}
+
+template <typename TValue, typename TPos, typename TContainer>
+void build(GenomicIntervalTree<TValue, Static> & tree,
+           TContainer const & values,
+           int rID)
+{
+    if (rID > (int)tree.contigTrees.size())
+        tree.contigTrees[rID].initialize(values);
+    tree.updateTotalSize();
+}
+
+// ----------------------------------------------------------------------------
+// Function length()
+// ----------------------------------------------------------------------------
+
+// TODO(holtgrewe): Get rid of non-const length once all such functions are removed
+template <typename TValue>
+typename Size<GenomicIntervalTree<TValue, Static> >::Type
+length(GenomicIntervalTree<TValue, Static> const & tree)
+{
+    return tree.totalSize;
+}
+
+template <typename TValue>
+typename Size<GenomicIntervalTree<TValue, Static> >::Type
+length(GenomicIntervalTree<TValue, Static> & tree)
+{
+    return tree.totalSize;
+}
+
+// ----------------------------------------------------------------------------
+// Function begin()
+// ----------------------------------------------------------------------------
+
+// TODO(holtgrewe): For some reason, using TIterSpec template parameter instead of Standard/Rooted created ambiguous function calls and references to missing class specialization of IteratorDefaultImp_, same below for end().
+
+template <typename TValue>
+typename Iterator<GenomicIntervalTree<TValue, Static> const, Standard>::Type
+begin(GenomicIntervalTree<TValue, Static> const & tree, Standard const & /*tag*/)
+{
+    return typename Iterator<GenomicIntervalTree<TValue, Static> const, Standard>::Type(tree, true);
+}
+
+template <typename TValue>
+typename Iterator<GenomicIntervalTree<TValue, Static>, Standard>::Type
+begin(GenomicIntervalTree<TValue, Static> & tree, Standard const & /*tag*/)
+{
+    return typename Iterator<GenomicIntervalTree<TValue, Static>, Standard>::Type(tree, true);
+}
+
+template <typename TValue>
+typename Iterator<GenomicIntervalTree<TValue, Static> const, Rooted>::Type
+begin(GenomicIntervalTree<TValue, Static> const & tree, Rooted const & /*tag*/)
+{
+    return typename Iterator<GenomicIntervalTree<TValue, Static> const, Standard>::Type(tree, true);
+}
+
+template <typename TValue>
+typename Iterator<GenomicIntervalTree<TValue, Static>, Rooted>::Type
+begin(GenomicIntervalTree<TValue, Static> & tree, Rooted const & /*tag*/)
+{
+    return typename Iterator<GenomicIntervalTree<TValue, Static>, Standard>::Type(tree, true);
+}
+
+// ----------------------------------------------------------------------------
+// Function end()
+// ----------------------------------------------------------------------------
+
+template <typename TValue>
+typename Iterator<GenomicIntervalTree<TValue, Static> const, Standard>::Type
+end(GenomicIntervalTree<TValue, Static> const & tree, Standard const & /*tag*/)
+{
+    return typename Iterator<GenomicIntervalTree<TValue, Static> const, Standard>::Type(tree, false);
+}
+
+template <typename TValue>
+typename Iterator<GenomicIntervalTree<TValue, Static>, Standard>::Type
+end(GenomicIntervalTree<TValue, Static> & tree, Standard const & /*tag*/)
+{
+    return typename Iterator<GenomicIntervalTree<TValue, Static>, Standard>::Type(tree, false);
+}
+
+template <typename TValue>
+typename Iterator<GenomicIntervalTree<TValue, Static> const, Rooted>::Type
+end(GenomicIntervalTree<TValue, Static> const & tree, Rooted const & /*tag*/)
+{
+    return typename Iterator<GenomicIntervalTree<TValue, Static> const, Standard>::Type(tree, false);
+}
+
+template <typename TValue>
+typename Iterator<GenomicIntervalTree<TValue, Static>, Rooted>::Type
+end(GenomicIntervalTree<TValue, Static> & tree, Rooted const & /*tag*/)
+{
+    return typename Iterator<GenomicIntervalTree<TValue, Static>, Standard>::Type(tree, false);
+}
+
+// ----------------------------------------------------------------------------
+// Function findOverlappingWithPoint()
+// ----------------------------------------------------------------------------
+
+// Guarantee: result is sorted by (beginPos, endPos), by search algorithm.
+
+template <typename TValue, typename TPos, typename TResult>
+void findOverlappingWithPoint(GenomicIntervalTree<TValue, Static> const & tree,
+                              int rID,
+                              TPos point,
+                              TResult & result)
+{
+    typedef GenomicIntervalTree<TValue, Static> const                     TGenomicIntervalTree;
+    typedef typename Position<TGenomicIntervalTree>::Type                 TPos2;
+    typedef typename Size<TGenomicIntervalTree>::Type                     TSize;
+    typedef typename Iterator<TGenomicIntervalTree const, Standard>::Type TIter;
+
+    typedef typename Iterator<IntervalTree<TValue, Static> const, Standard>::Type TTreeIter;
+    std::vector<TTreeIter> tmpResult;
+
+    findOverlappingWithPoint(tree.contigTrees[rID], point, tmpResult);
+
+    result.clear();
+    result.reserve(tmpResult.size());
+    for (unsigned i = 0; i < tmpResult.size(); ++i)
+        result.push_back(TIter(tree, rID, tmpResult[i]));
+}
+
+// ----------------------------------------------------------------------------
+// Function findOverlappingWithInterval()
+// ----------------------------------------------------------------------------
+
+// Guarantee: result is sorted by (beginPos, endPos), by search algorithm.
+
+template <typename TValue, typename TPos, typename TResult>
+void findOverlappingWithInterval(GenomicIntervalTree<TValue, Static> const & tree,
+                                 int rID,
+                                 TPos posBegin,
+                                 TPos posEnd,
+                                 TResult & result)
+{
+    typedef GenomicIntervalTree<TValue, Static> const                     TGenomicIntervalTree;
+    typedef typename Position<TGenomicIntervalTree>::Type                 TPos2;
+    typedef typename Size<TGenomicIntervalTree>::Type                     TSize;
+    typedef typename Iterator<TGenomicIntervalTree const, Standard>::Type TIter;
+
+    typedef typename Iterator<IntervalTree<TValue, Static> const, Standard>::Type TTreeIter;
+    std::vector<TTreeIter> tmpResult;
+
+    findOverlappingWithInterval(tree.contigTrees[rID], posBegin, posEnd, tmpResult);
+
+    result.clear();
+    result.reserve(tmpResult.size());
+    for (unsigned i = 0; i < tmpResult.size(); ++i)
+        result.push_back(TIter(tree, rID, tmpResult[i]));
+}
+
+}  // namespace seqan
+
+#endif  // INCLUDE_SEQAN_INTERVAL_TREE_STATIC_GENOMIC_INTERVAL_TREE_H_

--- a/include/seqan/interval_tree/static_genomic_interval_tree.h
+++ b/include/seqan/interval_tree/static_genomic_interval_tree.h
@@ -175,7 +175,7 @@ struct Iterator<GenomicIntervalTree<TValue, Static> const, TIterSpec>
 // Function build()
 // ----------------------------------------------------------------------------
 
-template <typename TValue, typename TPos, typename TContainer>
+template <typename TValue, typename TContainer>
 void build(GenomicIntervalTree<TValue, Static> & tree,
            TContainer const & values)
 {
@@ -183,13 +183,14 @@ void build(GenomicIntervalTree<TValue, Static> & tree,
     tree.updateTotalSize();
 }
 
-template <typename TValue, typename TPos, typename TContainer>
+template <typename TValue, typename TContainer>
 void build(GenomicIntervalTree<TValue, Static> & tree,
            TContainer const & values,
            int rID)
 {
-    if (rID > (int)tree.contigTrees.size())
-        tree.contigTrees[rID].initialize(values);
+    if (rID >= (int)tree.contigTrees.size())
+        tree.contigTrees.resize(rID + 1);
+    tree.contigTrees[rID].initialize(values);
     tree.updateTotalSize();
 }
 

--- a/include/seqan/interval_tree/static_genomic_interval_tree_iterator.h
+++ b/include/seqan/interval_tree/static_genomic_interval_tree_iterator.h
@@ -1,0 +1,292 @@
+// ==========================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ==========================================================================
+// Copyright (c) 2006-2015, Knut Reinert, FU Berlin
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ==========================================================================
+// Author: Manuel Holtgrewe <manuel.holtgrewe@fu-berlin.de>
+// ==========================================================================
+// Iterator for Static GenomicIntervalTree objects.
+// ==========================================================================
+
+#ifndef INCLUDE_SEQAN_INTERVAL_TREE_STATIC_GENOMIC_INTERVAL_TREE_ITERATOR_H_
+#define INCLUDE_SEQAN_INTERVAL_TREE_STATIC_GENOMIC_INTERVAL_TREE_ITERATOR_H_
+
+#include <vector>
+
+#include <seqan/basic.h>
+#include <seqan/sequence.h>
+
+#include "static_interval_tree.h"
+#include "static_interval_tree_iterator.h"
+
+namespace seqan
+{
+
+// ============================================================================
+// Forwards
+// ============================================================================
+
+struct Static_;
+typedef Tag<Static_> Static;
+
+template <typename TValue, typename TSpec> class GenomicIntervalTree;
+
+// ============================================================================
+// Tags, Classes, Enums
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// Class Iter                                  [GenomicIntervalTree, non-const]
+// ----------------------------------------------------------------------------
+
+template <typename TValue>
+class Iter<GenomicIntervalTree<TValue, Static>, void>
+{
+private:
+    typedef GenomicIntervalTree<TValue, Static> TTree_;
+    typedef typename Iterator<IntervalTree<TValue, Static>, Standard>::Type TIter_;
+
+public:
+    TTree_ * tree;
+    int rID;
+    TIter_ it;
+
+    Iter() : tree(), rID(), it() {}
+
+    Iter(TTree_ & tree, int rID, TIter_ it) : tree(&tree), rID(rID), it(it) {}
+
+    Iter(TTree_ & tree, bool isBegin) : tree(&tree), rID(), it()
+    {
+        if (tree.contigTrees.empty())
+            return;
+        if (isBegin)
+        {
+            rID = 0;
+            it = begin(tree.contigTrees[rID], Standard());
+        }
+        else
+        {
+            rID = tree.contigTrees.size() - 1;
+            it = end(tree.contigTrees[rID], Standard());
+        }
+    }
+
+    bool operator==(Iter const & other)
+    {
+        return (tree == other.tree && it == other.it);
+    }
+
+    bool operator!=(Iter const & other)
+    {
+        return (tree != other.tree || it != other.it);
+    }
+
+    TValue & operator*()
+    {
+        return *it;
+    }
+
+    TValue & operator*() const
+    {
+        return *it;
+    }
+
+    TValue * operator->() const
+    {
+        return &*it;
+    }
+
+    TValue * operator->()
+    {
+        return &*it;
+    }
+
+    Iter operator++(int)
+    {
+        Iter copy(*this);
+        operator++();
+        return copy;
+    }
+
+    Iter & operator++()
+    {
+        if (++it == tree->contigTrees[rID].end())
+        {
+            ++rID;
+            it = tree->contigTrees[rID].begin();
+        }
+        return *this;
+    }
+
+
+    Iter operator--(int)
+    {
+        Iter copy(*this);
+        operator--();
+        return copy;
+    }
+
+    Iter & operator--()
+    {
+        if (it == tree->contigTrees[rID].begin())
+        {
+            --rID;
+            it = tree->contigTrees[rID].end();
+        }
+        --it;
+        return *this;
+    }
+};
+
+// ----------------------------------------------------------------------------
+// Class Iter                                      [GenomicIntervalTree, const]
+// ----------------------------------------------------------------------------
+
+template <typename TValue>
+class Iter<GenomicIntervalTree<TValue, Static> const, void>
+{
+private:
+    typedef GenomicIntervalTree<TValue, Static> const TTree_;
+    typedef typename Iterator<IntervalTree<TValue, Static> const, Standard>::Type TIter_;
+
+public:
+    TTree_ * tree;
+    int rID;
+    TIter_ it;
+
+    Iter() : tree(), rID(), it() {}
+
+    Iter(TTree_ & tree, int rID, TIter_ it) : tree(&tree), rID(rID), it(it) {}
+
+    Iter(TTree_ & tree, bool isBegin) : tree(&tree), rID(), it()
+    {
+        if (tree.contigTrees.empty())
+            return;
+        if (isBegin)
+        {
+            rID = 0;
+            it = begin(tree.contigTrees[rID], Standard());
+        }
+        else
+        {
+            rID = tree.contigTrees.size() - 1;
+            it = end(tree.contigTrees[rID], Standard());
+        }
+    }
+
+    bool operator==(Iter const & other)
+    {
+        return (tree == other.tree && it == other.it);
+    }
+
+    bool operator!=(Iter const & other)
+    {
+        return (tree != other.tree || it != other.it);
+    }
+
+    TValue const & operator*()
+    {
+        return *it;
+    }
+
+    TValue const & operator*() const
+    {
+        return *it;
+    }
+
+    TValue const * operator->() const
+    {
+        return &*it;
+    }
+
+    TValue const * operator->()
+    {
+        return &*it;
+    }
+
+    Iter operator++(int)
+    {
+        Iter copy(*this);
+        operator++();
+        return copy;
+    }
+
+    Iter & operator++()
+    {
+        if (++it == tree->contigTrees[rID].end())
+        {
+            ++rID;
+            it = tree->contigTrees[rID].begin();
+        }
+        return *this;
+    }
+
+
+    Iter operator--(int)
+    {
+        Iter copy(*this);
+        operator--();
+        return copy;
+    }
+
+    Iter & operator--()
+    {
+        if (it == tree->contigTrees[rID].begin())
+        {
+            --rID;
+            it = tree->contigTrees[rID].end();
+        }
+        --it;
+        return *this;
+    }
+};
+
+// ============================================================================
+// Metafunctions
+// ============================================================================
+
+// ============================================================================
+// Functions
+// ============================================================================
+
+template <typename TValue>
+int getRID(Iter<GenomicIntervalTree<TValue, Static>, void> const & it)
+{
+    return it.rID;
+}
+
+template <typename TValue>
+int getRID(Iter<GenomicIntervalTree<TValue, Static> const, void> const & it)
+{
+    return it.rID;
+}
+
+}  // namespace seqan
+
+#endif  // INCLUDE_SEQAN_INTERVAL_TREE_STATIC_GENOMIC_INTERVAL_TREE_ITERATOR_H_

--- a/include/seqan/interval_tree/static_interval_tree.h
+++ b/include/seqan/interval_tree/static_interval_tree.h
@@ -160,7 +160,7 @@ IntervalTree<TValue, Static>::computeMaxEndProperties(
 
     entry.maxEnd = std::max(entry.maxEnd,
                             std::max(computeMaxEndProperties(beginIdx, centerIdx),
-                                     computeMaxEndProperties(centerIdx, endIdx)));
+                                     computeMaxEndProperties(centerIdx + 1, endIdx)));
     return entry.maxEnd;
 }
 

--- a/include/seqan/interval_tree/static_interval_tree.h
+++ b/include/seqan/interval_tree/static_interval_tree.h
@@ -1,0 +1,415 @@
+// ==========================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ==========================================================================
+// Copyright (c) 2006-2015, Knut Reinert, FU Berlin
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ==========================================================================
+// Author: Manuel Holtgrewe <manuel.holtgrewe@fu-berlin.de>
+// ==========================================================================
+// Static, immutable version of interval tree.
+// ==========================================================================
+
+// TODO(holtgrewe): Implement neighbor search in case of no overlapping intervals.
+
+#ifndef INCLUDE_SEQAN_INTERVAL_TREE_STATIC_INTERVAL_TREE_H_
+#define INCLUDE_SEQAN_INTERVAL_TREE_STATIC_INTERVAL_TREE_H_
+
+#include <algorithm>
+#include <vector>
+#include <utility>
+
+#include <seqan/basic.h>
+#include <seqan/sequence.h>
+
+#include "base_interval_tree.h"
+#include "interval_tree_entry.h"
+#include "static_interval_tree_iterator.h"
+
+namespace seqan
+{
+
+// ============================================================================
+// Forwards
+// ============================================================================
+
+// ============================================================================
+// Tags, Classes, Enums
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// Class StaticIntervalTree
+// ----------------------------------------------------------------------------
+
+// Tags for specializing IntervalTree<>.
+
+struct Static_;
+typedef Tag<Static_> Static;
+
+/*!
+ * @class StaticIntervalTree
+ * @headerfile <seqan/interval_tree.h>
+ * @brief Static @link IntervalTree @endlink implementation.
+ *
+ * @signature template <typename TValue>
+ *            class IntervalTree<TValue, Static>;
+ *
+ * @tparam TValue Value to store in the tree.
+ * @tparam TSpec  Specializing tag.
+ *
+ * The implementation is based on Cormen's augmented binary search trees as described in <a
+ * href="http://en.wikipedia.org/wiki/Interval_tree#Augmented_tree">this Wikipedia article</a>.
+ */
+template <typename TValue>
+class IntervalTree<TValue, Static>
+{
+public:
+    IntervalTree() {}
+
+    template <typename TContainer>
+    IntervalTree(TContainer const & container)
+    {
+        initialize(container);
+    }
+
+    std::vector<IntervalTreeEntry<TValue> > entries;
+
+private:
+
+    template <typename TContainer> void initialize(TContainer const & container);
+
+    typename Position<IntervalTreeEntry<TValue> >::Type
+    computeMaxEndProperties(typename std::vector<TValue>::size_type beginIdx,
+                            typename std::vector<TValue>::size_type endIdx);
+};
+
+template <typename TValue>
+struct CmpIntervalTreeEntryByBeginPos_
+{
+    bool operator()(IntervalTreeEntry<TValue> const & lhs, IntervalTreeEntry<TValue> const & rhs)
+    {
+        return (beginPos(lhs.value) < beginPos(rhs.value) ||
+                (beginPos(lhs.value) == beginPos(rhs.value) && endPos(lhs.value) < endPos(rhs.value)));
+    }
+};
+
+template <typename TValue>
+template <typename TContainer>
+void IntervalTree<TValue, Static>::initialize(TContainer const & container)
+{
+    // Fill this->entries[i].value from the values in container.
+    entries.resize(length(container));
+    typename std::vector<IntervalTreeEntry<TValue> >::iterator entryIt = entries.begin();
+    for (typename Iterator<TContainer const, Standard>::Type it = begin(container, Standard());
+         it != end(container, Standard()); ++it, ++entryIt)
+    {
+        entryIt->value = *it;
+        entryIt->maxEnd = endPos(*it);
+    }
+
+    // Sort this->entries by the begin position of their value member.
+    std::sort(begin(entries, Standard()), end(entries, Standard()),
+              CmpIntervalTreeEntryByBeginPos_<TValue>());
+
+    // Compute the maxEnd members of this->entries.
+    typedef typename std::vector<TValue>::size_type TSize;
+    computeMaxEndProperties((TSize)0, (TSize)length(entries));
+}
+
+template <typename TValue>
+typename Position<IntervalTreeEntry<TValue> >::Type
+IntervalTree<TValue, Static>::computeMaxEndProperties(
+        typename std::vector<TValue>::size_type beginIdx,
+        typename std::vector<TValue>::size_type endIdx)
+{
+    typedef typename Position<IntervalTreeEntry<TValue> >::Type TPos;
+    typedef typename std::vector<TValue>::size_type             TSize;
+
+    if (beginIdx == endIdx)
+        return MaxValue<TPos>::VALUE;
+
+    TSize centerIdx = (endIdx + beginIdx) / 2;
+    IntervalTreeEntry<TValue> & entry = entries[centerIdx];
+
+    if (beginIdx + 1 == endIdx)
+        return entry.maxEnd;
+
+    entry.maxEnd = std::max(entry.maxEnd,
+                            std::max(computeMaxEndProperties(beginIdx, centerIdx),
+                                     computeMaxEndProperties(centerIdx, endIdx)));
+    return entry.maxEnd;
+}
+
+// ============================================================================
+// Metafunctions
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// Metafunction Size
+// ----------------------------------------------------------------------------
+
+/**
+ * @mfn IntervalTree#Size
+ * @brief The size type of the <tt>IntervalTree</tt>.
+ */
+
+template <typename TValue>
+struct Size<IntervalTree<TValue, Static> >
+{
+    typedef typename std::vector<TValue>::size_type Type;
+};
+
+template <typename TValue>
+struct Size<IntervalTree<TValue, Static> const>
+{
+    typedef typename std::vector<TValue>::size_type Type;
+};
+
+// ----------------------------------------------------------------------------
+// Metafunction Iterator
+// ----------------------------------------------------------------------------
+
+/**
+ * @mfn IntervalTree#Iterator
+ * @brief The iterator type of the <tt>IntervalTree</tt>.
+ */
+
+template <typename TValue, typename TIterSpec>
+struct Iterator<IntervalTree<TValue, Static>, TIterSpec>
+{
+    typedef Iter<IntervalTree<TValue, Static>, void> Type;
+};
+
+template <typename TValue, typename TIterSpec>
+struct Iterator<IntervalTree<TValue, Static> const, TIterSpec>
+{
+    typedef Iter<IntervalTree<TValue, Static> const, void> Type;
+};
+
+// ============================================================================
+// Functions
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// Function length()
+// ----------------------------------------------------------------------------
+
+// TODO(holtgrewe): Get rid of non-const length once all such functions are removed
+template <typename TValue>
+typename Size<IntervalTree<TValue, Static> >::Type
+length(IntervalTree<TValue, Static> const & tree)
+{
+    return tree.entries.size();
+}
+
+template <typename TValue>
+typename Size<IntervalTree<TValue, Static> >::Type
+length(IntervalTree<TValue, Static> & tree)
+{
+    return tree.entries.size();
+}
+
+// ----------------------------------------------------------------------------
+// Function begin()
+// ----------------------------------------------------------------------------
+
+// TODO(holtgrewe): For some reason, using TIterSpec template parameter instead of Standard/Rooted created ambiguous function calls and references to missing class specialization of IteratorDefaultImp_, same below for end().
+
+template <typename TValue>
+typename Iterator<IntervalTree<TValue, Static> const, Standard>::Type
+begin(IntervalTree<TValue, Static> const & tree, Standard const & /*tag*/)
+{
+    return typename Iterator<IntervalTree<TValue, Static> const, Standard>::Type(tree.entries.begin());
+}
+
+template <typename TValue>
+typename Iterator<IntervalTree<TValue, Static>, Standard>::Type
+begin(IntervalTree<TValue, Static> & tree, Standard const & /*tag*/)
+{
+    return typename Iterator<IntervalTree<TValue, Static>, Standard>::Type(tree.entries.begin());
+}
+
+template <typename TValue>
+typename Iterator<IntervalTree<TValue, Static> const, Rooted>::Type
+begin(IntervalTree<TValue, Static> const & tree, Rooted const & /*tag*/)
+{
+    return typename Iterator<IntervalTree<TValue, Static> const, Standard>::Type(tree.entries.begin());
+}
+
+template <typename TValue>
+typename Iterator<IntervalTree<TValue, Static>, Rooted>::Type
+begin(IntervalTree<TValue, Static> & tree, Rooted const & /*tag*/)
+{
+    return typename Iterator<IntervalTree<TValue, Static>, Standard>::Type(tree.entries.begin());
+}
+
+// ----------------------------------------------------------------------------
+// Function end()
+// ----------------------------------------------------------------------------
+
+template <typename TValue>
+typename Iterator<IntervalTree<TValue, Static> const, Standard>::Type
+end(IntervalTree<TValue, Static> const & tree, Standard const & /*tag*/)
+{
+    return typename Iterator<IntervalTree<TValue, Static> const, Standard>::Type(tree.entries.end());
+}
+
+template <typename TValue>
+typename Iterator<IntervalTree<TValue, Static>, Standard>::Type
+end(IntervalTree<TValue, Static> & tree, Standard const & /*tag*/)
+{
+    return typename Iterator<IntervalTree<TValue, Static>, Standard>::Type(tree.entries.end());
+}
+
+template <typename TValue>
+typename Iterator<IntervalTree<TValue, Static> const, Rooted>::Type
+end(IntervalTree<TValue, Static> const & tree, Rooted const & /*tag*/)
+{
+    return typename Iterator<IntervalTree<TValue, Static> const, Standard>::Type(tree.entries.end());
+}
+
+template <typename TValue>
+typename Iterator<IntervalTree<TValue, Static>, Rooted>::Type
+end(IntervalTree<TValue, Static> & tree, Rooted const & /*tag*/)
+{
+    return typename Iterator<IntervalTree<TValue, Static>, Standard>::Type(tree.entries.end());
+}
+
+// ----------------------------------------------------------------------------
+// Function findOverlappingWithPoint()
+// ----------------------------------------------------------------------------
+
+template <typename TValue, typename TResult>
+void _findOverlappingWithPoint(IntervalTree<TValue, Static> const & tree,
+                               typename Size<IntervalTree<TValue, Static> const >::Type beginIdx,
+                               typename Size<IntervalTree<TValue, Static> const >::Type endIdx,
+                               typename Size<IntervalTree<TValue, Static> const >::Type centerIdx,
+                               typename Position<IntervalTree<TValue, Static> const >::Type point,
+                               TResult & result)
+{
+    typedef typename Iterator<IntervalTree<TValue, Static> const>::Type TIter;
+
+    if (beginIdx >= endIdx) // handle base case of empty interval
+        return;
+
+    IntervalTreeEntry<TValue> const & entry = tree.entries[centerIdx];
+
+    if (entry._allLeftOf(point)) // point is right of the rightmost point of any interval in this entry
+        return;
+    
+    if (beginIdx < centerIdx) // recurse left
+        _findOverlappingWithPoint(tree, beginIdx, centerIdx, beginIdx + (centerIdx - beginIdx) / 2,
+                                  point, result);
+    
+    if (entry._contains(point)) // check this entry
+        appendValue(result, TIter(tree.entries.begin() + centerIdx));
+    
+    if (entry._isRightOf(point)) // point is left of the start of the interval, can't to the right
+        return;
+    
+    if (centerIdx + 1 < endIdx) // recurse right
+        _findOverlappingWithPoint(tree, centerIdx + 1, endIdx, (centerIdx + 1) + (endIdx - (centerIdx + 1)) / 2,
+                                  point, result);
+}
+
+// Guarantee: result is sorted by (beginPos, endPos), by search algorithm.
+
+template <typename TValue, typename TPos, typename TResult>
+void findOverlappingWithPoint(IntervalTree<TValue, Static> const & tree,
+                              TPos point,
+                              TResult & result)
+{
+    typedef IntervalTree<TValue, Static> const                     TIntervalTree;
+    typedef typename Position<TIntervalTree>::Type                 TPos2;
+    typedef typename Size<TIntervalTree>::Type                     TSize;
+    typedef typename Iterator<TIntervalTree const, Standard>::Type TIter;
+
+    _findOverlappingWithPoint(tree, (TSize)0, (TSize)tree.entries.size(), (TSize)(tree.entries.size() / 2), (TPos2)point, result);
+}
+
+// ----------------------------------------------------------------------------
+// Function findOverlappingWithInterval()
+// ----------------------------------------------------------------------------
+
+// ----------------------------------------------------------------------------
+// Function findOverlappingWithPoint()
+// ----------------------------------------------------------------------------
+
+template <typename TValue, typename TResult>
+void _findOverlappingWithInterval(IntervalTree<TValue, Static> const & tree,
+                                  typename Size<IntervalTree<TValue, Static> const >::Type beginIdx,
+                                  typename Size<IntervalTree<TValue, Static> const >::Type endIdx,
+                                  typename Size<IntervalTree<TValue, Static> const >::Type centerIdx,
+                                  typename Position<IntervalTree<TValue, Static> const >::Type posBegin,
+                                  typename Position<IntervalTree<TValue, Static> const >::Type posEnd,
+                                  TResult & result)
+{
+    typedef typename Iterator<IntervalTree<TValue, Static> const>::Type TIter;
+
+    if (beginIdx >= endIdx) // handle base case of empty interval
+        return;
+
+    IntervalTreeEntry<TValue> const & entry = tree.entries[centerIdx];
+
+    if (entry._allLeftOf(posBegin)) // posBegin is right of the rightmost point of any interval in this node
+        return;
+
+    if (beginIdx < centerIdx) // recurse left
+        _findOverlappingWithInterval(tree, beginIdx, centerIdx, beginIdx + (centerIdx - beginIdx) / 2, posBegin,
+                                     posEnd, result);
+    
+    if (entry._overlapsWith(posBegin, posEnd)) // check this node
+        appendValue(result, TIter(tree.entries.begin() + centerIdx));
+
+    if (entry._isRightOf(posEnd - 1)) // last interval entry is left of the start of the interval, can't to the right
+        return;
+
+    if (centerIdx + 1 < endIdx) // recurse right
+        _findOverlappingWithInterval(tree, centerIdx + 1, endIdx, (centerIdx + 1) + (endIdx - (centerIdx + 1)) / 2,
+                                     posBegin, posEnd, result);
+}
+
+// Guarantee: result is sorted by (beginPos, endPos), by search algorithm.
+
+template <typename TValue, typename TPos, typename TResult>
+void findOverlappingWithInterval(IntervalTree<TValue, Static> const & tree,
+                                 TPos posBegin,
+                                 TPos posEnd,
+                                 TResult & result)
+{
+    typedef IntervalTree<TValue, Static> const                     TIntervalTree;
+    typedef typename Position<TIntervalTree>::Type                 TPos2;
+    typedef typename Size<TIntervalTree>::Type                     TSize;
+    typedef typename Iterator<TIntervalTree const, Standard>::Type TIter;
+
+    _findOverlappingWithInterval(tree, (TSize)0, (TSize)tree.entries.size(), (TSize)(tree.entries.size() / 2),
+                                 (TPos2)posBegin, (TPos2)posEnd, result);
+}
+
+}  // namespace seqan
+
+#endif  // INCLUDE_SEQAN_INTERVAL_TREE_STATIC_INTERVAL_TREE_H_

--- a/include/seqan/interval_tree/static_interval_tree.h
+++ b/include/seqan/interval_tree/static_interval_tree.h
@@ -98,9 +98,9 @@ public:
 
     std::vector<IntervalTreeEntry<TValue> > entries;
 
-private:
-
     template <typename TContainer> void initialize(TContainer const & container);
+
+private:
 
     typename Position<IntervalTreeEntry<TValue> >::Type
     computeMaxEndProperties(typename std::vector<TValue>::size_type beginIdx,
@@ -213,6 +213,17 @@ struct Iterator<IntervalTree<TValue, Static> const, TIterSpec>
 // ============================================================================
 // Functions
 // ============================================================================
+
+// ----------------------------------------------------------------------------
+// Function build()
+// ----------------------------------------------------------------------------
+
+template <typename TValue, typename TPos, typename TContainer>
+void build(IntervalTree<TValue, Static> & tree,
+           TContainer const & values)
+{
+    tree.initialize(values);
+}
 
 // ----------------------------------------------------------------------------
 // Function length()
@@ -353,10 +364,6 @@ void findOverlappingWithPoint(IntervalTree<TValue, Static> const & tree,
 
 // ----------------------------------------------------------------------------
 // Function findOverlappingWithInterval()
-// ----------------------------------------------------------------------------
-
-// ----------------------------------------------------------------------------
-// Function findOverlappingWithPoint()
 // ----------------------------------------------------------------------------
 
 template <typename TValue, typename TResult>

--- a/include/seqan/interval_tree/static_interval_tree_iterator.h
+++ b/include/seqan/interval_tree/static_interval_tree_iterator.h
@@ -1,0 +1,219 @@
+// ==========================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ==========================================================================
+// Copyright (c) 2006-2015, Knut Reinert, FU Berlin
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ==========================================================================
+// Author: Manuel Holtgrewe <manuel.holtgrewe@fu-berlin.de>
+// ==========================================================================
+// Iterator for Static IntervalTree objects.
+// ==========================================================================
+
+#ifndef INCLUDE_SEQAN_INTERVAL_TREE_STATIC_INTERVAL_TREE_ITERATOR_H_
+#define INCLUDE_SEQAN_INTERVAL_TREE_STATIC_INTERVAL_TREE_ITERATOR_H_
+
+#include <vector>
+
+#include <seqan/basic.h>
+#include <seqan/sequence.h>
+
+namespace seqan
+{
+
+// ============================================================================
+// Forwards
+// ============================================================================
+
+struct Static_;
+typedef Tag<Static_> Static;
+
+template <typename TValue, typename TSpec> class IntervalTree;
+
+// ============================================================================
+// Tags, Classes, Enums
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// Class Iter                                         [IntervalTree, non-const]
+// ----------------------------------------------------------------------------
+
+template <typename TValue>
+class Iter<IntervalTree<TValue, Static>, void>
+{
+private:
+    typedef typename std::vector<IntervalTreeEntry<TValue> >::iterator TIter_;
+
+public:
+    TIter_ it;
+
+    Iter() : it() {}
+    explicit Iter(TIter_ it) : it(it) {}
+
+    bool operator==(Iter const & other)
+    {
+        return (it == other.it);
+    }
+
+    bool operator!=(Iter const & other)
+    {
+        return (it != other.it);
+    }
+
+    TValue & operator*()
+    {
+        return it->value;
+    }
+
+    TValue & operator*() const
+    {
+        return it->value;
+    }
+
+    TValue * operator->() const
+    {
+        return &it->value;
+    }
+
+    TValue * operator->()
+    {
+        return &it->value;
+    }
+
+    Iter operator++(int)
+    {
+        Iter copy(*this);
+        operator++();
+        return copy;
+    }
+
+    Iter & operator++()
+    {
+        ++it;
+        return *this;
+    }
+
+
+    Iter operator--(int)
+    {
+        Iter copy(*this);
+        operator--();
+        return copy;
+    }
+
+    Iter & operator--()
+    {
+        --it;
+        return *this;
+    }
+};
+
+// ----------------------------------------------------------------------------
+// Class Iter                                             [IntervalTree, const]
+// ----------------------------------------------------------------------------
+
+template <typename TValue>
+class Iter<IntervalTree<TValue, Static> const, void>
+{
+private:
+    typedef typename std::vector<IntervalTreeEntry<TValue> >::const_iterator TIter_;
+
+public:
+    TIter_ it;
+
+    Iter() : it() {}
+    explicit Iter(TIter_ it) : it(it) {}
+
+    bool operator==(Iter const & other)
+    {
+        return (it == other.it);
+    }
+
+    bool operator!=(Iter const & other)
+    {
+        return (it != other.it);
+    }
+
+    TValue const & operator*()
+    {
+        return it->value;
+    }
+
+    TValue const & operator*() const
+    {
+        return it->value;
+    }
+
+    TValue const * operator->() const
+    {
+        return &it->value;
+    }
+
+    TValue const * operator->()
+    {
+        return &it->value;
+    }
+
+    Iter operator++(int)
+    {
+        Iter copy(*this);
+        operator++();
+        return copy;
+    }
+
+    Iter & operator++()
+    {
+        ++it;
+        return *this;
+    }
+
+
+    Iter operator--(int)
+    {
+        Iter copy(*this);
+        operator--();
+        return copy;
+    }
+
+    Iter & operator--()
+    {
+        --it;
+        return *this;
+    }
+};
+
+// ============================================================================
+// Metafunctions
+// ============================================================================
+
+// ============================================================================
+// Functions
+// ============================================================================
+
+}  // namespace seqan
+
+#endif  // INCLUDE_SEQAN_INTERVAL_TREE_STATIC_INTERVAL_TREE_ITERATOR_H_

--- a/include/seqan/realign/realign_base.h
+++ b/include/seqan/realign/realign_base.h
@@ -456,15 +456,15 @@ public:
             {
                 if (options.debug)
                 {
-                    swap(store.alignedReadStore, contigAlignedReads);
+                    TAlignedReadStore tmpStore = store.alignedReadStore;
+                    store.alignedReadStore = contigAlignedReads;
                     std::cerr << "ALIGNMENT is (current == " << store.readSeqStore[el.readId] << ")\n";
                     seqan::AlignedReadLayout layout;
                     layoutAlignment(layout, store);
                     std::stringstream ss;
                     printAlignment(std::cerr, layout, store, front(store.alignedReadStore).contigId,
                                    0, 1000, 0, 100);
-                    swap(store.alignedReadStore, contigAlignedReads);
-
+                    store.alignedReadStore = tmpStore;
                     std::cerr << " => removeGap(contigAlignedReads, " << posA << ", " << elPos << ")\n"
                               << "       pos == " << pos << "\n";
                     // std::cerr << "    itP:";
@@ -1119,14 +1119,15 @@ void AnsonMyersRealignmentRound_<TFragmentStore>::run(unsigned windowBegin, unsi
             }
             std::cerr << "Consensus                    " << contigSeq << "\n";
 
-            swap(store.alignedReadStore, contigAlignedReads);
+            TAlignedReadStore tmpStore = store.alignedReadStore;
+            store.alignedReadStore = contigAlignedReads;
             std::cerr << "ALIGNMENT is\n";
             seqan::AlignedReadLayout layout;
             layoutAlignment(layout, store);
             std::stringstream ss;
             printAlignment(std::cerr, layout, store, front(store.alignedReadStore).contigId,
                            0, 1000, 0, 100);
-            swap(store.alignedReadStore, contigAlignedReads);
+            store.alignedReadStore = tmpStore;
 
             std::cerr << "PROFILE\n";
             _printProfile(std::cerr, contigProfile);
@@ -1146,14 +1147,15 @@ void AnsonMyersRealignmentRound_<TFragmentStore>::run(unsigned windowBegin, unsi
             std::cerr << "PROFILE PART AFTER SUBTRACTION\n";
             _printProfile(std::cerr, profilePart);
 
-            swap(store.alignedReadStore, contigAlignedReads);
+            TAlignedReadStore tmpStore = store.alignedReadStore;
+            store.alignedReadStore = contigAlignedReads;
             std::cerr << "AFTER SUBTRACTION of " << store.readSeqStore[it->readId] << " id= " << it->readId << "\n";
             seqan::AlignedReadLayout layout;
             layoutAlignment(layout, store);
             std::stringstream ss;
             printAlignment(std::cerr, layout, store, front(store.alignedReadStore).contigId,
                            0, 1000, 0, 100);
-            swap(store.alignedReadStore, contigAlignedReads);
+            store.alignedReadStore = tmpStore;
         }
 
         // Realign the read against the profile.
@@ -1293,14 +1295,15 @@ void AnsonMyersRealignmentRound_<TFragmentStore>::run(unsigned windowBegin, unsi
 
         if (options.debug)
         {
-            swap(store.alignedReadStore, contigAlignedReads);
+            TAlignedReadStore tmpStore = store.alignedReadStore;
+            store.alignedReadStore = contigAlignedReads;
             std::cerr << "BEFORE INTEGRATION of " << store.readSeqStore[it->readId] << "\n";
             seqan::AlignedReadLayout layout;
             layoutAlignment(layout, store);
             std::stringstream ss;
             printAlignment(std::cerr, layout, store, front(store.alignedReadStore).contigId,
                            0, 1000, 0, 100);
-            swap(store.alignedReadStore, contigAlignedReads);
+            store.alignedReadStore = tmpStore;
 
             std::cerr << "begin/end positions of alignments after update\n";
             for (TAlignedReadIter it2 = begin(contigAlignedReads, Standard()); it2 != itEnd; ++it2)
@@ -1337,14 +1340,15 @@ void AnsonMyersRealignmentRound_<TFragmentStore>::run(unsigned windowBegin, unsi
             std::cerr << "PROFILE AFTER INTEGRATION PROFILE\n";
             _printProfile(std::cerr, contigProfile);
 
-            swap(store.alignedReadStore, contigAlignedReads);
+            TAlignedReadStore tmpStore = store.alignedReadStore;
+            store.alignedReadStore = contigAlignedReads;
             std::cerr << "AFTER REALIGNMENT STEP of " << store.readSeqStore[it->readId] << "\n";
             seqan::AlignedReadLayout layout;
             layoutAlignment(layout, store);
             std::stringstream ss;
             printAlignment(std::cerr, layout, store, front(store.alignedReadStore).contigId,
                            0, 1000, 0, 100);
-            swap(store.alignedReadStore, contigAlignedReads);
+            store.alignedReadStore = tmpStore;
 
             std::cerr << "begin/end positions of alignments after update\n";
             for (TAlignedReadIter it2 = begin(contigAlignedReads, Standard()); it2 != itEnd; ++it2)

--- a/include/seqan/seq_io/genomic_region.h
+++ b/include/seqan/seq_io/genomic_region.h
@@ -278,6 +278,24 @@ parse(GenomicRegion & region, CharString const & regionString)
         SEQAN_THROW(ParseError("GenomicRegion: End postition less than 1"));
 }
 
+// ---------------------------------------------------------------------------
+// Function beginPos()
+// ---------------------------------------------------------------------------
+
+__int32 beginPos(GenomicRegion const & region)
+{
+    return region.beginPos;
+}
+
+// ---------------------------------------------------------------------------
+// Function endPos()
+// ---------------------------------------------------------------------------
+
+__int32 endPos(GenomicRegion const & region)
+{
+    return region.endPos;
+}
+
 }  // namespace seqan
 
 #endif  // #ifndef INCLUDE_SEQAN_SEQ_IO_GENOMIC_REGION_H_

--- a/include/seqan/seq_io/genomic_region.h
+++ b/include/seqan/seq_io/genomic_region.h
@@ -282,7 +282,7 @@ parse(GenomicRegion & region, CharString const & regionString)
 // Function beginPos()
 // ---------------------------------------------------------------------------
 
-__int32 beginPos(GenomicRegion const & region)
+inline __int32 beginPos(GenomicRegion const & region)
 {
     return region.beginPos;
 }
@@ -291,7 +291,7 @@ __int32 beginPos(GenomicRegion const & region)
 // Function endPos()
 // ---------------------------------------------------------------------------
 
-__int32 endPos(GenomicRegion const & region)
+inline __int32 endPos(GenomicRegion const & region)
 {
     return region.endPos;
 }

--- a/tests/align/CMakeLists.txt
+++ b/tests/align/CMakeLists.txt
@@ -52,6 +52,8 @@ add_executable (test_align
                 test_align_global_alignment_specialized.h
                 test_evaluate_alignment.h)
 
+add_executable(test_align_shift_indels_left test_align_shift_indels_left.cpp)
+
 # Add dependencies found by find_package (SeqAn).
 target_link_libraries (test_align ${SEQAN_LIBRARIES})
 
@@ -63,3 +65,4 @@ set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SEQAN_CXX_FLAGS}")
 # ----------------------------------------------------------------------------
 
 add_test (NAME test_test_align COMMAND $<TARGET_FILE:test_align>)
+add_test (NAME test_test_align_shift_indels_left COMMAND $<TARGET_FILE:test_align_shift_indels_left>)

--- a/tests/align/test_align_shift_indels_left.cpp
+++ b/tests/align/test_align_shift_indels_left.cpp
@@ -1,0 +1,191 @@
+// ==========================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ==========================================================================
+// Copyright (c) 2006-2015, Knut Reinert, FU Berlin
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ==========================================================================
+// Author: Manuel Holtgrewe <manuel.holtgrewe@fu-berlin.de>
+// ==========================================================================
+
+#include <seqan/basic.h>
+#include <seqan/align/normalize.h>
+
+SEQAN_DEFINE_TEST(test_align_remove_nullifying_indels_ins_del)
+{
+    seqan::Align<seqan::Dna5String> align;
+    resize(rows(align), 2);
+    assignSource(row(align, 0), "TGAT");
+    assignSource(row(align, 1), "TCAT");
+    insertGap(row(align, 0), 1);
+    insertGap(row(align, 1), 2);
+
+    // std::cerr << align;
+
+    bool b = removeNullifyingIndels(row(align, 0), row(align, 1));
+    SEQAN_ASSERT(b);
+
+    std::stringstream ss0, ss1;
+    ss0 << row(align, 0);
+    ss1 << row(align, 1);
+
+    SEQAN_ASSERT_EQ("TGAT", ss0.str());
+    SEQAN_ASSERT_EQ("TCAT", ss1.str());
+}
+
+SEQAN_DEFINE_TEST(test_align_remove_nullifying_indels_del_ins)
+{
+    seqan::Align<seqan::Dna5String> align;
+    resize(rows(align), 2);
+    assignSource(row(align, 0), "TGAT");
+    assignSource(row(align, 1), "TCAT");
+    insertGap(row(align, 0), 2);
+    insertGap(row(align, 1), 1);
+
+    // std::cerr << align;
+
+    bool b = removeNullifyingIndels(row(align, 0), row(align, 1));
+    SEQAN_ASSERT(b);
+
+    std::stringstream ss0, ss1;
+    ss0 << row(align, 0);
+    ss1 << row(align, 1);
+
+    SEQAN_ASSERT_EQ("TGAT", ss0.str());
+    SEQAN_ASSERT_EQ("TCAT", ss1.str());
+}
+
+SEQAN_DEFINE_TEST(test_align_remove_nullifying_indels_complex)
+{
+    seqan::Align<seqan::Dna5String> align;
+    resize(rows(align), 2);
+    assignSource(row(align, 0), "TCATTCATTCATTCATTCAT");
+    assignSource(row(align, 1), "TCATTCATTCATTCATTCAT");
+    insertGaps(iter(row(align, 0), 4), 4);
+    insertGaps(iter(row(align, 0), 11), 3);
+    insertGaps(iter(row(align, 1), 8), 3);
+    insertGaps(iter(row(align, 1), 14), 4);
+
+    // std::cerr << align;
+
+    bool b = removeNullifyingIndels(row(align, 0), row(align, 1));
+    SEQAN_ASSERT(b);
+
+    // std::cerr << align;
+
+    std::stringstream ss0, ss1;
+    ss0 << row(align, 0);
+    ss1 << row(align, 1);
+
+    SEQAN_ASSERT_EQ("TCAT-TCATTCATTCATTCAT", ss0.str());
+    SEQAN_ASSERT_EQ("TCATTCATTCA-TTCATTCAT", ss1.str());
+}
+
+SEQAN_DEFINE_TEST(test_align_left_align_indels_nop)
+{
+    seqan::Align<seqan::Dna5String> align;
+    resize(rows(align), 2);
+    assignSource(row(align, 0), "TGAT");
+    assignSource(row(align, 1), "TCAT");
+    insertGap(row(align, 0), 1);
+    insertGap(row(align, 1), 3);
+
+    // std::cerr << align;
+
+    bool b = leftAlignIndels(row(align, 0), row(align, 1));
+    SEQAN_ASSERT_NOT(b);
+
+    std::stringstream ss0, ss1;
+    ss0 << row(align, 0);
+    ss1 << row(align, 1);
+
+    SEQAN_ASSERT_EQ("T-GAT", ss0.str());
+    SEQAN_ASSERT_EQ("TCA-T", ss1.str());
+}
+
+// Actual left-shifting of gaps.
+SEQAN_DEFINE_TEST(test_align_left_align_indels_simple)
+{
+    seqan::Align<seqan::Dna5String> align;
+    resize(rows(align), 2);
+    assignSource(row(align, 0), "TTAGAGAGTT");
+    assignSource(row(align, 1), "TTAGAGTT");
+    insertGaps(iter(row(align, 1), 6), 2);
+
+    // std::cerr << align;
+
+    bool b = leftAlignIndels(row(align, 0), row(align, 1));
+    SEQAN_ASSERT(b);
+
+    // std::cerr << align;
+
+    std::stringstream ss0, ss1;
+    ss0 << row(align, 0);
+    ss1 << row(align, 1);
+
+    SEQAN_ASSERT_EQ("TTAGAGAGTT", ss0.str());
+    SEQAN_ASSERT_EQ("TT--AGAGTT", ss1.str());
+}
+
+// Actual left-shifting of multiple gaps.
+SEQAN_DEFINE_TEST(test_align_left_align_indels_multiple)
+{
+    seqan::Align<seqan::Dna5String> align;
+    resize(rows(align), 2);
+    assignSource(row(align, 0), "TTAGAGAGTTTCAGCAGG");
+    assignSource(row(align, 1), "TTAGTTCACAG");
+    insertGaps(iter(row(align, 1), 10), 1);
+    insertGaps(iter(row(align, 1), 8), 1);
+    insertGaps(iter(row(align, 1), 6), 1);
+    insertGaps(iter(row(align, 1), 4), 2);
+    insertGaps(iter(row(align, 1), 2), 2);
+
+    // std::cerr << align;
+
+    bool b = leftAlignIndels(row(align, 0), row(align, 1));
+    SEQAN_ASSERT(b);
+
+    // std::cerr << align;
+
+    std::stringstream ss0, ss1;
+    ss0 << row(align, 0);
+    ss1 << row(align, 1);
+
+    SEQAN_ASSERT_EQ("TTAGAGAGTTTCAGCAGG", ss0.str());
+    SEQAN_ASSERT_EQ("TT----AG-TTCA-CA-G", ss1.str());
+}
+
+SEQAN_BEGIN_TESTSUITE(test_align_shift_indels_left)
+{
+    SEQAN_CALL_TEST(test_align_remove_nullifying_indels_ins_del);
+    SEQAN_CALL_TEST(test_align_remove_nullifying_indels_del_ins);
+    SEQAN_CALL_TEST(test_align_remove_nullifying_indels_complex);
+    SEQAN_CALL_TEST(test_align_left_align_indels_nop);
+    SEQAN_CALL_TEST(test_align_left_align_indels_simple);
+    SEQAN_CALL_TEST(test_align_left_align_indels_multiple);
+}
+SEQAN_END_TESTSUITE

--- a/tests/interval_tree/CMakeLists.txt
+++ b/tests/interval_tree/CMakeLists.txt
@@ -31,9 +31,12 @@ add_definitions (${SEQAN_DEFINITIONS})
 # Update the list of file names below if you add source files to your test.
 add_executable (test_interval_tree
                 test_interval_tree.cpp)
+add_executable (test_genomic_interval_tree
+                test_genomic_interval_tree.cpp)
 
 # Add dependencies found by find_package (SeqAn).
 target_link_libraries (test_interval_tree ${SEQAN_LIBRARIES})
+target_link_libraries (test_genomic_interval_tree ${SEQAN_LIBRARIES})
 
 # Add CXX flags found by find_package (SeqAn).
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SEQAN_CXX_FLAGS}")
@@ -43,3 +46,4 @@ set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SEQAN_CXX_FLAGS}")
 # ----------------------------------------------------------------------------
 
 add_test (NAME test_test_interval_tree COMMAND $<TARGET_FILE:test_interval_tree>)
+add_test (NAME test_test_genomic_interval_tree COMMAND $<TARGET_FILE:test_genomic_interval_tree>)

--- a/tests/interval_tree/CMakeLists.txt
+++ b/tests/interval_tree/CMakeLists.txt
@@ -1,0 +1,45 @@
+# ===========================================================================
+#                  SeqAn - The Library for Sequence Analysis
+# ===========================================================================
+# File: /tests/interval_tree/CMakeLists.txt
+#
+# CMakeLists.txt file for the interval_tree module tests.
+# ===========================================================================
+
+cmake_minimum_required (VERSION 2.8.2)
+project (seqan_tests_interval_tree)
+message (STATUS "Configuring tests/interval_tree")
+
+# ----------------------------------------------------------------------------
+# Dependencies
+# ----------------------------------------------------------------------------
+
+# Search SeqAn and select dependencies.
+set (SEQAN_FIND_DEPENDENCIES ZLIB)
+find_package (SeqAn REQUIRED)
+
+# ----------------------------------------------------------------------------
+# Build Setup
+# ----------------------------------------------------------------------------
+
+# Add include directories.
+include_directories (${SEQAN_INCLUDE_DIRS})
+
+# Add definitions set by find_package (SeqAn).
+add_definitions (${SEQAN_DEFINITIONS})
+
+# Update the list of file names below if you add source files to your test.
+add_executable (test_interval_tree
+                test_interval_tree.cpp)
+
+# Add dependencies found by find_package (SeqAn).
+target_link_libraries (test_interval_tree ${SEQAN_LIBRARIES})
+
+# Add CXX flags found by find_package (SeqAn).
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SEQAN_CXX_FLAGS}")
+
+# ----------------------------------------------------------------------------
+# Register with CTest
+# ----------------------------------------------------------------------------
+
+add_test (NAME test_test_interval_tree COMMAND $<TARGET_FILE:test_interval_tree>)

--- a/tests/interval_tree/test_genomic_interval_tree.cpp
+++ b/tests/interval_tree/test_genomic_interval_tree.cpp
@@ -1,0 +1,194 @@
+// ==========================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ==========================================================================
+// Copyright (c) 2006-2015, Knut Reinert, FU Berlin
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ==========================================================================
+// Author: Manuel Holtgrewe <manuel.holtgrewe@fu-berlin.de>
+// ==========================================================================
+
+#include <seqan/basic.h>
+#include <seqan/file.h>
+
+#include <seqan/interval_tree.h>
+
+SEQAN_DEFINE_TEST(test_genomic_interval_tree_empty)
+{
+    seqan::GenomicIntervalTree<seqan::IntervalWithCargo<unsigned, int>, seqan::Static> intervalTree;
+
+    SEQAN_ASSERT_EQ(0u, length(intervalTree));
+    SEQAN_ASSERT(begin(intervalTree, seqan::Standard()) == end(intervalTree, seqan::Standard()));
+}
+
+struct SmallIntervalTreeFixture
+{
+    typedef seqan::IntervalWithCargo<unsigned, int>                        TIntervalWithCargo;
+    typedef seqan::GenomicIntervalTree<TIntervalWithCargo, seqan::Static>  TIntervalTree;
+    typedef seqan::Iterator<TIntervalTree const, seqan::Standard>::Type    TIterator;
+    typedef std::vector<TIterator>                                         TResult;
+
+    std::vector<std::vector<TIntervalWithCargo> > gIntervals;
+
+    SmallIntervalTreeFixture()
+    {
+        std::vector<TIntervalWithCargo> intervals;
+        intervals.push_back(TIntervalWithCargo(0, 1, 4));
+        intervals.push_back(TIntervalWithCargo(1, 5, 9));
+        intervals.push_back(TIntervalWithCargo(2, 4, 8));
+        intervals.push_back(TIntervalWithCargo(3, 5, 7));
+        intervals.push_back(TIntervalWithCargo(4, 16, 20));
+        intervals.push_back(TIntervalWithCargo(5, 11, 16));
+        intervals.push_back(TIntervalWithCargo(6, 30, 67));
+        gIntervals.push_back(intervals);
+    }
+};
+
+SEQAN_DEFINE_TEST(test_genomic_interval_tree_small_construction)
+{
+    SmallIntervalTreeFixture fixture;
+    seqan::GenomicIntervalTree<seqan::IntervalWithCargo<unsigned, int>, seqan::Static> intervalTree(fixture.gIntervals);
+
+    SEQAN_ASSERT_EQ(7u, length(intervalTree));
+    SEQAN_ASSERT(begin(intervalTree, seqan::Standard()) != end(intervalTree, seqan::Standard()));
+}
+
+SEQAN_DEFINE_TEST(test_genomic_interval_tree_small_find_overlapping_with_point)
+{
+    SmallIntervalTreeFixture fixture;
+    seqan::GenomicIntervalTree<seqan::IntervalWithCargo<unsigned, int>, seqan::Static> intervalTree(fixture.gIntervals);
+
+    SEQAN_ASSERT_EQ(7u, length(intervalTree));
+    SEQAN_ASSERT(begin(intervalTree, seqan::Standard()) != end(intervalTree, seqan::Standard()));
+
+    // overlaps(0) => {}
+    {
+        SmallIntervalTreeFixture::TResult result;
+        findOverlappingWithPoint(intervalTree, 0, 0, result);
+        SEQAN_ASSERT_EQ(length(result), 0u);
+    }
+    // overlaps(5) => {1,2,3}
+    {
+        SmallIntervalTreeFixture::TResult result;
+        findOverlappingWithPoint(intervalTree, 0, 5, result);
+        SEQAN_ASSERT_EQ(length(result), 3u);
+        SEQAN_ASSERT_EQ(cargo(*result[0]), 2u);
+        SEQAN_ASSERT_EQ(getRID(result[0]), 0);
+        SEQAN_ASSERT_EQ(cargo(*result[1]), 3u);
+        SEQAN_ASSERT_EQ(getRID(result[1]), 0);
+        SEQAN_ASSERT_EQ(cargo(*result[2]), 1u);
+        SEQAN_ASSERT_EQ(getRID(result[2]), 0);
+    }
+    // overlaps(67) => {}
+    {
+        SmallIntervalTreeFixture::TResult result;
+        findOverlappingWithPoint(intervalTree, 0, 67, result);
+        SEQAN_ASSERT_EQ(length(result), 0u);
+    }
+}
+
+struct BugIntervalTreeFixture
+{
+    typedef seqan::IntervalWithCargo<unsigned, int>                       TIntervalWithCargo;
+    typedef seqan::GenomicIntervalTree<TIntervalWithCargo, seqan::Static> TIntervalTree;
+    typedef seqan::Iterator<TIntervalTree const, seqan::Standard>::Type   TIterator;
+    typedef std::vector<TIterator>                                        TResult;
+
+    std::vector<std::vector<TIntervalWithCargo> > gIntervals;
+
+    BugIntervalTreeFixture()
+    {
+        std::vector<TIntervalWithCargo> intervals;
+        intervals.push_back(TIntervalWithCargo(0, 2985989, 2985990));
+        intervals.push_back(TIntervalWithCargo(1, 3102611, 3102757));
+        intervals.push_back(TIntervalWithCargo(2, 3102881, 3102984));
+        intervals.push_back(TIntervalWithCargo(3, 3103125, 3103127));
+        gIntervals.push_back(intervals);
+    }
+};
+
+SEQAN_DEFINE_TEST(test_genomic_interval_tree_small_find_overlapping_with_interval)
+{
+    SmallIntervalTreeFixture fixture;
+    seqan::GenomicIntervalTree<seqan::IntervalWithCargo<unsigned, int>, seqan::Static> intervalTree(fixture.gIntervals);
+
+    SEQAN_ASSERT_EQ(7u, length(intervalTree));
+    SEQAN_ASSERT(begin(intervalTree, seqan::Standard()) != end(intervalTree, seqan::Standard()));
+
+    // overlaps(0, 1) => {}
+    {
+        BugIntervalTreeFixture::TResult result;
+        findOverlappingWithInterval(intervalTree, 0, 0, 1, result);
+        SEQAN_ASSERT_EQ(length(result), 0u);
+    }
+    // overlaps(5, 6) => {1,2,3}
+    {
+        BugIntervalTreeFixture::TResult result;
+        findOverlappingWithInterval(intervalTree, 0, 5, 6, result);
+        SEQAN_ASSERT_EQ(length(result), 3u);
+        SEQAN_ASSERT_EQ(cargo(*result[0]), 2u);
+        SEQAN_ASSERT_EQ(getRID(result[0]), 0);
+        SEQAN_ASSERT_EQ(cargo(*result[1]), 3u);
+        SEQAN_ASSERT_EQ(getRID(result[1]), 0);
+        SEQAN_ASSERT_EQ(cargo(*result[2]), 1u);
+        SEQAN_ASSERT_EQ(getRID(result[2]), 0);
+    }
+    // overlaps(67, 68) => {}
+    {
+        BugIntervalTreeFixture::TResult result;
+        findOverlappingWithInterval(intervalTree, 0, 67, 68, result);
+        SEQAN_ASSERT_EQ(length(result), 0u);
+    }
+}
+
+SEQAN_DEFINE_TEST(test_genomic_interval_tree_small_find_overlapping_with_interval_bug)
+{
+    BugIntervalTreeFixture fixture;
+    seqan::GenomicIntervalTree<seqan::IntervalWithCargo<unsigned, int>, seqan::Static> intervalTree(fixture.gIntervals);
+
+    SEQAN_ASSERT_EQ(4u, length(intervalTree));
+    SEQAN_ASSERT(begin(intervalTree, seqan::Standard()) != end(intervalTree, seqan::Standard()));
+
+    // overlaps(0, 1) => {}
+    {
+        BugIntervalTreeFixture::TResult result;
+        findOverlappingWithInterval(intervalTree, 0, 3102981, 3103082, result);
+        SEQAN_ASSERT_EQ(length(result), 1u);
+        SEQAN_ASSERT_EQ(cargo(*result[0]), 2u);
+        SEQAN_ASSERT_EQ(getRID(result[0]), 0);
+   }
+}
+
+SEQAN_BEGIN_TESTSUITE(test_genomic_interval_tree)
+{
+    SEQAN_CALL_TEST(test_genomic_interval_tree_empty);
+    SEQAN_CALL_TEST(test_genomic_interval_tree_small_construction);
+    SEQAN_CALL_TEST(test_genomic_interval_tree_small_find_overlapping_with_point);
+    SEQAN_CALL_TEST(test_genomic_interval_tree_small_find_overlapping_with_interval);
+    SEQAN_CALL_TEST(test_genomic_interval_tree_small_find_overlapping_with_interval_bug);
+}
+SEQAN_END_TESTSUITE

--- a/tests/interval_tree/test_interval_tree.cpp
+++ b/tests/interval_tree/test_interval_tree.cpp
@@ -1,0 +1,147 @@
+// ==========================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ==========================================================================
+// Copyright (c) 2006-2015, Knut Reinert, FU Berlin
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ==========================================================================
+// Author: Manuel Holtgrewe <manuel.holtgrewe@fu-berlin.de>
+// ==========================================================================
+
+#include <seqan/basic.h>
+#include <seqan/file.h>
+
+#include <seqan/interval_tree.h>
+
+SEQAN_DEFINE_TEST(test_interval_tree_empty)
+{
+    seqan::IntervalTree<seqan::Interval<unsigned, int>, seqan::Static> intervalTree;
+
+    SEQAN_ASSERT_EQ(0u, length(intervalTree));
+    SEQAN_ASSERT(begin(intervalTree, seqan::Standard()) == end(intervalTree, seqan::Standard()));
+}
+
+struct SmallIntervalTreeFixture
+{
+    typedef seqan::Interval<unsigned, int>                              TInterval;
+    typedef seqan::IntervalTree<TInterval, seqan::Static>               TIntervalTree;
+    typedef seqan::Iterator<TIntervalTree const, seqan::Standard>::Type TIterator;
+    typedef std::vector<TIterator>                                      TResult;
+
+    std::vector<TInterval> intervals;
+
+    SmallIntervalTreeFixture()
+    {
+        intervals.push_back(TInterval(0, 1, 4));
+        intervals.push_back(TInterval(1, 5, 9));
+        intervals.push_back(TInterval(2, 4, 8));
+        intervals.push_back(TInterval(3, 5, 7));
+        intervals.push_back(TInterval(4, 16, 20));
+        intervals.push_back(TInterval(5, 11, 16));
+        intervals.push_back(TInterval(6, 30, 67));
+    }
+};
+
+SEQAN_DEFINE_TEST(test_interval_tree_small_construction)
+{
+    SmallIntervalTreeFixture fixture;
+    seqan::IntervalTree<seqan::Interval<unsigned, int>, seqan::Static> intervalTree(fixture.intervals);
+
+    SEQAN_ASSERT_EQ(7u, length(intervalTree));
+    SEQAN_ASSERT(begin(intervalTree, seqan::Standard()) != end(intervalTree, seqan::Standard()));
+}
+
+SEQAN_DEFINE_TEST(test_interval_tree_small_find_overlapping_with_point)
+{
+    SmallIntervalTreeFixture fixture;
+    seqan::IntervalTree<seqan::Interval<unsigned, int>, seqan::Static> intervalTree(fixture.intervals);
+
+    SEQAN_ASSERT_EQ(7u, length(intervalTree));
+    SEQAN_ASSERT(begin(intervalTree, seqan::Standard()) != end(intervalTree, seqan::Standard()));
+
+    // overlaps(0) => {}
+    {
+        SmallIntervalTreeFixture::TResult result;
+        findOverlappingWithPoint(intervalTree, 0, result);
+        SEQAN_ASSERT_EQ(length(result), 0u);
+    }
+    // overlaps(5) => {1,2,3}
+    {
+        SmallIntervalTreeFixture::TResult result;
+        findOverlappingWithPoint(intervalTree, 5, result);
+        SEQAN_ASSERT_EQ(length(result), 3u);
+        SEQAN_ASSERT_EQ(cargo(*result[0]), 2u);
+        SEQAN_ASSERT_EQ(cargo(*result[1]), 3u);
+        SEQAN_ASSERT_EQ(cargo(*result[2]), 1u);
+    }
+    // overlaps(67) => {}
+    {
+        SmallIntervalTreeFixture::TResult result;
+        findOverlappingWithPoint(intervalTree, 67, result);
+        SEQAN_ASSERT_EQ(length(result), 0u);
+    }
+}
+
+SEQAN_DEFINE_TEST(test_interval_tree_small_find_overlapping_with_interval)
+{
+    SmallIntervalTreeFixture fixture;
+    seqan::IntervalTree<seqan::Interval<unsigned, int>, seqan::Static> intervalTree(fixture.intervals);
+
+    SEQAN_ASSERT_EQ(7u, length(intervalTree));
+    SEQAN_ASSERT(begin(intervalTree, seqan::Standard()) != end(intervalTree, seqan::Standard()));
+
+    // overlaps(0, 1) => {}
+    {
+        SmallIntervalTreeFixture::TResult result;
+        findOverlappingWithInterval(intervalTree, 0, 1, result);
+        SEQAN_ASSERT_EQ(length(result), 0u);
+    }
+    // overlaps(5, 6) => {1,2,3}
+    {
+        SmallIntervalTreeFixture::TResult result;
+        findOverlappingWithInterval(intervalTree, 5, 6, result);
+        SEQAN_ASSERT_EQ(length(result), 3u);
+        SEQAN_ASSERT_EQ(cargo(*result[0]), 2u);
+        SEQAN_ASSERT_EQ(cargo(*result[1]), 3u);
+        SEQAN_ASSERT_EQ(cargo(*result[2]), 1u);
+    }
+    // overlaps(67, 68) => {}
+    {
+        SmallIntervalTreeFixture::TResult result;
+        findOverlappingWithInterval(intervalTree, 67, 68, result);
+        SEQAN_ASSERT_EQ(length(result), 0u);
+    }
+}
+
+SEQAN_BEGIN_TESTSUITE(test_interval_tree)
+{
+    SEQAN_CALL_TEST(test_interval_tree_empty);
+    SEQAN_CALL_TEST(test_interval_tree_small_construction);
+    SEQAN_CALL_TEST(test_interval_tree_small_find_overlapping_with_point);
+    SEQAN_CALL_TEST(test_interval_tree_small_find_overlapping_with_interval);
+}
+SEQAN_END_TESTSUITE


### PR DESCRIPTION
Static interval trees are better implemented as arrays than
pointer-based trees. This is an attempt at an implementation.

Includes test and demos, docs are missing.

Major difference to the current implementation in misc is that
the intervals are 1-based instead of 0-based.

@esiragusa @h-2 @rrahn @weese I realize that the documentation is missing but I want to push this in early for a review. The difference in coordinate systems used (0-based here 1-based in AKE's implementation) is a feature. I have not done any benchmarking but I assume that this implementation is not only simpler (and thus easier to understand and maintain) but also faster.

The same trick could be used to implement a dynamic `IntervalTree<>` based on RB-trees, for example. However, I do not see its direct use and RB-trees are somewhat tricky to implement efficiently.

Note that the `Interval<>` class is only here for convenience and any other type implementing `beginPos()` and `endPos()` can be used. Further, not the cargos are returned but pointers to the `TValue`s of the `IntervalTree<>`.

Please point out missing functions for this to be a `ContainerConcept`. Note that for some reason, I did not succeed in writing generic `Iterator<>` functions so I would welcome any help here. After review, I will update the PR to also have documentation.