### PR TITLE
[FIXED-#828] Adds assertion to writeRecord of Bam/Sam IO. 

### DIFF
--- a/include/seqan/bam_io/write_bam.h
+++ b/include/seqan/bam_io/write_bam.h
@@ -244,6 +244,7 @@ void write(TTarget & target,
     // Check for valid IO Context.
     SEQAN_ASSERT_LT_MSG(record.rID, static_cast<__int32>(length(contigNames(context))), "BAM IO Assertion: Unknown REF ID!");
     SEQAN_ASSERT_LT_MSG(record.rNextId, static_cast<__int32>(length(contigNames(context))), "BAM IO Assertion: Unknown NEXT REF ID!");
+    ignoreUnusedVariableWarning(context);
 
     // Update internal lengths
     __uint32 size = updateLengths(record);

--- a/include/seqan/bam_io/write_bam.h
+++ b/include/seqan/bam_io/write_bam.h
@@ -238,9 +238,13 @@ _writeBamRecordWrapper(TTarget & target,
 template <typename TTarget, typename TNameStore, typename TNameStoreCache, typename TStorageSpec>
 void write(TTarget & target,
            BamAlignmentRecord const & record,
-           BamIOContext<TNameStore, TNameStoreCache, TStorageSpec> & /* context */,
+           BamIOContext<TNameStore, TNameStoreCache, TStorageSpec> & context,
            Bam const & tag)
 {
+    // Check for valid IO Context.
+    SEQAN_ASSERT_LT_MSG(record.rID, static_cast<__int32>(length(contigNames(context))), "BAM IO Assertion: Unknown REF ID!");
+    SEQAN_ASSERT_LT_MSG(record.rNextId, static_cast<__int32>(length(contigNames(context))), "BAM IO Assertion: Unknown NEXT REF ID!");
+
     // Update internal lengths
     __uint32 size = updateLengths(record);
 

--- a/include/seqan/bam_io/write_sam.h
+++ b/include/seqan/bam_io/write_sam.h
@@ -128,6 +128,10 @@ inline void write(TTarget & target,
                   BamIOContext<TNameStore, TNameStoreCache, TStorageSpec> const & context,
                   Sam const & /*tag*/)
 {
+    // Check for valid IO Context.
+    SEQAN_ASSERT_LT_MSG(record.rID, static_cast<__int32>(length(contigNames(context))), "SAM IO Assertion: Unknown REF ID!");
+    SEQAN_ASSERT_LT_MSG(record.rNextId, static_cast<__int32>(length(contigNames(context))), "SAM IO Assertion: Unknown NEXT REF ID!");
+
     write(target, record.qName);
     writeValue(target, '\t');
 


### PR DESCRIPTION
Given the nature of the FormattedFile it would be in general possible to create a Bam/Sam file with an empty IO context. By the Sam specifications this might be valid (contains only unmapped reads), so we need a way to assert an incomplete IO context, which can happen easily as demonstrated by the following example taken from demos/tutorial/bam_io/solution1.cpp:

```cpp
BamFileIn bamIn("example.bam")
// some error checking.
BamFileOut bamOut(cout, Sam());
// Reading bamFile and writing sam file to console (as demonstrated by the demo above.) 
```
The code is valid but yields an error, since the context (contig names) of the ```bamOut``` is not set. This leads to a misleading error when writing Sam and even worse no error when writing in Bam format. The error would first appear, when one tries to read in from the erroneous bam file. 

This fix simply adds an assertion when writing Sam/Bam file that checks if the ```rID``` and the ```rNextID``` points to a valid contig name according to the Sam specifications.
This way the user can detect the error more easily.
