### PR TITLE
Added pkg-config support and augmented the SeqAn build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,12 +129,12 @@ if (("${SEQAN_BUILD_SYSTEM}" STREQUAL "SEQAN_RELEASE") OR
     ("${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP"))
     message (STATUS "Configuring demos")
     add_subdirectory (demos)
+    message (STATUS "Configuring apps")
+    add_subdirectory (apps)
+    message (STATUS "Configuring dox")
+    add_subdirectory (dox)
 endif ()
 
-message (STATUS "Configuring apps")
-add_subdirectory (apps)
-message (STATUS "Configuring dox")
-add_subdirectory (dox)
 message (STATUS "Configuring manual")
 add_subdirectory (manual)
 message (STATUS "Configuring util/py_lib")
@@ -163,3 +163,18 @@ include (package)
 # ===========================================================================
 
 include (SeqAnCtdSetup)
+
+# ===========================================================================
+# Install all C++ header files
+# ===========================================================================
+
+install (DIRECTORY include/seqan DESTINATION "${CMAKE_INSTALL_PREFIX}/include")
+
+# ===========================================================================
+# Install pkg-config file on Unix-like systems
+# ===========================================================================
+
+if (NOT CMAKE_SYSTEM_NAME MATCHES Windows)
+	configure_file("pkg-config/seqan-2.pc.in" "pkg-config/seqan-2.pc" @ONLY)
+	install(FILES "${CMAKE_BINARY_DIR}/pkg-config/seqan-2.pc" DESTINATION "${CMAKE_INSTALL_PREFIX}/share/pkgconfig")
+endif (NOT CMAKE_SYSTEM_NAME MATCHES Windows)

--- a/pkg-config/seqan-2.pc.in
+++ b/pkg-config/seqan-2.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+includedir=${prefix}/include
+
+Name: @CMAKE_PROJECT_NAME@
+Description: C++ library for biological sequence analysis
+URL: http://www.seqan.de
+Version: @SEQAN_VERSION_STRING@
+Requires: zlib
+Cflags: -I${includedir}


### PR DESCRIPTION
Dear SeqAn maintainers,
I have integrated pkg-config support now. In addition, I have excluded building the demos, apps and dox when users specify "-DSEQAN_BUILD_SYSTEM=SEQAN_RELEASE_MINIMAL" in order to prevent unnecessary building of apps. My take is that most linux distributions and macports only want to install the headers for their users without the apps.

Furthermore, the standard SeqAn cmake build system does not install the headers, which is non-standard and requires further intervention on the side of the user. Standard best practice should be to **always** install headers. Macports even copies them manually:
https://trac.macports.org/browser/trunk/dports/science/seqan/Portfile?order=name

Finally, I think it would be a good idea to have a crude API versioning scheme in place: namely instead of stuffing all headers in ${include_dir}/seqan, they should be put into ${include_dir}/seqan2, with the effect that multiple major version SeqAn installations can be used in parallel. Changing this should be trivial, and given the degree to which interfaces changed between 1.4 and 2.0, I think such a forward-looking approach is desirable for the sake of the stability of older software requiring certain interfaces without impeding the progress of the library overall. This is for instance how gtk-2 and gtk-3 can co-exist peacefully on one system. As such, I have called the .pc file seqan-2.pc on purpose, to allow for such changes to happen gracefully in the future.