### PR TITLE
[FIX] remove warning that was due to incorrect parameter order

### DIFF
--- a/include/seqan/index/index_sa_qsort.h
+++ b/include/seqan/index/index_sa_qsort.h
@@ -86,8 +86,8 @@ namespace SEQAN_NAMESPACE_MAIN
     {
         typedef StringSet<TString, TSetSpec> const TText;
 
-        typename Size<TString>::Type _offset;
         TText &_text;
+        typename Size<TString>::Type _offset;
 
         SuffixLess_(TText &text):
             _text(text) {}


### PR DESCRIPTION
remove some annoying warnings

as this is a ~whitespace change I will merge it tonight.