### PR TITLE
[FIX] deactivate one test on freebsd

### DIFF
--- a/apps/bs_tools/tests/run_tests.py
+++ b/apps/bs_tools/tests/run_tests.py
@@ -208,19 +208,24 @@ def main(source_base, binary_base):
     # pe
     # ============================================================
     # 0
-    conf = app_tests.TestConf(
-        program=path_to_casbar,
-        redir_stdout=ph.outFile('other.stdout'),
-        args=['-nec', '-mc', str(6), '-msc', str(5), '-mpc', str(0.5), '-hes', str(0.005),
-              '-o', ph.outFile('snps_pe_0.vcf'),
-              '-b', ph.outFile('meths_pe_0.bed'),
-              ph.inFile('hg18_chr21_3000.fa'),
-              ph.inFile('reads_pe_N6000_0.CT_GA.verified.pos_so.sam')],
-        to_diff=[(ph.inFile('snps_pe_0.vcf'),
-                  ph.outFile('snps_pe_0.vcf')),
-                  (ph.inFile('meths_pe_0.bed'),
-                  ph.outFile('meths_pe_0.bed'))])
-    conf_list.append(conf)
+
+    if not sys.platform.startswith('freebsd'):
+        conf = app_tests.TestConf(
+            program=path_to_casbar,
+            redir_stdout=ph.outFile('other.stdout'),
+            args=['-nec', '-mc', str(6), '-msc', str(5), '-mpc', str(0.5), '-hes', str(0.005),
+                '-o', ph.outFile('snps_pe_0.vcf'),
+                '-b', ph.outFile('meths_pe_0.bed'),
+                ph.inFile('hg18_chr21_3000.fa'),
+                ph.inFile('reads_pe_N6000_0.CT_GA.verified.pos_so.sam')],
+            to_diff=[(ph.inFile('snps_pe_0.vcf'),
+                    ph.outFile('snps_pe_0.vcf')),
+                    (ph.inFile('meths_pe_0.bed'),
+                    ph.outFile('meths_pe_0.bed'))])
+        conf_list.append(conf)
+    else:
+        print "One test not executed on FreeBSD, because of lower math precision."
+
 
     # ============================================================
     # Execute the tests.


### PR DESCRIPTION
this deactivates a test on FreeBSD that otherwise fails because of lower math precision in the FreeBSD c standard library.

Will merge later today, unless someone objects. 

@skrakau is this okay for you? it shouldnt effect anything else.