### PR TITLE
[FIX] add implicit conversions similiar to infix

### DIFF
--- a/include/seqan/sequence/segment_prefix.h
+++ b/include/seqan/sequence/segment_prefix.h
@@ -119,6 +119,15 @@ public:
         assign(*this, source);
         return *this;
     }
+
+#if defined(SEQAN_CXX11_STANDARD) && (!defined(_MSC_VER) || _MSC_VER >= 1800)
+    template<typename T> explicit operator T () const
+    {
+        T temp_copy;
+        assign(temp_copy, *this);
+        return temp_copy;
+    }
+#endif
 //____________________________________________________________________________
 
 public:

--- a/include/seqan/sequence/segment_suffix.h
+++ b/include/seqan/sequence/segment_suffix.h
@@ -139,6 +139,14 @@ SEQAN_CHECKPOINT
         assign(*this, source);
         return *this;
     }
+#if defined(SEQAN_CXX11_STANDARD) && (!defined(_MSC_VER) || _MSC_VER >= 1800)
+    template<typename T> explicit operator T () const
+    {
+        T temp_copy;
+        assign(temp_copy, *this);
+        return temp_copy;
+    }
+#endif
 //____________________________________________________________________________
 
 public:


### PR DESCRIPTION
make changes from #910 work for prefixes and suffixes, as well (not only infixes).

Will merge if there are no errors.