### PR TITLE
[FIX] fixed bgzfstream tell to return the begin offset ... [master]

### DIFF
--- a/tests/bam_io/test_bam_file.h
+++ b/tests/bam_io/test_bam_file.h
@@ -466,7 +466,7 @@ SEQAN_DEFINE_TEST(test_bam_io_bam_file_bam_file_size)
 
     readRecord(record, bamFile);
 
-    SEQAN_ASSERT_EQ((int)position(bamFile), 0x0120);
+    SEQAN_ASSERT_EQ((int)position(bamFile), 0x9F0000);
 }
 
 SEQAN_DEFINE_TEST(test_bam_io_bam_file_bam_file_seek)


### PR DESCRIPTION
... of the next block instead of the end of the previous one, as the samtools do.