### PR TITLE
Fix/modified iterators

### DIFF
--- a/apps/rabema/curve_smoothing.h
+++ b/apps/rabema/curve_smoothing.h
@@ -258,7 +258,7 @@ void smoothErrorCurve(String<WeightedMatch> & errorCurve)
             {
                 currentMax = _max(currentMax, value(it).distance);
 //                 std::cerr << "value(" << value(it) << ") = " << currentMax << std::endl;
-                value(it).distance = currentMax;
+                value(host(it)).distance = currentMax;
             }
         }
 

--- a/include/seqan/modifier/modifier_iterator.h
+++ b/include/seqan/modifier/modifier_iterator.h
@@ -130,8 +130,14 @@ struct Value<ModifiedIterator<THost, TSpec> const> : Value<ModifiedIterator<THos
 // Metafunction GetValue
 // --------------------------------------------------------------------------
 
+//NOTE(h-2): ModifiedStringIterators always return by value since some
+// modified strings result in values being created anyway (e.g. ModViews)
+// and depending on scope these might be lost.
+// For example iterators over infixes of ModViews would otherwise reference
+// part of the stack that were freed.
+
 template <typename THost, typename TSpec>
-struct GetValue< ModifiedIterator<THost, TSpec> > : GetValue<THost>
+struct GetValue< ModifiedIterator<THost, TSpec> > : Value<THost>
 {};
 
 template <typename THost, typename TSpec>
@@ -142,8 +148,10 @@ struct GetValue<ModifiedIterator<THost, TSpec> const> : GetValue<ModifiedIterato
 // Metafunction Reference
 // --------------------------------------------------------------------------
 
+//NOTE(h-2): see above
+
 template <typename THost, typename TSpec>
-struct Reference<ModifiedIterator<THost, TSpec> > : Reference<THost>
+struct Reference<ModifiedIterator<THost, TSpec> > : Value<THost>
 {};
 
 template <typename THost, typename TSpec>


### PR DESCRIPTION
This is a fix for #644 and hopefully also for #538. For develop it is included in #997, because it was triggered by changes there.  For master it comes by way of this pull request.

Previous tests showed that this effects no apps or tests other than rabema which is fixed by one of the diffs below. The corresponding part in rabema is covered by app tests (which pass), but maybe @holtgrewe wants to double-check it?