### PR TITLE
Feature/set host

### DIFF
--- a/include/seqan/align/dp_matrix.h
+++ b/include/seqan/align/dp_matrix.h
@@ -122,21 +122,6 @@ public:
     {
         create(data_host);
     }
-//
-//    DPMatrix_(DPMatrix_ const & other) :
-//        data_host(other.data_host) {}
-//
-//    ~DPMatrix_() {}
-//
-//    DPMatrix_ & operator=(DPMatrix_ const & other)
-//    {
-//        if (this != &other)
-//        {
-//            data_host = other.data_host;
-//        }
-//        return *this;
-//    }
-
 };
 
 // ============================================================================

--- a/include/seqan/align/dp_matrix.h
+++ b/include/seqan/align/dp_matrix.h
@@ -60,6 +60,13 @@ struct DefaultScoreMatrixSpec_;
 // ============================================================================
 
 // ----------------------------------------------------------------------------
+// Tag MatrixMember
+// ----------------------------------------------------------------------------
+
+struct DPMatrixMember_;
+typedef Tag<DPMatrixMember_> DPMatrixMember;
+
+// ----------------------------------------------------------------------------
 // Tag SparseDPMatrix
 // ----------------------------------------------------------------------------
 
@@ -106,29 +113,29 @@ class DPMatrix_<TValue, FullDPMatrix>
 {
 public:
 
-    typedef Matrix<TValue, 2> THost;
+    typedef typename Member<DPMatrix_, DPMatrixMember>::Type THost;
 
-    Holder<THost>   _dataHost;  // The host containing the actual matrix.
+    Holder<THost>   data_host;  // The host containing the actual matrix.
 
     DPMatrix_() :
-        _dataHost()
+        data_host()
     {
-        create(_dataHost);
+        create(data_host);
     }
-
-    DPMatrix_(DPMatrix_ const & other) :
-        _dataHost(other._dataHost) {}
-
-    ~DPMatrix_() {}
-
-    DPMatrix_ & operator=(DPMatrix_ const & other)
-    {
-        if (this != &other)
-        {
-            _dataHost = other._dataHost;
-        }
-        return *this;
-    }
+//
+//    DPMatrix_(DPMatrix_ const & other) :
+//        data_host(other.data_host) {}
+//
+//    ~DPMatrix_() {}
+//
+//    DPMatrix_ & operator=(DPMatrix_ const & other)
+//    {
+//        if (this != &other)
+//        {
+//            data_host = other.data_host;
+//        }
+//        return *this;
+//    }
 
 };
 
@@ -160,21 +167,16 @@ struct DefaultScoreMatrixSpec_<LocalAlignment_<WatermanEggert> >
 // ----------------------------------------------------------------------------
 
 // Returns the type of the underlying matrix.
-template <typename TDPMatrix>
-struct DataHost_ {};
-
 template <typename TValue, typename TMatrixSpec>
-struct DataHost_<DPMatrix_<TValue, TMatrixSpec> >
+struct Member<DPMatrix_<TValue, TMatrixSpec>, DPMatrixMember>
 {
-    typedef DPMatrix_<TValue, TMatrixSpec> TDPMatrix_;
-    typedef typename TDPMatrix_::THost Type;
+    typedef Matrix<TValue, 2> Type;
 };
 
 template <typename TValue, typename TMatrixSpec>
-struct DataHost_<DPMatrix_<TValue, TMatrixSpec> const>
+struct Member<DPMatrix_<TValue, TMatrixSpec> const, DPMatrixMember>
 {
-    typedef DPMatrix_<TValue, TMatrixSpec> TDPMatrix_;
-    typedef typename TDPMatrix_::THost const Type;
+    typedef Matrix<TValue, 2> const Type;
 };
 
 // ----------------------------------------------------------------------------
@@ -190,7 +192,7 @@ template <typename TValue, typename TMatrixSpec>
 struct SizeArr_<DPMatrix_<TValue, TMatrixSpec> >
 {
     typedef DPMatrix_<TValue, TMatrixSpec> TDPMatrix_;
-    typedef typename DataHost_<TDPMatrix_>::Type TDataHost_;
+    typedef typename Member<TDPMatrix_, DPMatrixMember>::Type TDataHost_;
     typedef typename SizeArr_<TDataHost_>::Type Type;
 };
 
@@ -198,7 +200,7 @@ template <typename TValue, typename TMatrixSpec>
 struct SizeArr_<DPMatrix_<TValue, TMatrixSpec> const>
 {
     typedef DPMatrix_<TValue, TMatrixSpec> TDPMatrix_;
-    typedef typename DataHost_<TDPMatrix_>::Type TDataHost_;
+    typedef typename Member<TDPMatrix_, DPMatrixMember>::Type TDataHost_;
     typedef typename SizeArr_<TDataHost_>::Type const Type;
 };
 
@@ -299,7 +301,7 @@ template <typename TValue, typename TMatrixSpec>
 struct Host<DPMatrix_<TValue, TMatrixSpec> >
 {
     typedef DPMatrix_<TValue, TMatrixSpec> TDPMatrix_;
-    typedef typename DataHost_<TDPMatrix_>::Type TDataMatrix_;
+    typedef typename Member<TDPMatrix_, DPMatrixMember>::Type TDataMatrix_;
     typedef typename Host<TDataMatrix_>::Type Type;
 };
 
@@ -307,7 +309,7 @@ template <typename TValue, typename TMatrixSpec>
 struct Host<DPMatrix_<TValue, TMatrixSpec> const>
 {
     typedef DPMatrix_<TValue, TMatrixSpec> TDPMatrix_;
-    typedef typename DataHost_<TDPMatrix_>::Type TDataMatrix_;
+    typedef typename Member<TDPMatrix_, DPMatrixMember>::Type TDataMatrix_;
     typedef typename Host<TDataMatrix_>::Type const Type;
 };
 
@@ -339,7 +341,7 @@ template <typename TValue, typename TMatrixSpec>
 struct Iterator<DPMatrix_<TValue, TMatrixSpec>, Rooted const>
 {
     typedef DPMatrix_<TValue, TMatrixSpec> TDPMatrix_;
-    typedef typename  DataHost_<TDPMatrix_>::Type TDataMatrix_;
+    typedef typename Member<TDPMatrix_, DPMatrixMember>::Type TDataMatrix_;
     typedef typename Iterator<TDataMatrix_, Rooted>::Type Type;
 };
 
@@ -347,7 +349,7 @@ template <typename TValue, typename TMatrixSpec>
 struct Iterator<DPMatrix_<TValue, TMatrixSpec> const, Rooted const>
 {
     typedef DPMatrix_<TValue, TMatrixSpec> TDPMatrix_;
-    typedef typename  DataHost_<TDPMatrix_>::Type TDataMatrix_;
+    typedef typename Member<TDPMatrix_, DPMatrixMember>::Type TDataMatrix_;
     typedef typename Iterator<TDataMatrix_ const, Rooted>::Type Type;
 };
 
@@ -371,17 +373,17 @@ inline bool _checkCorrectDimension(DPMatrixDimension_::TValue dim)
 
 // Returns a reference to the hosted matrix.
 template <typename TValue, typename TMatrixSpec>
-inline typename DataHost_<DPMatrix_<TValue, TMatrixSpec> >::Type &
-_dataHost(DPMatrix_<TValue, TMatrixSpec>&dpMatrix)
+inline Holder<typename Host<DPMatrix_<TValue, TMatrixSpec> >::Type> &
+_dataHost(DPMatrix_<TValue, TMatrixSpec>& dpMatrix)
 {
-    return value(dpMatrix._dataHost);
+    return _dataHost(value(dpMatrix.data_host));
 }
 
 template <typename TValue, typename TMatrixSpec>
-inline typename DataHost_<DPMatrix_<TValue, TMatrixSpec> const>::Type &
+inline Holder<typename Host<DPMatrix_<TValue, TMatrixSpec> >::Type> const &
 _dataHost(DPMatrix_<TValue, TMatrixSpec> const & dpMatrix)
 {
-    return value(dpMatrix._dataHost);
+    return _dataHost(value(dpMatrix.data_host));
 }
 
 // ----------------------------------------------------------------------------
@@ -393,14 +395,14 @@ template <typename TValue, typename TMatrixSpec>
 inline typename SizeArr_<DPMatrix_<TValue, TMatrixSpec> >::Type &
 _dataLengths(DPMatrix_<TValue, TMatrixSpec>&dpMatrix)
 {
-    return _dataLengths(_dataHost(dpMatrix));
+    return _dataLengths(value(dpMatrix.data_host));
 }
 
 template <typename TValue, typename TMatrixSpec>
 inline typename SizeArr_<DPMatrix_<TValue, TMatrixSpec> const>::Type &
 _dataLengths(DPMatrix_<TValue, TMatrixSpec> const & dpMatrix)
 {
-    return _dataLengths(_dataHost(dpMatrix));
+    return _dataLengths(value(dpMatrix.data_host));
 }
 
 // ----------------------------------------------------------------------------
@@ -412,54 +414,14 @@ template <typename TValue, typename TMatrixSpec>
 inline typename SizeArr_<DPMatrix_<TValue, TMatrixSpec> >::Type &
 _dataFactors(DPMatrix_<TValue, TMatrixSpec>&dpMatrix)
 {
-    return _dataFactors(_dataHost(dpMatrix));
+    return _dataFactors(value(dpMatrix.data_host));
 }
 
 template <typename TValue, typename TMatrixSpec>
 inline typename SizeArr_<DPMatrix_<TValue, TMatrixSpec> const>::Type &
 _dataFactors(DPMatrix_<TValue, TMatrixSpec> const & dpMatrix)
 {
-    return _dataFactors(_dataHost(dpMatrix));
-}
-
-// ----------------------------------------------------------------------------
-// Function host()
-// ----------------------------------------------------------------------------
-
-// Returns a reference to the underlying vector of the hosted matrix.
-template <typename TValue, typename TMatrixSpec>
-inline typename Host<DPMatrix_<TValue, TMatrixSpec> >::Type &
-host(DPMatrix_<TValue, TMatrixSpec>&dpMatrix)
-{
-    return host(_dataHost(dpMatrix));
-}
-
-template <typename TValue, typename TMatrixSpec>
-inline typename Host<DPMatrix_<TValue, TMatrixSpec> const>::Type &
-host(DPMatrix_<TValue, TMatrixSpec> const & dpMatrix)
-{
-    return host(_dataHost(dpMatrix));
-}
-
-// ----------------------------------------------------------------------------
-// Function setHost()
-// ----------------------------------------------------------------------------
-
-// Sets a new value to the underlying vector of the hosted matrix.
-template <typename TValue, typename TMatrixSpec, typename THost>
-inline void
-setHost(DPMatrix_<TValue, TMatrixSpec> & dpMatrix,
-        THost & newHost)
-{
-    setHost(_dataHost(dpMatrix), newHost);
-}
-
-template <typename TValue, typename TMatrixSpec, typename THost>
-inline void
-setHost(DPMatrix_<TValue, TMatrixSpec> & dpMatrix,
-        THost const & newHost)
-{
-    setHost(_dataHost(dpMatrix), newHost);
+    return _dataFactors(value(dpMatrix.data_host));
 }
 
 // ----------------------------------------------------------------------------
@@ -472,7 +434,7 @@ inline typename Reference<DPMatrix_<TValue, TMatrixSpec> >::Type
 value(DPMatrix_<TValue, TMatrixSpec> & dpMatrix,
       TPosition const & pos)
 {
-    return value(_dataHost(dpMatrix), pos);
+    return value(value(dpMatrix.data_host), pos);
 }
 
 template <typename TValue, typename TMatrixSpec, typename TPosition>
@@ -480,7 +442,7 @@ inline typename Reference<DPMatrix_<TValue, TMatrixSpec> const>::Type
 value(DPMatrix_<TValue, TMatrixSpec> const & dpMatrix,
       TPosition const & pos)
 {
-    return value(_dataHost(dpMatrix), pos);
+    return value(value(dpMatrix.data_host), pos);
 }
 
 // Returns the value of the matrix at the two given coordinates.
@@ -490,7 +452,7 @@ value(DPMatrix_<TValue, TMatrixSpec> & dpMatrix,
       TPositionV const & posDimV,
       TPositionH const & posDimH)
 {
-    return value(_dataHost(dpMatrix), posDimV, posDimH);
+    return value(value(dpMatrix.data_host), posDimV, posDimH);
 }
 
 template <typename TValue, typename TMatrixSpec, typename TPositionV, typename TPositionH>
@@ -499,7 +461,7 @@ value(DPMatrix_<TValue, TMatrixSpec> const & dpMatrix,
       TPositionV const & posDimV,
       TPositionH const & posDimH)
 {
-    return value(_dataHost(dpMatrix), posDimV, posDimH);
+    return value(value(dpMatrix.data_host), posDimV, posDimH);
 }
 
 // ----------------------------------------------------------------------------
@@ -514,7 +476,7 @@ length(DPMatrix_<TValue, TMatrixSpec> const & dpMatrix,
 {
     SEQAN_ASSERT(_checkCorrectDimension(dimension));
 
-    return length(_dataHost(dpMatrix), dimension);
+    return length(value(dpMatrix.data_host), dimension);
 }
 
 // Returns the overall length of the underlying vector of the hosted matrix.
@@ -522,7 +484,7 @@ template <typename TValue, typename TMatrixSpec>
 inline typename Size<DPMatrix_<TValue, TMatrixSpec> const>::Type
 length(DPMatrix_<TValue, TMatrixSpec> const & dpMatrix)
 {
-    return length(_dataHost(dpMatrix));  // Note that even if the dimensional lengths are set but the matrix was not resized
+    return length(value(dpMatrix.data_host));  // Note that even if the dimensional lengths are set but the matrix was not resized
     // this function returns 0 or the previous length of the host before the resize.
 }
 
@@ -565,7 +527,7 @@ setLength(DPMatrix_<TValue, TMatrixSpec> & dpMatrix,
           TSize const & newLength)
 {
     SEQAN_ASSERT(_checkCorrectDimension(dimension));
-    setLength(_dataHost(dpMatrix), dimension, newLength);
+    setLength(value(dpMatrix.data_host), dimension, newLength);
 }
 
 // ----------------------------------------------------------------------------
@@ -579,7 +541,7 @@ updateFactors(DPMatrix_<TValue, TMatrixSpec> & dpMatrix)
     typedef typename Size<DPMatrix_<TValue, TMatrixSpec> >::Type TSize;
 
     TSize factor_ = _dataFactors(dpMatrix)[0] * length(dpMatrix, 0);
-    for (unsigned int i = 1; (factor_ > 0) && (i < dimension(_dataHost(dpMatrix))); ++i)
+    for (unsigned int i = 1; (factor_ > 0) && (i < dimension(value(dpMatrix.data_host))); ++i)
     {
         _dataFactors(dpMatrix)[i] = factor_;
         factor_ *= length(dpMatrix, i);
@@ -637,14 +599,14 @@ template <typename TValue, typename TMatrixSpec>
 inline typename Iterator<DPMatrix_<TValue, TMatrixSpec>, Rooted const>::Type
 begin(DPMatrix_<TValue, TMatrixSpec> & dpMatrix, Rooted const)
 {
-    return begin(_dataHost(dpMatrix));
+    return begin(value(dpMatrix.data_host));
 }
 
 template <typename TValue, typename TMatrixSpec>
 inline typename Iterator<DPMatrix_<TValue, TMatrixSpec> const, Rooted const>::Type
 begin(DPMatrix_<TValue, TMatrixSpec> const & dpMatrix, Rooted const)
 {
-    return begin(_dataHost(dpMatrix));
+    return begin(value(dpMatrix.data_host));
 }
 
 // ----------------------------------------------------------------------------
@@ -669,14 +631,14 @@ template <typename TValue, typename TMatrixSpec>
 inline typename Iterator<DPMatrix_<TValue, TMatrixSpec>, Rooted const>::Type
 end(DPMatrix_<TValue, TMatrixSpec> & dpMatrix, Rooted const)
 {
-    return end(_dataHost(dpMatrix));
+    return end(value(dpMatrix.data_host));
 }
 
 template <typename TValue, typename TMatrixSpec>
 inline typename Iterator<DPMatrix_<TValue, TMatrixSpec> const, Rooted const>::Type
 end(DPMatrix_<TValue, TMatrixSpec> const & dpMatrix, Rooted const)
 {
-    return end(_dataHost(dpMatrix));
+    return end(value(dpMatrix.data_host));
 }
 
 // ----------------------------------------------------------------------------
@@ -690,7 +652,7 @@ coordinate(DPMatrix_<TValue, FullDPMatrix> const & dpMatrix,
            TPosition hostPos,
            typename DPMatrixDimension_::TValue dimension)
 {
-    return coordinate(_dataHost(dpMatrix), hostPos, dimension);
+    return coordinate(value(dpMatrix.data_host), hostPos, dimension);
 }
 
 } // namespace seqan

--- a/include/seqan/align/dp_matrix_sparse.h
+++ b/include/seqan/align/dp_matrix_sparse.h
@@ -54,30 +54,29 @@ class DPMatrix_<TValue, SparseDPMatrix>
 {
 public:
 
-    typedef Matrix<TValue, 2> THost;
+    typedef typename Member<DPMatrix_, DPMatrixMember>::Type THost;
 
-    Holder<THost>   _dataHost;  // The host containing the actual matrix.
+    Holder<THost>   data_host;  // The host containing the actual matrix.
 
     DPMatrix_() :
-        _dataHost()
+        data_host()
     {
-        create(_dataHost);
+        create(data_host);
     }
 
-    DPMatrix_(DPMatrix_ const & other) :
-        _dataHost(other._dataHost) {}
-
-    ~DPMatrix_() {}
-
-    DPMatrix_ & operator=(DPMatrix_ const & other)
-    {
-        if (this != &other)
-        {
-            _dataHost = other._dataHost;
-        }
-        return *this;
-    }
-
+//    DPMatrix_(DPMatrix_ const & other) :
+//        data_host(other.data_host) {}
+//
+//    ~DPMatrix_() {}
+//
+//    DPMatrix_ & operator=(DPMatrix_ const & other)
+//    {
+//        if (this != &other)
+//        {
+//            _dataHost = other._dataHost;
+//        }
+//        return *this;
+//    }
 };
 
 // ============================================================================

--- a/include/seqan/align/dp_matrix_sparse.h
+++ b/include/seqan/align/dp_matrix_sparse.h
@@ -63,20 +63,6 @@ public:
     {
         create(data_host);
     }
-
-//    DPMatrix_(DPMatrix_ const & other) :
-//        data_host(other.data_host) {}
-//
-//    ~DPMatrix_() {}
-//
-//    DPMatrix_ & operator=(DPMatrix_ const & other)
-//    {
-//        if (this != &other)
-//        {
-//            _dataHost = other._dataHost;
-//        }
-//        return *this;
-//    }
 };
 
 // ============================================================================

--- a/include/seqan/align/matrix_base.h
+++ b/include/seqan/align/matrix_base.h
@@ -67,6 +67,12 @@ struct Host<Matrix<TValue, DIMENSION> >
     typedef String<TValue> Type;
 };
 
+template <typename TValue, unsigned DIMENSION>
+struct Host<Matrix<TValue, DIMENSION> const>
+{
+    typedef String<TValue> const Type;
+};
+
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
@@ -312,28 +318,18 @@ dependent(Matrix<TValue, DIMENSION> & me)
 
 //____________________________________________________________________________
 
-template <typename TValue, unsigned DIMENSION, typename THost>
-inline void
-setHost(Matrix<TValue, DIMENSION> & me, THost & host_)
-{
-    setValue(me.data_host, host_);
-}
-
-//____________________________________________________________________________
-
-
 template <typename TValue, unsigned DIMENSION>
-inline typename Host<Matrix<TValue, DIMENSION> >::Type &
-host(Matrix<TValue, DIMENSION> & me)
+inline Holder<typename Host<Matrix<TValue, DIMENSION> >::Type> &
+_dataHost(Matrix<TValue, DIMENSION> & matrix)
 {
-    return value(me.data_host);
+    return matrix.data_host;
 }
 
 template <typename TValue, unsigned DIMENSION>
-inline typename Host<Matrix<TValue, DIMENSION> >::Type const &
-host(Matrix<TValue, DIMENSION> const & me)
+inline Holder<typename Host<Matrix<TValue, DIMENSION> >::Type> const &
+_dataHost(Matrix<TValue, DIMENSION> const & matrix)
 {
-    return value(me.data_host);
+    return matrix.data_host;
 }
 
 //____________________________________________________________________________

--- a/include/seqan/bam_io/bam_tags_dict.h
+++ b/include/seqan/bam_io/bam_tags_dict.h
@@ -324,6 +324,15 @@ _dataHost(BamTagsDict const & bamTags)
 // Function setHost()
 // ----------------------------------------------------------------------------
 
+#ifdef SEQAN_CXX11_STANDARD
+template <typename THost>
+inline void
+setHost(BamTagsDict & me, THost && host_)
+{
+    setValue(_dataHost(me), std::forward<THost>(host_));
+    clear(me._positions);
+}
+#else
 template <typename THost>
 inline void
 setHost(BamTagsDict & me, THost & host_)
@@ -341,7 +350,7 @@ setHost(BamTagsDict & me, THost const & host_)
     setValue(_dataHost(me), host_);
     clear(me._positions);
 }
-
+#endif  // SEQAN_CXX11_STANDARD
 // ----------------------------------------------------------------------------
 // Function length()
 // ----------------------------------------------------------------------------

--- a/include/seqan/basic/hosted_type_interface.h
+++ b/include/seqan/basic/hosted_type_interface.h
@@ -241,7 +241,18 @@ host(T const & me)
  * it is possible that begin- and end-position of the segment does not fit into the new host sequence.
  */
 
-/// TODO(holtgrew): Move documentation here?
+#ifdef SEQAN_CXX11_STANDARD
+
+template <typename T, typename THost>
+inline void
+setHost(T & me,
+        THost && host_)
+{
+    SEQAN_CHECKPOINT;
+    setValue(_dataHost(me), std::forward<THost>(host_));
+}
+
+#else  // SEQAN_CXX11_STANDARD
 
 template <typename T, typename THost>
 inline void
@@ -260,6 +271,8 @@ setHost(T & me,
     SEQAN_CHECKPOINT;
     setValue(_dataHost(me), host_);
 }
+
+#endif  // SEQAN_CXX11_STANDARD
 
 // ----------------------------------------------------------------------------
 // Function assignHost()

--- a/include/seqan/find/find_abndm.h
+++ b/include/seqan/find/find_abndm.h
@@ -131,6 +131,37 @@ public:
         blockCount(0), last(0), needleLength(0), haystackLength(0), limit(1), cP(0), findNext(false)
     {}
 
+#ifdef SEQAN_CXX11_STANDARD
+    template <typename TNeedle2>
+    Pattern(TNeedle2 && ndl,
+            SEQAN_CTOR_DISABLE_IF(IsSameType<typename std::remove_reference<TNeedle2>::type const &, Pattern const &>)) :
+        blockCount(0),
+        last(0),
+        needleLength(0),
+        haystackLength(0),
+        limit(1),
+        cP(0),
+        findNext(false),
+        verifier(std::forward<TNeedle2>(ndl), -1)
+    {
+        setHost(*this, std::forward<TNeedle2>(ndl));
+        ignoreUnusedVariableWarning(dummy);
+    }
+
+    template <typename TNeedle2>
+    Pattern(TNeedle2 && ndl, int _limit = -1) :
+        blockCount(0),
+        last(0),
+        needleLength(0),
+        haystackLength(0),
+        limit(- _limit),
+        cP(0),
+        findNext(false),
+        verifier(std::forward<TNeedle2>(ndl), _limit)
+    {
+        setHost(*this, std::forward<TNeedle2>(ndl));
+    }
+#else
     template <typename TNeedle2>
     Pattern(TNeedle2 const & ndl) :
         blockCount(0), last(0), needleLength(0), haystackLength(0), limit(1), cP(0), findNext(false),
@@ -145,6 +176,7 @@ public:
     {
         setHost(*this, ndl);
     }
+#endif  // SEQAN_CXX11_STANDARD
 };
 
 //////////////////////////////////////////////////////////////////////////////
@@ -162,8 +194,8 @@ void _printR(Pattern<TNeedle, AbndmAlgo> & me)
 
 //////////////////////////////////////////////////////////////////////////////
 
-template <typename TNeedle, typename TNeedle2>
-void setHost (Pattern<TNeedle, AbndmAlgo> & me, TNeedle2 const& needle)
+template <typename TNeedle>
+void _reinitPattern(Pattern<TNeedle, AbndmAlgo> & me)
 {
 SEQAN_CHECKPOINT
     typedef unsigned int TWord;
@@ -172,7 +204,7 @@ SEQAN_CHECKPOINT
     me.cP = 0;
     me.findNext = false;
 
-    me.needleLength = length(needle);
+    me.needleLength = length(needle(me));
     if (me.needleLength<1)
         me.blockCount = 1;
     else
@@ -183,13 +215,13 @@ SEQAN_CHECKPOINT
 
     for (TWord j = 0; j < me.needleLength; ++j) {
         // Determine character position in array table
-        TWord pos = convert<TWord>(getValue(needle,j));
+        TWord pos = convert<TWord>(getValue(needle(me),j));
         me.b_table[me.blockCount*pos + j / BitsPerValue<TWord>::VALUE] |= (1<<(j%BitsPerValue<TWord>::VALUE));
     }
 
 #ifdef SEQAN_DEBUG_ABNDM
-    std::cout << "Needle:   " << needle << std::endl;
-    std::cout << "|Needle|: " << length(needle) << std::endl;
+    std::cout << "Needle:   " << needle(me) << std::endl;
+    std::cout << "|Needle|: " << length(needle(me)) << std::endl;
     std::cout << "Alphabet size: " << ValueSize<TValue>::VALUE << std::endl;
 
     for(unsigned i=0;i<ValueSize<TValue>::VALUE;++i) {
@@ -206,14 +238,7 @@ SEQAN_CHECKPOINT
 #endif
     clear(me.r_table); // init is only possible if we know the the error count
 
-    me.data_host = needle;
-    setHost(me.verifier,needle);
-}
-
-template <typename TNeedle, typename TNeedle2>
-void setHost (Pattern<TNeedle, AbndmAlgo> & me, TNeedle2 & needle)
-{
-    setHost(me, reinterpret_cast<TNeedle2 const &>(needle));
+    setHost(me.verifier, needle(me));  // Set the same host to the verifier.
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -227,24 +252,6 @@ inline void _patternInit (Pattern<TNeedle, AbndmAlgo> & me)
     me.findNext = false;
     me.last = 0;
     _findBeginInit(me, needle(me));
-}
-
-//////////////////////////////////////////////////////////////////////////////
-
-template <typename TNeedle>
-inline typename Host<Pattern<TNeedle, AbndmAlgo> >::Type &
-host(Pattern<TNeedle, AbndmAlgo> & me)
-{
-    SEQAN_CHECKPOINT
-    return value(me.data_host);
-}
-
-template <typename TNeedle>
-inline typename Host<Pattern<TNeedle, AbndmAlgo> const>::Type &
-host(Pattern<TNeedle, AbndmAlgo> const & me)
-{
-    SEQAN_CHECKPOINT
-    return value(me.data_host);
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/include/seqan/find/find_ahocorasick.h
+++ b/include/seqan/find/find_ahocorasick.h
@@ -115,30 +115,24 @@ public:
     Pattern() : data_keywordIndex(0), data_needleLength(0)
     {}
 
+#ifdef SEQAN_CXX11_STANDARD
+    template <typename TNeedle2>
+    Pattern(TNeedle2 && ndl,
+            SEQAN_CTOR_DISABLE_IF(IsSameType<typename std::remove_reference<TNeedle2>::type const &, Pattern const &>))
+        : data_keywordIndex(0), data_needleLength(0)
+    {
+        setHost(*this, std::forward<TNeedle2>(ndl));
+        ignoreUnusedVariableWarning(dummy);
+    }
+#else
+
     template <typename TNeedle2>
     Pattern(TNeedle2 const & ndl) : data_keywordIndex(0), data_needleLength(0)
     {
         setHost(*this, ndl);
     }
-
+#endif  // SEQAN_CXX11_STANDARD
 //____________________________________________________________________________
-};
-
-
-//////////////////////////////////////////////////////////////////////////////
-// Host Metafunctions
-//////////////////////////////////////////////////////////////////////////////
-
-template <typename TNeedle>
-struct Host< Pattern<TNeedle, AhoCorasick> >
-{
-    typedef TNeedle Type;
-};
-
-template <typename TNeedle>
-struct Host< Pattern<TNeedle, AhoCorasick> const>
-{
-    typedef TNeedle const Type;
 };
 
 
@@ -213,11 +207,10 @@ _createAcTrie(Pattern<TNeedle, AhoCorasick> & me)
 }
 
 
-template <typename TNeedle, typename TNeedle2>
-void setHost (Pattern<TNeedle, AhoCorasick> & me, TNeedle2 const & needle) {
+template <typename TNeedle>
+void _reinitPattern(Pattern<TNeedle, AhoCorasick> & me) {
     SEQAN_CHECKPOINT;
-    SEQAN_ASSERT_NOT(empty(needle));
-    setValue(me.data_host, needle);
+    SEQAN_ASSERT_NOT(empty(needle(me)));
     clear(me.data_graph);
     clear(me.data_supplyMap);
     clear(me.data_endPositions);
@@ -238,13 +231,6 @@ void setHost (Pattern<TNeedle, AhoCorasick> & me, TNeedle2 const & needle) {
     //for(unsigned int i=0;i<length(me.data_supplyMap);++i) {
     //    std::cout << i << "->" << getProperty(me.data_supplyMap,i) << std::endl;
     //}
-}
-
-template <typename TNeedle, typename TNeedle2>
-inline void
-setHost (Pattern<TNeedle, AhoCorasick> & me, TNeedle2 & needle)
-{
-    setHost(me, reinterpret_cast<TNeedle2 const &>(needle));
 }
 
 //____________________________________________________________________________

--- a/include/seqan/find/find_begin.h
+++ b/include/seqan/find/find_begin.h
@@ -129,6 +129,10 @@ struct FindBeginImpl_
     _findBeginInit(TPattern & pattern, TNeedle & needle_)
     {
 //        setNeedle(pattern.data_findBeginPattern, reverseString(needle(pattern)));
+        // TODO(rrahn): Mhmm, is this really intended here, or is it due to a wrong design of setHost of patterns which always copies instread of strong the reference where it can?
+        // It could happen, that we are really overwriting the original needle, if it was passed as non-const lvalue reference.
+        // The version above would be safer, as reverseString always returns a copy.
+        // But maybe the set function of ModifiedStrings is overloaded such that we will do a copy anyway in the holder class.
         setHost(needle(pattern.data_findBeginPattern), needle_);
         setScoringScheme(pattern.data_findBeginPattern, scoringScheme(pattern));
     }

--- a/include/seqan/find/find_bndm.h
+++ b/include/seqan/find/find_bndm.h
@@ -79,12 +79,23 @@ public:
 
     Pattern() {}
 
+#ifdef SEQAN_CXX11_STANDARD
+    template <typename TNeedle2>
+    Pattern(TNeedle2 && ndl,
+            SEQAN_CTOR_DISABLE_IF(IsSameType<typename std::remove_reference<TNeedle2>::type const &, Pattern const &>))
+    {
+        setHost(*this, std::forward<TNeedle2>(ndl));
+        ignoreUnusedVariableWarning(dummy);
+    }
+
+#else
+
     template <typename TNeedle2>
     Pattern(TNeedle2 const & ndl)
     {
         setHost(*this, ndl);
     }
-
+#endif  // SEQAN_CXX11_STANDARD
 //____________________________________________________________________________
 };
 
@@ -93,13 +104,13 @@ public:
 // Functions
 //////////////////////////////////////////////////////////////////////////////
 
-template <typename TNeedle, typename TNeedle2>
-void setHost (Pattern<TNeedle, BndmAlgo> & me, TNeedle2 const& needle) {
+template <typename TNeedle>
+void _reinitPattern(Pattern<TNeedle, BndmAlgo> & me) {
     SEQAN_CHECKPOINT
     typedef unsigned int TWord;
     typedef typename Value<TNeedle>::Type TValue;
 
-    me.needleLength = length(needle);
+    me.needleLength = length(needle(me));
     if (me.needleLength<1) me.blockCount=1;
     else me.blockCount=((me.needleLength-1) / BitsPerValue<TWord>::VALUE)+1;
 
@@ -108,11 +119,9 @@ void setHost (Pattern<TNeedle, BndmAlgo> & me, TNeedle2 const& needle) {
 
     for (TWord j = 0; j < me.needleLength; ++j) {
         // Determine character position in array table
-        TWord pos = convert<TWord>(getValue(needle,j));
+        TWord pos = convert<TWord>(getValue(needle(me),j));
         me.table[me.blockCount*pos + j / BitsPerValue<TWord>::VALUE] |= (1<<(j%BitsPerValue<TWord>::VALUE));
     }
-
-    setValue(me.data_host, needle);
     /*
     // Debug code
     std::cout << "Alphabet size: " << ValueSize<TValue>::VALUE << std::endl;
@@ -130,12 +139,6 @@ void setHost (Pattern<TNeedle, BndmAlgo> & me, TNeedle2 const& needle) {
         std::cout << std::endl;
     }
     */
-}
-
-template <typename TNeedle, typename TNeedle2>
-void setHost (Pattern<TNeedle, BndmAlgo> & me, TNeedle2 & needle)
-{
-    setHost(me, reinterpret_cast<TNeedle2 const &>(needle));
 }
 
 //____________________________________________________________________________
@@ -159,6 +162,8 @@ inline bool _findBndmSmallNeedle(TFinder & finder,
                                   Pattern<TNeedle, BndmAlgo> & me) {
     SEQAN_CHECKPOINT
     typedef unsigned int TWord;
+    typedef typename Value<TNeedle>::Type TNeedleAlphabet;
+
     if (me.haystackLength < me.needleLength) return false;
     while (position(finder) <= me.haystackLength - me.needleLength)
     {
@@ -167,7 +172,7 @@ inline bool _findBndmSmallNeedle(TFinder & finder,
         me.activeFactors[0]=~0;
         while (me.activeFactors[0]!=0)
         {
-            TWord pos = convert<TWord>(*(finder+j-1));
+            TWord pos = convert<TWord>(convert<TNeedleAlphabet>(*(finder+j-1)));
             me.activeFactors[0] = (me.activeFactors[0] & me.table[me.blockCount*pos]);
             j--;
             if ((me.activeFactors[0] & 1) != 0)
@@ -190,6 +195,8 @@ template <typename TFinder, typename TNeedle>
 inline bool _findBndmLargeNeedle(TFinder & finder, Pattern<TNeedle, BndmAlgo> & me) {
     SEQAN_CHECKPOINT
     typedef unsigned int TWord;
+    typedef typename Value<TNeedle>::Type TNeedleAlphabet;
+
     TWord carryPattern = ((TWord)1 << (BitsPerValue<TWord>::VALUE - 1));
     while (position(finder) <= me.haystackLength - me.needleLength) {
         me.last=me.needleLength;
@@ -197,7 +204,7 @@ inline bool _findBndmLargeNeedle(TFinder & finder, Pattern<TNeedle, BndmAlgo> & 
         for(TWord block=0;block<me.blockCount;++block) me.activeFactors[block]=~0;
         bool zeroPrefSufMatch = false;
         while (!zeroPrefSufMatch) {
-            TWord pos = convert<TWord>(*(finder+j-1));
+            TWord pos = convert<TWord>(convert<TNeedleAlphabet>(*(finder+j-1)));
 
             /*
             // Debug code

--- a/include/seqan/find/find_hamming_simple.h
+++ b/include/seqan/find/find_hamming_simple.h
@@ -83,19 +83,19 @@ public:
     Pattern(TNeedle2 && ndl,
             int k = -1,
             SEQAN_CTOR_DISABLE_IF(IsSameType<typename std::remove_reference<TNeedle2>::type const &, Pattern const &>))
-                :   maxDistance(-1),
+                :   maxDistance(-k),
                     distance(0),
                     matchNFlags(0)
     {
-        setHost(*this, std::forward<TNeedle2>(ndl), k);
+        setHost(*this, std::forward<TNeedle2>(ndl));
         ignoreUnusedVariableWarning(dummy);
     }
 
 #else
     template <typename TNeedle2>
-    Pattern(const TNeedle2 &ndl, int k = -1) : maxDistance(-1), distance(0), matchNFlags(0) {
+    Pattern(const TNeedle2 &ndl, int k = -1) : maxDistance(-k), distance(0), matchNFlags(0) {
         SEQAN_CHECKPOINT;
-        setHost(*this, ndl, k);
+        setHost(*this, ndl);
     }
 #endif  // SEQAN_CXX11_STANDARD
 };
@@ -120,18 +120,6 @@ inline void _patternMatchNOfFinder(Pattern<TNeedle, HammingSimple> & pattern, bo
     else
         pattern.matchNFlags &= 1;  // &= 01b
     pattern.matchNFlags |= 4;
-}
-
-
-template <typename TNeedle>
-void _reinitPattern(Pattern<TNeedle, HammingSimple> & me, int k)
-{
-    SEQAN_CHECKPOINT;
-
-    SEQAN_ASSERT_NOT(empty(needle(me)));
-    SEQAN_ASSERT_LEQ_MSG(k, 0, "Are you confusing distances and scores?");
-
-    me.maxDistance = -k;
 }
 
 template <typename TNeedle>

--- a/include/seqan/find/find_hamming_simple.h
+++ b/include/seqan/find/find_hamming_simple.h
@@ -78,11 +78,26 @@ public:
 
     Pattern() : maxDistance(-1), distance(0), matchNFlags(0) {}
 
+#ifdef SEQAN_CXX11_STANDARD
+    template <typename TNeedle2>
+    Pattern(TNeedle2 && ndl,
+            int k = -1,
+            SEQAN_CTOR_DISABLE_IF(IsSameType<typename std::remove_reference<TNeedle2>::type const &, Pattern const &>))
+                :   maxDistance(-1),
+                    distance(0),
+                    matchNFlags(0)
+    {
+        setHost(*this, std::forward<TNeedle2>(ndl), k);
+        ignoreUnusedVariableWarning(dummy);
+    }
+
+#else
     template <typename TNeedle2>
     Pattern(const TNeedle2 &ndl, int k = -1) : maxDistance(-1), distance(0), matchNFlags(0) {
         SEQAN_CHECKPOINT;
         setHost(*this, ndl, k);
     }
+#endif  // SEQAN_CXX11_STANDARD
 };
 
 
@@ -108,26 +123,16 @@ inline void _patternMatchNOfFinder(Pattern<TNeedle, HammingSimple> & pattern, bo
 }
 
 
-template <typename TNeedle, typename TNeedle2>
-void setHost (Pattern<TNeedle, HammingSimple> & me,
-              const TNeedle2 & needle, int k) {
+template <typename TNeedle>
+void _reinitPattern(Pattern<TNeedle, HammingSimple> & me, int k)
+{
     SEQAN_CHECKPOINT;
 
-    SEQAN_ASSERT_NOT(empty(needle));
+    SEQAN_ASSERT_NOT(empty(needle(me)));
     SEQAN_ASSERT_LEQ_MSG(k, 0, "Are you confusing distances and scores?");
 
-    setValue(me.data_host, needle);
     me.maxDistance = -k;
 }
-
-
-template <typename TNeedle, typename TNeedle2>
-void
-setHost(Pattern<TNeedle, HammingSimple> &horsp, TNeedle2 &ndl, int k) {
-    SEQAN_CHECKPOINT;
-    setHost(horsp, reinterpret_cast<const TNeedle2&>(ndl), k);
-}
-
 
 template <typename TNeedle>
 inline void _finderInit(Pattern<TNeedle, HammingSimple> & me) {

--- a/include/seqan/find/find_multiple_bfam.h
+++ b/include/seqan/find/find_multiple_bfam.h
@@ -97,7 +97,7 @@ public:
             //note: if to_verify_begin == to_verify_end then searching in Haystack must go on
 
     //preprocessed data: these members are initialized in setHost
-    Holder<TNeedle> needle;
+    Holder<TNeedle> data_host;
     TGraph automaton; //automaton of the reverse lmin-prefixes of the keywords
     String<String<TNeedlePosition> > terminals; //map of terminal states in automaton
 
@@ -110,16 +110,29 @@ public:
     {
     }
 
+#ifdef SEQAN_CXX11_STANDARD
+    Pattern(Pattern && other) = delete;
+    Pattern & operator=(Pattern && other) = delete;
+
+    template <typename TNeedle2>
+    Pattern(TNeedle2 && ndl,
+            SEQAN_CTOR_DISABLE_IF(IsSameType<typename std::remove_reference<TNeedle2>::type const &, Pattern const &>))
+    {
+        setHost(*this, std::forward<TNeedle2>(ndl));
+        ignoreUnusedVariableWarning(dummy);
+    }
+
+#else
     template <typename TNeedle2>
     Pattern(TNeedle2 const & ndl)
     {
         SEQAN_CHECKPOINT
         setHost(*this, ndl);
     }
+# endif
 
     ~Pattern()
-    {
-    }
+    {}
 //____________________________________________________________________________
 
 private:
@@ -150,16 +163,14 @@ _buildAutomatonMultiBfam(Pattern<TNeedle, MultiBfam<Trie> > & me,
 
 //____________________________________________________________________________
 
-template <typename TNeedle, typename TAutomaton, typename TNeedle2>
-void _setHostMultiBfam(Pattern<TNeedle, MultiBfam<TAutomaton> > & me,
-                        TNeedle2 const & needle_)
+template <typename TNeedle, typename TAutomaton>
+void _reinitPattern(Pattern<TNeedle, MultiBfam<TAutomaton> > & me)
 {
     typedef typename Value<TNeedle>::Type TKeyword;
     typedef typename Value<TKeyword>::Type TValue;
     typedef typename Size<TKeyword>::Type TSize;
 
     //me.needle
-    setValue(me.needle, needle_);
     TNeedle & ndl = needle(me);
 
     //determine lmin
@@ -193,39 +204,6 @@ void _setHostMultiBfam(Pattern<TNeedle, MultiBfam<TAutomaton> > & me,
 
     //build automaton
     _buildAutomatonMultiBfam(me, strs);
-}
-
-template <typename TNeedle, typename TAutomaton, typename TNeedle2>
-void setHost (Pattern<TNeedle, MultiBfam<TAutomaton> > & me,
-              TNeedle2 const & needle)
-{
-    _setHostMultiBfam(me, needle);
-}
-
-template <typename TNeedle, typename TAutomaton, typename TNeedle2>
-inline void
-setHost(Pattern<TNeedle, MultiBfam<TAutomaton> > & me,
-        TNeedle2 & needle)
-{
-    _setHostMultiBfam(me, needle);
-}
-
-//////////////////////////////////////////////////////////////////////////////
-
-template <typename TNeedle, typename TAutomaton>
-inline typename Host<Pattern<TNeedle, MultiBfam<TAutomaton> > >::Type &
-host(Pattern<TNeedle, MultiBfam<TAutomaton> > & me)
-{
-SEQAN_CHECKPOINT
-    return value(me.needle);
-}
-
-template <typename TNeedle, typename TAutomaton>
-inline typename Host<Pattern<TNeedle, MultiBfam<TAutomaton> > const>::Type &
-host(Pattern<TNeedle, MultiBfam<TAutomaton> > const & me)
-{
-SEQAN_CHECKPOINT
-    return value(me.needle);
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/include/seqan/find/find_myers_ukkonen.h
+++ b/include/seqan/find/find_myers_ukkonen.h
@@ -672,102 +672,12 @@ _patternMatchNOfFinder(Pattern<TNeedle, Myers<TSpec, THasState, void> > & patter
     _patternMatchNOfFinderImpl(pattern, match);
 }
 
-
-// data_host is not used anymore, the needle can be reconstructed from the bitmasks
-//template <typename TNeedle, typename TSpec, typename THasState, typename TFindBeginPatternSpec, typename TNeedle2>
-//inline void
-//_myersSetHost(Pattern<TNeedle, Myers<TSpec, THasState, TFindBeginPatternSpec> > &, TNeedle2 const &)
-//{
-//}
-//
-//template <typename TNeedle, typename TSpec, typename TFinderCSP, typename TPatternCSP, typename THasState, typename TFindBeginPatternSpec, typename TNeedle2>
-//inline void
-//_myersSetHost(Pattern<TNeedle, Myers<AlignTextBanded<TSpec, TFinderCSP, TPatternCSP>, THasState, TFindBeginPatternSpec> > & pattern, TNeedle2 const & ndl)
-//{
-//    setValue(pattern.data_host, ndl);
-//}
-
-// TODO(rrahn): At the moment we simply delegate to _patternFirstInit, as I am not sure if it is called from somewhere else.
 template <typename TNeedle, typename TSpec, typename THasState, typename TFindBeginPatternSpec>
 inline void
 _reinitPattern(Pattern<TNeedle, Myers<TSpec, THasState, TFindBeginPatternSpec> > & pattern)
 {
     _patternFirstInit(pattern, needle(pattern));
 }
-
-
-//____________________________________________________________________________
-
-
-//template <typename TNeedle, typename TSpec, typename TFinderCSP, typename TPatternCSP, typename THasState, typename TFindBeginPatternSpec>
-//inline typename Host<Pattern<TNeedle, Myers<AlignTextBanded<TSpec, TFinderCSP, TPatternCSP>, THasState, TFindBeginPatternSpec> > >::Type &
-//host(Pattern<TNeedle, Myers<AlignTextBanded<TSpec, TFinderCSP, TPatternCSP>, THasState, TFindBeginPatternSpec> > & pattern)
-//{
-//SEQAN_CHECKPOINT
-//    return value(pattern.data_host);
-//}
-//
-//
-//template <typename TNeedle, typename TSpec, typename TFinderCSP, typename TPatternCSP, typename THasState, typename TFindBeginPatternSpec>
-//inline typename Host<Pattern<TNeedle, Myers<AlignTextBanded<TSpec, TFinderCSP, TPatternCSP>, THasState, TFindBeginPatternSpec> > const>::Type &
-//host(Pattern<TNeedle, Myers<AlignTextBanded<TSpec, TFinderCSP, TPatternCSP>, THasState, TFindBeginPatternSpec> > const & pattern)
-//{
-//SEQAN_CHECKPOINT
-//    return value(pattern.data_host);
-//}
-//
-//
-//template <typename TNeedle, typename TSpec, typename THasState, typename TFindBeginPatternSpec>
-//inline TNeedle
-//host(Pattern<TNeedle, Myers<TSpec, THasState, TFindBeginPatternSpec> > const & pattern)
-//{
-//SEQAN_CHECKPOINT
-//
-//    typedef typename Pattern<TNeedle, Myers<TSpec, TFindBeginPatternSpec> >::TWord TWord;
-//    typedef typename Value<TNeedle>::Type TValue;
-//
-//    TNeedle temp;
-//    resize(temp, pattern.needleSize, Exact());
-//
-//    unsigned blockCount = (pattern.needleSize + pattern.MACHINE_WORD_SIZE - 1) / pattern.MACHINE_WORD_SIZE;
-//    TValue v = TValue();
-//    for (unsigned i = 0; i < length(pattern.bitMasks); i += blockCount)
-//    {
-//        for (unsigned j = 0; j < pattern.needleSize; j++)
-//            if ((pattern.bitMasks[i + j / pattern.MACHINE_WORD_SIZE] & (TWord)1 << (j % pattern.MACHINE_WORD_SIZE)) != (TWord)0)
-//                temp[j] = v;
-//        ++v;
-//    }
-//    return temp;
-//}
-//
-//template <typename TNeedle, typename TSpec, typename THasState, typename TFindBeginPatternSpec>
-//inline TNeedle
-//host(Pattern<TNeedle, Myers<TSpec, THasState, TFindBeginPatternSpec> > & pattern)
-//{
-//SEQAN_CHECKPOINT
-//    typedef Pattern<TNeedle, Myers<TSpec, THasState, TFindBeginPatternSpec> > TPattern;
-//    return host(const_cast<TPattern const &>(pattern));
-//}
-
-//____________________________________________________________________________
-
-//template <typename TNeedle, typename TSpec, typename THasState, typename TFindBeginPatternSpec>
-//inline TNeedle
-//needle(Pattern<TNeedle, Myers<TSpec, THasState, TFindBeginPatternSpec> > const & pattern)
-//{
-//SEQAN_CHECKPOINT
-//    return host(pattern);
-//}
-//
-//template <typename TNeedle, typename TSpec, typename THasState, typename TFindBeginPatternSpec>
-//inline TNeedle
-//needle(Pattern<TNeedle, Myers<TSpec, THasState, TFindBeginPatternSpec> > & pattern)
-//{
-//SEQAN_CHECKPOINT
-//    typedef Pattern<TNeedle, Myers<TSpec, THasState, TFindBeginPatternSpec> > TPattern;
-//    return host(const_cast<TPattern const &>(pattern));
-//}
 
 //____________________________________________________________________________
 /*!

--- a/include/seqan/find/find_myers_ukkonen.h
+++ b/include/seqan/find/find_myers_ukkonen.h
@@ -298,6 +298,16 @@ public:
             largeState = new TLargeState(*other.largeState);
     }
 
+#ifdef SEQAN_CXX11_STANDARD
+    // Add move constructor.
+    PatternState_(PatternState_ && other):
+        TSmallState(std::forward<PatternState_>(other)),
+        largeState(NULL)
+    {
+        swap(largeState, other.largeState);
+    }
+#endif  // SEQAN_CXX11_STANDARD
+
     ~PatternState_()
     {
         delete largeState;
@@ -318,6 +328,20 @@ public:
         }
         return *this;
     }
+
+#ifdef SEQAN_CXX11_STANDARD
+    // Add move assignment.
+    PatternState_&
+    operator=(PatternState_ && other)
+    {
+        TSmallState::operator=(std::forward<PatternState_>(other));
+        delete largeState;
+        largeState = NULL; // *this is now in a valid state in case of self assignment.
+        largeState = other.largeState;
+        other.largeState = NULL;  // We moved the data.
+        return *this;
+    }
+#endif  // SEQAN_CXX11_STANDARD
 };
 
 
@@ -334,6 +358,7 @@ struct MyersSmallPattern_
     typedef unsigned long TWord;
 #endif
 
+    Holder<TNeedle> data_host;   // Hold a reference to the needle
     String<TWord> bitMasks;        // encode the needle with bitmasks for each alphabet character
     unsigned needleSize;        // needle size
 
@@ -411,6 +436,24 @@ public:
             largePattern = new TLargePattern(*other.largePattern);
     }
 
+#ifdef SEQAN_CXX11_STANDARD
+    // Add move constructor.
+    Pattern(Pattern && other) :
+        TSmallPattern(std::forward<Pattern>(other)),
+        TPatternState(std::forward<Pattern>(other)),
+        largePattern(NULL)
+    {
+        swap(largePattern, other.largePattern);  // swap the content setting the large pattern of other to NULL.
+    }
+
+    template <typename TNeedle2>
+    Pattern(TNeedle2 && ndl, int _limit = -1) :
+        largePattern(NULL)
+    {
+        setScoreLimit(*this, _limit);
+        setHost(*this, std::forward<TNeedle2>(ndl));
+    }
+#else
     template <typename TNeedle2>
     Pattern(TNeedle2 const & ndl, int _limit = -1):
         largePattern(NULL)
@@ -418,6 +461,7 @@ public:
         setScoreLimit(*this, _limit);
         setHost(*this, ndl);
     }
+#endif  // SEQAN_CXX11_STANDARD
 
     ~Pattern()
     {
@@ -440,6 +484,21 @@ public:
         }
         return *this;
     }
+
+#ifdef SEQAN_CXX11_STANDARD
+    // Add move assignment.
+    Pattern &
+    operator= (Pattern && other)
+    {
+        TSmallPattern::operator=(std::forward<Pattern>(other));
+        TPatternState::operator=(std::forward<Pattern>(other));
+        delete largePattern;  // delete old data.
+        largePattern = NULL;  // *this is now in a valid state in case of self-assignment.
+        largePattern = other.largePattern;  // Move data.
+        other.largePattern = NULL;  // Reset other to default.
+        return *this;
+    }
+#endif  // SEQAN_CXX11_STANDARD
 };
 
 //////////////////////////////////////////////////////////////////////////////
@@ -615,109 +674,100 @@ _patternMatchNOfFinder(Pattern<TNeedle, Myers<TSpec, THasState, void> > & patter
 
 
 // data_host is not used anymore, the needle can be reconstructed from the bitmasks
-template <typename TNeedle, typename TSpec, typename THasState, typename TFindBeginPatternSpec, typename TNeedle2>
-inline void
-_myersSetHost(Pattern<TNeedle, Myers<TSpec, THasState, TFindBeginPatternSpec> > &, TNeedle2 const &)
-{
-}
+//template <typename TNeedle, typename TSpec, typename THasState, typename TFindBeginPatternSpec, typename TNeedle2>
+//inline void
+//_myersSetHost(Pattern<TNeedle, Myers<TSpec, THasState, TFindBeginPatternSpec> > &, TNeedle2 const &)
+//{
+//}
+//
+//template <typename TNeedle, typename TSpec, typename TFinderCSP, typename TPatternCSP, typename THasState, typename TFindBeginPatternSpec, typename TNeedle2>
+//inline void
+//_myersSetHost(Pattern<TNeedle, Myers<AlignTextBanded<TSpec, TFinderCSP, TPatternCSP>, THasState, TFindBeginPatternSpec> > & pattern, TNeedle2 const & ndl)
+//{
+//    setValue(pattern.data_host, ndl);
+//}
 
-template <typename TNeedle, typename TSpec, typename TFinderCSP, typename TPatternCSP, typename THasState, typename TFindBeginPatternSpec, typename TNeedle2>
+// TODO(rrahn): At the moment we simply delegate to _patternFirstInit, as I am not sure if it is called from somewhere else.
+template <typename TNeedle, typename TSpec, typename THasState, typename TFindBeginPatternSpec>
 inline void
-_myersSetHost(Pattern<TNeedle, Myers<AlignTextBanded<TSpec, TFinderCSP, TPatternCSP>, THasState, TFindBeginPatternSpec> > & pattern, TNeedle2 const & ndl)
+_reinitPattern(Pattern<TNeedle, Myers<TSpec, THasState, TFindBeginPatternSpec> > & pattern)
 {
-    setValue(pattern.data_host, ndl);
-}
-
-template <typename TNeedle, typename TSpec, typename THasState, typename TFindBeginPatternSpec, typename TNeedle2>
-inline void
-setHost(Pattern<TNeedle, Myers<TSpec, THasState, TFindBeginPatternSpec> > & pattern, TNeedle2 & ndl)
-{
-    _myersSetHost(pattern, ndl);
-    _patternFirstInit(pattern, ndl);
-}
-
-
-template <typename TNeedle, typename TSpec, typename THasState, typename TFindBeginPatternSpec, typename TNeedle2>
-inline void
-setHost(Pattern<TNeedle, Myers<TSpec, THasState, TFindBeginPatternSpec> > & pattern, TNeedle2 const & ndl)
-{
-    _myersSetHost(pattern, ndl);
-    _patternFirstInit(pattern, ndl);
+    _patternFirstInit(pattern, needle(pattern));
 }
 
 
 //____________________________________________________________________________
 
 
-template <typename TNeedle, typename TSpec, typename TFinderCSP, typename TPatternCSP, typename THasState, typename TFindBeginPatternSpec>
-inline typename Host<Pattern<TNeedle, Myers<AlignTextBanded<TSpec, TFinderCSP, TPatternCSP>, THasState, TFindBeginPatternSpec> > >::Type &
-host(Pattern<TNeedle, Myers<AlignTextBanded<TSpec, TFinderCSP, TPatternCSP>, THasState, TFindBeginPatternSpec> > & pattern)
-{
-SEQAN_CHECKPOINT
-    return value(pattern.data_host);
-}
-
-
-template <typename TNeedle, typename TSpec, typename TFinderCSP, typename TPatternCSP, typename THasState, typename TFindBeginPatternSpec>
-inline typename Host<Pattern<TNeedle, Myers<AlignTextBanded<TSpec, TFinderCSP, TPatternCSP>, THasState, TFindBeginPatternSpec> > const>::Type &
-host(Pattern<TNeedle, Myers<AlignTextBanded<TSpec, TFinderCSP, TPatternCSP>, THasState, TFindBeginPatternSpec> > const & pattern)
-{
-SEQAN_CHECKPOINT
-    return value(pattern.data_host);
-}
-
-
-template <typename TNeedle, typename TSpec, typename THasState, typename TFindBeginPatternSpec>
-inline TNeedle
-host(Pattern<TNeedle, Myers<TSpec, THasState, TFindBeginPatternSpec> > const & pattern)
-{
-SEQAN_CHECKPOINT
-
-    typedef typename Pattern<TNeedle, Myers<TSpec, TFindBeginPatternSpec> >::TWord TWord;
-    typedef typename Value<TNeedle>::Type TValue;
-
-    TNeedle temp;
-    resize(temp, pattern.needleSize, Exact());
-
-    unsigned blockCount = (pattern.needleSize + pattern.MACHINE_WORD_SIZE - 1) / pattern.MACHINE_WORD_SIZE;
-    TValue v = TValue();
-    for (unsigned i = 0; i < length(pattern.bitMasks); i += blockCount)
-    {
-        for (unsigned j = 0; j < pattern.needleSize; j++)
-            if ((pattern.bitMasks[i + j / pattern.MACHINE_WORD_SIZE] & (TWord)1 << (j % pattern.MACHINE_WORD_SIZE)) != (TWord)0)
-                temp[j] = v;
-        ++v;
-    }
-    return temp;
-}
-
-template <typename TNeedle, typename TSpec, typename THasState, typename TFindBeginPatternSpec>
-inline TNeedle
-host(Pattern<TNeedle, Myers<TSpec, THasState, TFindBeginPatternSpec> > & pattern)
-{
-SEQAN_CHECKPOINT
-    typedef Pattern<TNeedle, Myers<TSpec, THasState, TFindBeginPatternSpec> > TPattern;
-    return host(const_cast<TPattern const &>(pattern));
-}
+//template <typename TNeedle, typename TSpec, typename TFinderCSP, typename TPatternCSP, typename THasState, typename TFindBeginPatternSpec>
+//inline typename Host<Pattern<TNeedle, Myers<AlignTextBanded<TSpec, TFinderCSP, TPatternCSP>, THasState, TFindBeginPatternSpec> > >::Type &
+//host(Pattern<TNeedle, Myers<AlignTextBanded<TSpec, TFinderCSP, TPatternCSP>, THasState, TFindBeginPatternSpec> > & pattern)
+//{
+//SEQAN_CHECKPOINT
+//    return value(pattern.data_host);
+//}
+//
+//
+//template <typename TNeedle, typename TSpec, typename TFinderCSP, typename TPatternCSP, typename THasState, typename TFindBeginPatternSpec>
+//inline typename Host<Pattern<TNeedle, Myers<AlignTextBanded<TSpec, TFinderCSP, TPatternCSP>, THasState, TFindBeginPatternSpec> > const>::Type &
+//host(Pattern<TNeedle, Myers<AlignTextBanded<TSpec, TFinderCSP, TPatternCSP>, THasState, TFindBeginPatternSpec> > const & pattern)
+//{
+//SEQAN_CHECKPOINT
+//    return value(pattern.data_host);
+//}
+//
+//
+//template <typename TNeedle, typename TSpec, typename THasState, typename TFindBeginPatternSpec>
+//inline TNeedle
+//host(Pattern<TNeedle, Myers<TSpec, THasState, TFindBeginPatternSpec> > const & pattern)
+//{
+//SEQAN_CHECKPOINT
+//
+//    typedef typename Pattern<TNeedle, Myers<TSpec, TFindBeginPatternSpec> >::TWord TWord;
+//    typedef typename Value<TNeedle>::Type TValue;
+//
+//    TNeedle temp;
+//    resize(temp, pattern.needleSize, Exact());
+//
+//    unsigned blockCount = (pattern.needleSize + pattern.MACHINE_WORD_SIZE - 1) / pattern.MACHINE_WORD_SIZE;
+//    TValue v = TValue();
+//    for (unsigned i = 0; i < length(pattern.bitMasks); i += blockCount)
+//    {
+//        for (unsigned j = 0; j < pattern.needleSize; j++)
+//            if ((pattern.bitMasks[i + j / pattern.MACHINE_WORD_SIZE] & (TWord)1 << (j % pattern.MACHINE_WORD_SIZE)) != (TWord)0)
+//                temp[j] = v;
+//        ++v;
+//    }
+//    return temp;
+//}
+//
+//template <typename TNeedle, typename TSpec, typename THasState, typename TFindBeginPatternSpec>
+//inline TNeedle
+//host(Pattern<TNeedle, Myers<TSpec, THasState, TFindBeginPatternSpec> > & pattern)
+//{
+//SEQAN_CHECKPOINT
+//    typedef Pattern<TNeedle, Myers<TSpec, THasState, TFindBeginPatternSpec> > TPattern;
+//    return host(const_cast<TPattern const &>(pattern));
+//}
 
 //____________________________________________________________________________
 
-template <typename TNeedle, typename TSpec, typename THasState, typename TFindBeginPatternSpec>
-inline TNeedle
-needle(Pattern<TNeedle, Myers<TSpec, THasState, TFindBeginPatternSpec> > const & pattern)
-{
-SEQAN_CHECKPOINT
-    return host(pattern);
-}
-
-template <typename TNeedle, typename TSpec, typename THasState, typename TFindBeginPatternSpec>
-inline TNeedle
-needle(Pattern<TNeedle, Myers<TSpec, THasState, TFindBeginPatternSpec> > & pattern)
-{
-SEQAN_CHECKPOINT
-    typedef Pattern<TNeedle, Myers<TSpec, THasState, TFindBeginPatternSpec> > TPattern;
-    return host(const_cast<TPattern const &>(pattern));
-}
+//template <typename TNeedle, typename TSpec, typename THasState, typename TFindBeginPatternSpec>
+//inline TNeedle
+//needle(Pattern<TNeedle, Myers<TSpec, THasState, TFindBeginPatternSpec> > const & pattern)
+//{
+//SEQAN_CHECKPOINT
+//    return host(pattern);
+//}
+//
+//template <typename TNeedle, typename TSpec, typename THasState, typename TFindBeginPatternSpec>
+//inline TNeedle
+//needle(Pattern<TNeedle, Myers<TSpec, THasState, TFindBeginPatternSpec> > & pattern)
+//{
+//SEQAN_CHECKPOINT
+//    typedef Pattern<TNeedle, Myers<TSpec, THasState, TFindBeginPatternSpec> > TPattern;
+//    return host(const_cast<TPattern const &>(pattern));
+//}
 
 //____________________________________________________________________________
 /*!

--- a/include/seqan/find/find_pattern_base.h
+++ b/include/seqan/find/find_pattern_base.h
@@ -45,6 +45,13 @@ namespace seqan {
 
 //////////////////////////////////////////////////////////////////////////////
 
+template <typename TNeedle>
+class PatternBase
+{
+public:
+    Holder<TNeedle>  data_host;
+};
+
 /*!
  * @class Pattern
  * @headerfile <seqan/find.h>
@@ -71,11 +78,12 @@ class Pattern<TNeedle, void>
 public:
     typedef typename Position<TNeedle>::Type TNeedlePosition;
 
+
     Holder<TNeedle> data_host;
     TNeedlePosition data_begin_position;
     TNeedlePosition data_end_position;
 
-    Pattern() : data_begin_position(), data_end_position()
+    Pattern() : data_host(), data_begin_position(), data_end_position()
     {}
 
     template <typename TNeedle_>
@@ -85,7 +93,6 @@ public:
     template <typename TNeedle_>
     Pattern(TNeedle_ const & ndl) : data_host(ndl), data_begin_position(), data_end_position()
     {}
-
 };
 //////////////////////////////////////////////////////////////////////////////
 
@@ -221,36 +228,99 @@ struct ScoringScheme<TNeedle const>:
 //////////////////////////////////////////////////////////////////////////////
 
 template <typename TNeedle, typename TSpec>
+inline void
+_reinitPattern(Pattern<TNeedle, TSpec> &)
+{
+    // no-op.
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+template <typename TNeedle, typename TSpec>
 inline Holder<TNeedle> &
 _dataHost(Pattern<TNeedle, TSpec> & me)
 {
     return me.data_host;
 }
+
 template <typename TNeedle, typename TSpec>
-inline Holder<TNeedle> &
+inline Holder<TNeedle> const &
 _dataHost(Pattern<TNeedle, TSpec> const & me)
 {
-    return const_cast<Holder<TNeedle> &>(me.data_host);
+    return me.data_host;
 }
 
 //host access: see basic_host.h
 
+#ifdef SEQAN_CXX11_STANDARD
 
-//???TODO: Diese Funktion entfernen! (sobald setHost bei anderen pattern nicht mehr eine Art "assignHost" ist)
+template <typename TNeedle, typename TSpec, typename TNeedle2>
+inline void
+setHost(Pattern<TNeedle, TSpec> & me,
+        TNeedle2 && ndl)
+{
+    SEQAN_ASSERT(!empty(ndl));
+    setValue(_dataHost(me), std::forward<TNeedle2>(ndl));  // Set generic setHost function.
+    _reinitPattern(me);
+}
+
+template <typename TNeedle, typename TSpec, typename TNeedle2, typename TError>
+inline void
+setHost(Pattern<TNeedle, TSpec> & me,
+        TNeedle2 && ndl,
+        TError const k)
+{
+    SEQAN_ASSERT(!empty(ndl));
+    setValue(_dataHost(me), std::forward<TNeedle2>(ndl));  // Set generic setHost function.
+    _reinitPattern(me, k);
+}
+
+#else
+
 template <typename TNeedle, typename TSpec, typename TNeedle2>
 inline void
 setHost(Pattern<TNeedle, TSpec> & me,
         TNeedle2 const & ndl)
 {
-     me.data_host = ndl; //assign => Pattern haelt eine Kopie => doof!
+    SEQAN_ASSERT(!empty(ndl));
+    setValue(_dataHost(me), ndl);  // Set generic setHost function.
+    _reinitPattern(me);
 }
+
 template <typename TNeedle, typename TSpec, typename TNeedle2>
 inline void
 setHost(Pattern<TNeedle, TSpec> & me,
         TNeedle2 & ndl)
 {
-     me.data_host = ndl; //assign => Pattern haelt eine Kopie => doof!
+    SEQAN_ASSERT(!empty(ndl));
+    setValue(_dataHost(me), ndl);  // Set generic setHost function.
+    _reinitPattern(me);
 }
+
+template <typename TNeedle, typename TSpec, typename TNeedle2, typename TError>
+inline void
+setHost(Pattern<TNeedle, TSpec> & me,
+        TNeedle2 const & ndl,
+        TError const k)
+{
+    SEQAN_ASSERT(!empty(ndl));
+    setValue(_dataHost(me), ndl);  // Set generic setHost function.
+    _reinitPattern(me, k);
+}
+
+template <typename TNeedle, typename TSpec, typename TNeedle2, typename TError>
+inline void
+setHost(Pattern<TNeedle, TSpec> & me,
+        TNeedle2 & ndl,
+        TError const k)
+{
+    SEQAN_ASSERT(!empty(ndl));
+    setValue(_dataHost(me), ndl);  // Set generic setHost function.
+    _reinitPattern(me, k);
+}
+
+#endif  // SEQAN_CXX11_STANDARD
+
 //////////////////////////////////////////////////////////////////////////////
 
 template <typename TNeedle, typename TSpec>
@@ -332,7 +402,7 @@ template <typename TNeedle, typename TSpec>
 inline typename Host<Pattern<TNeedle, TSpec> >::Type &
 host(Pattern<TNeedle, TSpec> & me)
 {
-SEQAN_CHECKPOINT
+    SEQAN_CHECKPOINT
     return value(me.data_host);
 }
 
@@ -340,10 +410,9 @@ template <typename TNeedle, typename TSpec>
 inline typename Host<Pattern<TNeedle, TSpec> const>::Type &
 host(Pattern<TNeedle, TSpec> const & me)
 {
-SEQAN_CHECKPOINT
+    SEQAN_CHECKPOINT
     return value(me.data_host);
 }
-
 
 //////////////////////////////////////////////////////////////////////////////
 

--- a/include/seqan/find/find_pattern_base.h
+++ b/include/seqan/find/find_pattern_base.h
@@ -45,13 +45,6 @@ namespace seqan {
 
 //////////////////////////////////////////////////////////////////////////////
 
-template <typename TNeedle>
-class PatternBase
-{
-public:
-    Holder<TNeedle>  data_host;
-};
-
 /*!
  * @class Pattern
  * @headerfile <seqan/find.h>
@@ -260,7 +253,7 @@ setHost(Pattern<TNeedle, TSpec> & me,
         TNeedle2 && ndl)
 {
     SEQAN_ASSERT(!empty(ndl));
-    setValue(_dataHost(me), std::forward<TNeedle2>(ndl));  // Set generic setHost function.
+    setValue(_dataHost(me), std::forward<TNeedle2>(ndl));
     _reinitPattern(me);
 }
 
@@ -272,7 +265,7 @@ setHost(Pattern<TNeedle, TSpec> & me,
         TNeedle2 const & ndl)
 {
     SEQAN_ASSERT(!empty(ndl));
-    setValue(_dataHost(me), ndl);  // Set generic setHost function.
+    setValue(_dataHost(me), ndl);
     _reinitPattern(me);
 }
 
@@ -282,7 +275,7 @@ setHost(Pattern<TNeedle, TSpec> & me,
         TNeedle2 & ndl)
 {
     SEQAN_ASSERT(!empty(ndl));
-    setValue(_dataHost(me), ndl);  // Set generic setHost function.
+    setValue(_dataHost(me), ndl);
     _reinitPattern(me);
 }
 

--- a/include/seqan/find/find_pattern_base.h
+++ b/include/seqan/find/find_pattern_base.h
@@ -264,18 +264,7 @@ setHost(Pattern<TNeedle, TSpec> & me,
     _reinitPattern(me);
 }
 
-template <typename TNeedle, typename TSpec, typename TNeedle2, typename TError>
-inline void
-setHost(Pattern<TNeedle, TSpec> & me,
-        TNeedle2 && ndl,
-        TError const k)
-{
-    SEQAN_ASSERT(!empty(ndl));
-    setValue(_dataHost(me), std::forward<TNeedle2>(ndl));  // Set generic setHost function.
-    _reinitPattern(me, k);
-}
-
-#else
+#else  // SEQAN_CXX11_STANDARD
 
 template <typename TNeedle, typename TSpec, typename TNeedle2>
 inline void
@@ -295,28 +284,6 @@ setHost(Pattern<TNeedle, TSpec> & me,
     SEQAN_ASSERT(!empty(ndl));
     setValue(_dataHost(me), ndl);  // Set generic setHost function.
     _reinitPattern(me);
-}
-
-template <typename TNeedle, typename TSpec, typename TNeedle2, typename TError>
-inline void
-setHost(Pattern<TNeedle, TSpec> & me,
-        TNeedle2 const & ndl,
-        TError const k)
-{
-    SEQAN_ASSERT(!empty(ndl));
-    setValue(_dataHost(me), ndl);  // Set generic setHost function.
-    _reinitPattern(me, k);
-}
-
-template <typename TNeedle, typename TSpec, typename TNeedle2, typename TError>
-inline void
-setHost(Pattern<TNeedle, TSpec> & me,
-        TNeedle2 & ndl,
-        TError const k)
-{
-    SEQAN_ASSERT(!empty(ndl));
-    setValue(_dataHost(me), ndl);  // Set generic setHost function.
-    _reinitPattern(me, k);
 }
 
 #endif  // SEQAN_CXX11_STANDARD

--- a/include/seqan/find/find_pex.h
+++ b/include/seqan/find/find_pex.h
@@ -187,6 +187,32 @@ class Pattern<TNeedle, Pex<TVerification, TMultiFinder > >:
        limit(1), lastFPos(0), lastFNdl(0), findNext(false), patternNeedsInit(true)
    {}
 
+#ifdef SEQAN_CXX11_STANDARD
+    template <typename TNeedle2>
+    Pattern(TNeedle2 && ndl,
+            SEQAN_CTOR_DISABLE_IF(IsSameType<typename std::remove_reference<TNeedle2>::type const &, Pattern const &>)) :
+        limit(1),
+        lastFPos(0),
+        lastFNdl(0),
+        findNext(false),
+        patternNeedsInit(true)
+    {
+        setHost(*this, std::forward<TNeedle2>(ndl));
+        ignoreUnusedVariableWarning(dummy);
+    }
+
+    template <typename TNeedle2>
+    Pattern(TNeedle2 && ndl, int _limit = -1) :
+        limit(-_limit),
+        lastFPos(0),
+        lastFNdl(0),
+        findNext(false),
+        patternNeedsInit(true)
+    {
+        setHost(*this, std::forward<TNeedle2>(ndl));
+    }
+
+#else
    template <typename TNeedle2>
    Pattern(TNeedle2 const & ndl) :
        limit(1), lastFPos(0), lastFNdl(0), findNext(false), patternNeedsInit(true)
@@ -200,43 +226,19 @@ class Pattern<TNeedle, Pex<TVerification, TMultiFinder > >:
    {
      setHost(*this, ndl);
    }
+#endif  // SEQAN_CXX11_STANDARD
 };
 
 //////////////////////////////////////////////////////////////////////////////
 
-template <typename TNeedle, typename TNeedle2, typename TVerification, typename TMultiFinder>
-void setHost (Pattern<TNeedle, Pex<TVerification,TMultiFinder > > & me, TNeedle2 const & needle)
+template <typename TNeedle, typename TVerification, typename TMultiFinder>
+void _reinitPattern(Pattern<TNeedle, Pex<TVerification,TMultiFinder > > & me)
 {
   // initialisation of the find-tree etc. will be done when patternInit
   // is called to assure that we already know the scoreLimit
-  me.data_host = needle;
-  me.needleLength = length(needle);
+  me.needleLength = length(needle(me));
   me.findNext = false;
   me.patternNeedsInit = true;
-}
-
-template <typename TNeedle, typename TNeedle2, typename TVerification, typename TMultiFinder>
-void setHost (Pattern<TNeedle, Pex<TVerification,TMultiFinder > > & me, TNeedle2 & needle)
-{
-  setHost(me, reinterpret_cast<TNeedle2 const &>(needle));
-}
-
-//////////////////////////////////////////////////////////////////////////////
-
-template <typename TNeedle, typename TVerification, typename TMultiFinder>
-inline typename Host<Pattern<TNeedle, Pex<TVerification,TMultiFinder > > >::Type &
-host(Pattern<TNeedle, Pex<TVerification,TMultiFinder > > & me)
-{
-SEQAN_CHECKPOINT
-  return value(me.data_host);
-}
-
-template <typename TNeedle, typename TVerification, typename TMultiFinder>
-inline typename Host<Pattern<TNeedle, Pex<TVerification,TMultiFinder > > const>::Type &
-host(Pattern<TNeedle, Pex<TVerification,TMultiFinder > > const & me)
-{
-SEQAN_CHECKPOINT
-  return value(me.data_host);
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/include/seqan/find/find_score.h
+++ b/include/seqan/find/find_score.h
@@ -81,6 +81,24 @@ public:
     Pattern() : data_limit(0), data_maxscore(0)
     {}
 
+#ifdef SEQAN_CXX11_STANDARD
+    template <typename TNeedle2>
+    Pattern(TNeedle2 && ndl, TScore const & _score_func, TScoreValue _limit = 0) :
+        data_score(_score_func),
+        data_limit(_limit),
+        data_maxscore(0)
+    {
+        setHost(*this, std::forward<TNeedle2>(ndl));
+    }
+
+    template <typename TNeedle2>
+    Pattern(TNeedle2 && ndl, TScoreValue _limit = 0) :
+        data_limit(_limit),
+        data_maxscore(0)
+    {
+        setHost(*this, std::forward<TNeedle2>(ndl));
+    }
+#else  // TODO(rrahn): Replace when c11 is standard.
     Pattern(TNeedle & _needle, TScore const & _score_func, TScoreValue _limit = 0) :
         data_score(_score_func), data_limit(_limit), data_maxscore(0)
     {
@@ -92,6 +110,7 @@ public:
     {
         setHost(*this, _needle);
     }
+#endif  // SEQAN_CXX11_STANDARD
 
     Pattern(TScoreValue _limit) : data_limit(_limit), data_maxscore(0)
     {
@@ -107,6 +126,10 @@ public:
         data_maxscore( other.data_maxscore)
     {}
 
+#ifdef SEQAN_CXX11_STANDARD
+    Pattern(Pattern && other) = default;
+    Pattern& operator = (Pattern && other) = default;
+#endif
     inline Pattern &
     operator = (Pattern const & other)
     {
@@ -118,6 +141,9 @@ public:
 
         return *this;
     }
+
+    ~Pattern()
+    {}
 };
 
 //////////////////////////////////////////////////////////////////////////////
@@ -151,43 +177,15 @@ struct FindBeginPatternSpec <Pattern<TNeedle, DPSearch<TScore, FindPrefix, TFind
     typedef void Type;
 };
 
-//////////////////////////////////////////////////////////////////////////////
-
-
-template <typename TNeedle, typename TScore, typename TSpec, typename TFindBeginPatternSpec>
-inline typename Host<Pattern<TNeedle, DPSearch<TScore, TSpec, TFindBeginPatternSpec> > >::Type &
-host(Pattern<TNeedle, DPSearch<TScore, TSpec, TFindBeginPatternSpec> > & me)
-{
-    return value(me.data_host);
-}
-
-template <typename TNeedle, typename TScore, typename TSpec, typename TFindBeginPatternSpec>
-inline typename Host<Pattern<TNeedle, DPSearch<TScore, TSpec, TFindBeginPatternSpec> > const>::Type &
-host(Pattern<TNeedle, DPSearch<TScore, TSpec, TFindBeginPatternSpec> >  const & me)
-{
-    return value(me.data_host);
-}
-
 
 //____________________________________________________________________________
 
-template <typename TNeedle, typename TScore, typename TSpec, typename TFindBeginPatternSpec, typename TNeedle2>
-void
-setHost(Pattern<TNeedle, DPSearch<TScore, TSpec, TFindBeginPatternSpec> > & me,
-        TNeedle2 & ndl)
+template <typename TNeedle, typename TScore, typename TSpec, typename TFindBeginPatternSpec>
+inline void
+_reinitPattern(Pattern<TNeedle, DPSearch<TScore, TSpec, TFindBeginPatternSpec> > & me)
 {
-    me.data_host = ndl;
     clear(me.data_tab);
 }
-template <typename TNeedle, typename TScore, typename TSpec, typename TFindBeginPatternSpec, typename TNeedle2>
-void
-setHost(Pattern<TNeedle, DPSearch<TScore, TSpec, TFindBeginPatternSpec> > & me,
-        TNeedle2 const & ndl)
-{
-    me.data_host = ndl;
-    clear(me.data_tab);
-}
-
 
 //____________________________________________________________________________
 

--- a/include/seqan/find/find_shiftand.h
+++ b/include/seqan/find/find_shiftand.h
@@ -150,65 +150,6 @@ _reinitPattern(Pattern<TNeedle, ShiftAnd> & me)
     */
 }
 
-//template <typename TNeedle, typename TNeedle2>
-//inline void
-//setHost(Pattern<TNeedle, ShiftAnd> & me, TNeedle2 & needle)
-//{
-//    setHost(me, reinterpret_cast<TNeedle2 const &>(needle));
-//}
-
-//____________________________________________________________________________
-
-// TODO(rrahn): Pattern should always keep a pointer to the needle!
-//template <typename TNeedle>
-//inline TNeedle
-//host(Pattern<TNeedle, ShiftAnd> const & pattern)
-//{
-//SEQAN_CHECKPOINT
-//
-//    typedef typename Pattern<TNeedle, ShiftAnd>::TWord TWord;
-//    typedef typename Value<TNeedle>::Type TValue;
-//
-//    TNeedle temp;
-//    resize(temp, pattern.needleLength, Exact());
-//
-//    TValue v = TValue();
-//    for (unsigned i = 0; i < length(pattern.bitMasks); i += pattern.blockCount)
-//    {
-//        for (unsigned j = 0; j < pattern.needleLength; j++)
-//            if ((pattern.bitMasks[i + j / pattern.MACHINE_WORD_SIZE] & (TWord)1 << (j % pattern.MACHINE_WORD_SIZE)) != (TWord)0)
-//                temp[j] = v;
-//        ++v;
-//    }
-//    return temp;
-//}
-//
-//template <typename TNeedle>
-//inline TNeedle
-//host(Pattern<TNeedle, ShiftAnd> & pattern)
-//{
-//SEQAN_CHECKPOINT
-//    return host(const_cast<Pattern<TNeedle, ShiftAnd> const &>(pattern));
-//}
-//
-////____________________________________________________________________________
-//
-//template <typename TNeedle>
-//inline TNeedle
-//needle(Pattern<TNeedle, ShiftAnd> const & pattern)
-//{
-//SEQAN_CHECKPOINT
-//    return host(pattern);
-//}
-//
-//template <typename TNeedle>
-//inline TNeedle
-//needle(Pattern<TNeedle, ShiftAnd> & pattern)
-//{
-//SEQAN_CHECKPOINT
-//    return host(const_cast<Pattern<TNeedle, ShiftAnd> const &>(pattern));
-//}
-
 //____________________________________________________________________________
 
 template <typename TNeedle>

--- a/include/seqan/find/find_shiftand.h
+++ b/include/seqan/find/find_shiftand.h
@@ -64,29 +64,39 @@ typedef Tag<ShiftAnd_> ShiftAnd;
 //////////////////////////////////////////////////////////////////////////////
 
 template <typename TNeedle>
-class Pattern<TNeedle, ShiftAnd> {
+class Pattern<TNeedle, ShiftAnd>
+{
 //____________________________________________________________________________
 public:
     typedef unsigned int TWord;
     enum { MACHINE_WORD_SIZE = sizeof(TWord) * 8 };
 
-//    Holder<TNeedle> data_host;
+    Holder<TNeedle>  data_host;
     String<TWord> bitMasks;            // Look up table for each character in the alphabet (called B in "Navarro")
     String<TWord> prefSufMatch;        // Set of all the prefixes of needle that match a suffix of haystack (called D in "Navarro")
     TWord needleLength;                // e.g., needleLength=33 --> blockCount=2 (iff w=32 bits)
     TWord blockCount;                // #unsigned ints required to store needle
 
-//____________________________________________________________________________
+    Pattern()
+    {}
 
-    Pattern() {}
+#ifdef SEQAN_CXX11_STANDARD
 
+    // Custom c'tor setting a needle.
+    template <typename TNeedle2>
+    Pattern(TNeedle2 && ndl, SEQAN_CTOR_DISABLE_IF(IsSameType<typename std::remove_reference<TNeedle2>::type const &, Pattern const &>))
+    {
+        setHost(*this, std::forward<TNeedle2>(ndl));
+        ignoreUnusedVariableWarning(dummy);
+    }
+#else
     template <typename TNeedle2>
     Pattern(TNeedle2 const & ndl)
     {
         setHost(*this, ndl);
     }
+#endif  // SEQAN_CXX11_STANDARD
 
-//____________________________________________________________________________
 };
 
 
@@ -94,15 +104,17 @@ public:
 // Functions
 //////////////////////////////////////////////////////////////////////////////
 
-template <typename TNeedle, typename TNeedle2>
+template <typename TNeedle>
 inline void
-setHost(Pattern<TNeedle, ShiftAnd> & me, TNeedle2 const & needle)
+_reinitPattern(Pattern<TNeedle, ShiftAnd> & me)
 {
     SEQAN_CHECKPOINT
     typedef unsigned int TWord;
     typedef typename Value<TNeedle>::Type TValue;
 
-    me.needleLength = length(needle);
+    TNeedle& ndl = needle(me);
+
+    me.needleLength = length(ndl);
     if (me.needleLength < 1)
         me.blockCount = 1;
     else
@@ -113,7 +125,7 @@ setHost(Pattern<TNeedle, ShiftAnd> & me, TNeedle2 const & needle)
 
     for (TWord j = 0; j < me.needleLength; ++j)
         me.bitMasks[
-            me.blockCount * ordValue(convert<TValue>(getValue(needle, j)))
+            me.blockCount * ordValue(convert<TValue>(getValue(ndl, j)))
             + j / me.MACHINE_WORD_SIZE
         ] |= (TWord)1 << (j % me.MACHINE_WORD_SIZE);
 
@@ -138,63 +150,64 @@ setHost(Pattern<TNeedle, ShiftAnd> & me, TNeedle2 const & needle)
     */
 }
 
-template <typename TNeedle, typename TNeedle2>
-inline void
-setHost(Pattern<TNeedle, ShiftAnd> & me, TNeedle2 & needle)
-{
-    setHost(me, reinterpret_cast<TNeedle2 const &>(needle));
-}
+//template <typename TNeedle, typename TNeedle2>
+//inline void
+//setHost(Pattern<TNeedle, ShiftAnd> & me, TNeedle2 & needle)
+//{
+//    setHost(me, reinterpret_cast<TNeedle2 const &>(needle));
+//}
 
 //____________________________________________________________________________
 
-template <typename TNeedle>
-inline TNeedle
-host(Pattern<TNeedle, ShiftAnd> const & pattern)
-{
-SEQAN_CHECKPOINT
-
-    typedef typename Pattern<TNeedle, ShiftAnd>::TWord TWord;
-    typedef typename Value<TNeedle>::Type TValue;
-
-    TNeedle temp;
-    resize(temp, pattern.needleLength, Exact());
-
-    TValue v = TValue();
-    for (unsigned i = 0; i < length(pattern.bitMasks); i += pattern.blockCount)
-    {
-        for (unsigned j = 0; j < pattern.needleLength; j++)
-            if ((pattern.bitMasks[i + j / pattern.MACHINE_WORD_SIZE] & (TWord)1 << (j % pattern.MACHINE_WORD_SIZE)) != (TWord)0)
-                temp[j] = v;
-        ++v;
-    }
-    return temp;
-}
-
-template <typename TNeedle>
-inline TNeedle
-host(Pattern<TNeedle, ShiftAnd> & pattern)
-{
-SEQAN_CHECKPOINT
-    return host(const_cast<Pattern<TNeedle, ShiftAnd> const &>(pattern));
-}
-
-//____________________________________________________________________________
-
-template <typename TNeedle>
-inline TNeedle
-needle(Pattern<TNeedle, ShiftAnd> const & pattern)
-{
-SEQAN_CHECKPOINT
-    return host(pattern);
-}
-
-template <typename TNeedle>
-inline TNeedle
-needle(Pattern<TNeedle, ShiftAnd> & pattern)
-{
-SEQAN_CHECKPOINT
-    return host(const_cast<Pattern<TNeedle, ShiftAnd> const &>(pattern));
-}
+// TODO(rrahn): Pattern should always keep a pointer to the needle!
+//template <typename TNeedle>
+//inline TNeedle
+//host(Pattern<TNeedle, ShiftAnd> const & pattern)
+//{
+//SEQAN_CHECKPOINT
+//
+//    typedef typename Pattern<TNeedle, ShiftAnd>::TWord TWord;
+//    typedef typename Value<TNeedle>::Type TValue;
+//
+//    TNeedle temp;
+//    resize(temp, pattern.needleLength, Exact());
+//
+//    TValue v = TValue();
+//    for (unsigned i = 0; i < length(pattern.bitMasks); i += pattern.blockCount)
+//    {
+//        for (unsigned j = 0; j < pattern.needleLength; j++)
+//            if ((pattern.bitMasks[i + j / pattern.MACHINE_WORD_SIZE] & (TWord)1 << (j % pattern.MACHINE_WORD_SIZE)) != (TWord)0)
+//                temp[j] = v;
+//        ++v;
+//    }
+//    return temp;
+//}
+//
+//template <typename TNeedle>
+//inline TNeedle
+//host(Pattern<TNeedle, ShiftAnd> & pattern)
+//{
+//SEQAN_CHECKPOINT
+//    return host(const_cast<Pattern<TNeedle, ShiftAnd> const &>(pattern));
+//}
+//
+////____________________________________________________________________________
+//
+//template <typename TNeedle>
+//inline TNeedle
+//needle(Pattern<TNeedle, ShiftAnd> const & pattern)
+//{
+//SEQAN_CHECKPOINT
+//    return host(pattern);
+//}
+//
+//template <typename TNeedle>
+//inline TNeedle
+//needle(Pattern<TNeedle, ShiftAnd> & pattern)
+//{
+//SEQAN_CHECKPOINT
+//    return host(const_cast<Pattern<TNeedle, ShiftAnd> const &>(pattern));
+//}
 
 //____________________________________________________________________________
 

--- a/include/seqan/find/find_shiftor.h
+++ b/include/seqan/find/find_shiftor.h
@@ -151,64 +151,6 @@ _reinitPattern(Pattern<TNeedle, ShiftOr> & me)
     */
 }
 
-//template <typename TNeedle, typename TNeedle2>
-//inline void
-//setHost(Pattern<TNeedle, ShiftOr> & me, TNeedle2 & needle)
-//{
-//    setHost(me, const_cast<TNeedle2 const &>(needle));
-//}
-//
-////____________________________________________________________________________
-//
-//template <typename TNeedle>
-//inline TNeedle
-//host(Pattern<TNeedle, ShiftOr> const & pattern)
-//{
-//SEQAN_CHECKPOINT
-//
-//    typedef typename Pattern<TNeedle, ShiftOr>::TWord TWord;
-//    typedef typename Value<TNeedle>::Type TValue;
-//
-//    TNeedle temp;
-//    resize(temp, pattern.needleLength, Exact());
-//
-//    TValue v = TValue();
-//    for (unsigned i = 0; i < length(pattern.bitMasks); i += pattern.blockCount)
-//    {
-//        for (unsigned j = 0; j < pattern.needleLength; j++)
-//            if ((pattern.bitMasks[i + j / pattern.MACHINE_WORD_SIZE] & (TWord)1 << (j % pattern.MACHINE_WORD_SIZE)) == (TWord)0)
-//                temp[j] = v;
-//        ++v;
-//    }
-//    return temp;
-//}
-//
-//template <typename TNeedle>
-//inline TNeedle
-//host(Pattern<TNeedle, ShiftOr> & pattern)
-//{
-//SEQAN_CHECKPOINT
-//    return host(const_cast<Pattern<TNeedle, ShiftOr> const &>(pattern));
-//}
-//
-////____________________________________________________________________________
-//
-//template <typename TNeedle>
-//inline TNeedle
-//needle(Pattern<TNeedle, ShiftOr> const & pattern)
-//{
-//SEQAN_CHECKPOINT
-//    return host(pattern);
-//}
-//
-//template <typename TNeedle>
-//inline TNeedle
-//needle(Pattern<TNeedle, ShiftOr> & pattern)
-//{
-//SEQAN_CHECKPOINT
-//    return host(const_cast<Pattern<TNeedle, ShiftOr> const &>(pattern));
-//}
-
 //____________________________________________________________________________
 
 template <typename TNeedle>

--- a/include/seqan/find/find_shiftor.h
+++ b/include/seqan/find/find_shiftor.h
@@ -64,13 +64,14 @@ typedef Tag<ShiftOr_> ShiftOr;
 //////////////////////////////////////////////////////////////////////////////
 
 template <typename TNeedle>
-class Pattern<TNeedle, ShiftOr> {
+class Pattern<TNeedle, ShiftOr>
+{
 //____________________________________________________________________________
 public:
     typedef unsigned int TWord;
     enum { MACHINE_WORD_SIZE = sizeof(TWord) * 8 };
 
-//    Holder<TNeedle> data_host;
+    Holder<TNeedle> data_host;
     String<TWord> bitMasks;            // Look up table for each character in the alphabet (called B in "Navarro")
     String<TWord> prefSufMatch;        // Set of all the prefixes of needle that match a suffix of haystack (called D in "Navarro")
     TWord needleLength;                // e.g., needleLength=33 --> blockCount=2 (iff w=32 bits)
@@ -78,14 +79,24 @@ public:
 
 //____________________________________________________________________________
 
-    Pattern() {}
+    Pattern()
+    {}
 
+#ifdef SEQAN_CXX11_STANDARD
+    // Custom c'tor setting a needle.
+    template <typename TNeedle2>
+    Pattern(TNeedle2 && ndl, SEQAN_CTOR_DISABLE_IF(IsSameType<typename std::remove_reference<TNeedle2>::type const &, Pattern const &>))
+    {
+        setHost(*this, std::forward<TNeedle2>(ndl));
+        ignoreUnusedVariableWarning(dummy);
+    }
+#else
     template <typename TNeedle2>
     Pattern(TNeedle2 const & ndl)
     {
         setHost(*this, ndl);
     }
-
+#endif  // SEQAN_CXX11_STANDARD
 //____________________________________________________________________________
 };
 
@@ -94,15 +105,17 @@ public:
 // Functions
 //////////////////////////////////////////////////////////////////////////////
 
-template <typename TNeedle, typename TNeedle2>
+// TODO(rrahn): Change to rvalue reference for TNeedle2 as soon as all pattern store pointer to the needle.
+template <typename TNeedle>
 inline void
-setHost(Pattern<TNeedle, ShiftOr> & me, TNeedle2 const & needle)
+_reinitPattern(Pattern<TNeedle, ShiftOr> & me)
 {
     SEQAN_CHECKPOINT
     typedef unsigned int TWord;
     typedef typename Value<TNeedle>::Type TValue;
 
-    me.needleLength = length(needle);
+    TNeedle& ndl = needle(me);
+    me.needleLength = length(ndl);
     if (me.needleLength < 1)
         me.blockCount = 1;
     else
@@ -113,7 +126,7 @@ setHost(Pattern<TNeedle, ShiftOr> & me, TNeedle2 const & needle)
 
     for (TWord j = 0; j < me.needleLength; ++j)
         me.bitMasks[
-            me.blockCount * ordValue(convert<TValue>(getValue(needle, j)))
+            me.blockCount * ordValue(convert<TValue>(getValue(ndl, j)))
             + j / me.MACHINE_WORD_SIZE
         ] ^= (TWord)1 << (j % me.MACHINE_WORD_SIZE);
 
@@ -138,63 +151,63 @@ setHost(Pattern<TNeedle, ShiftOr> & me, TNeedle2 const & needle)
     */
 }
 
-template <typename TNeedle, typename TNeedle2>
-inline void
-setHost(Pattern<TNeedle, ShiftOr> & me, TNeedle2 & needle)
-{
-    setHost(me, const_cast<TNeedle2 const &>(needle));
-}
-
-//____________________________________________________________________________
-
-template <typename TNeedle>
-inline TNeedle
-host(Pattern<TNeedle, ShiftOr> const & pattern)
-{
-SEQAN_CHECKPOINT
-
-    typedef typename Pattern<TNeedle, ShiftOr>::TWord TWord;
-    typedef typename Value<TNeedle>::Type TValue;
-
-    TNeedle temp;
-    resize(temp, pattern.needleLength, Exact());
-
-    TValue v = TValue();
-    for (unsigned i = 0; i < length(pattern.bitMasks); i += pattern.blockCount)
-    {
-        for (unsigned j = 0; j < pattern.needleLength; j++)
-            if ((pattern.bitMasks[i + j / pattern.MACHINE_WORD_SIZE] & (TWord)1 << (j % pattern.MACHINE_WORD_SIZE)) == (TWord)0)
-                temp[j] = v;
-        ++v;
-    }
-    return temp;
-}
-
-template <typename TNeedle>
-inline TNeedle
-host(Pattern<TNeedle, ShiftOr> & pattern)
-{
-SEQAN_CHECKPOINT
-    return host(const_cast<Pattern<TNeedle, ShiftOr> const &>(pattern));
-}
-
-//____________________________________________________________________________
-
-template <typename TNeedle>
-inline TNeedle
-needle(Pattern<TNeedle, ShiftOr> const & pattern)
-{
-SEQAN_CHECKPOINT
-    return host(pattern);
-}
-
-template <typename TNeedle>
-inline TNeedle
-needle(Pattern<TNeedle, ShiftOr> & pattern)
-{
-SEQAN_CHECKPOINT
-    return host(const_cast<Pattern<TNeedle, ShiftOr> const &>(pattern));
-}
+//template <typename TNeedle, typename TNeedle2>
+//inline void
+//setHost(Pattern<TNeedle, ShiftOr> & me, TNeedle2 & needle)
+//{
+//    setHost(me, const_cast<TNeedle2 const &>(needle));
+//}
+//
+////____________________________________________________________________________
+//
+//template <typename TNeedle>
+//inline TNeedle
+//host(Pattern<TNeedle, ShiftOr> const & pattern)
+//{
+//SEQAN_CHECKPOINT
+//
+//    typedef typename Pattern<TNeedle, ShiftOr>::TWord TWord;
+//    typedef typename Value<TNeedle>::Type TValue;
+//
+//    TNeedle temp;
+//    resize(temp, pattern.needleLength, Exact());
+//
+//    TValue v = TValue();
+//    for (unsigned i = 0; i < length(pattern.bitMasks); i += pattern.blockCount)
+//    {
+//        for (unsigned j = 0; j < pattern.needleLength; j++)
+//            if ((pattern.bitMasks[i + j / pattern.MACHINE_WORD_SIZE] & (TWord)1 << (j % pattern.MACHINE_WORD_SIZE)) == (TWord)0)
+//                temp[j] = v;
+//        ++v;
+//    }
+//    return temp;
+//}
+//
+//template <typename TNeedle>
+//inline TNeedle
+//host(Pattern<TNeedle, ShiftOr> & pattern)
+//{
+//SEQAN_CHECKPOINT
+//    return host(const_cast<Pattern<TNeedle, ShiftOr> const &>(pattern));
+//}
+//
+////____________________________________________________________________________
+//
+//template <typename TNeedle>
+//inline TNeedle
+//needle(Pattern<TNeedle, ShiftOr> const & pattern)
+//{
+//SEQAN_CHECKPOINT
+//    return host(pattern);
+//}
+//
+//template <typename TNeedle>
+//inline TNeedle
+//needle(Pattern<TNeedle, ShiftOr> & pattern)
+//{
+//SEQAN_CHECKPOINT
+//    return host(const_cast<Pattern<TNeedle, ShiftOr> const &>(pattern));
+//}
 
 //____________________________________________________________________________
 

--- a/include/seqan/find/find_simple.h
+++ b/include/seqan/find/find_simple.h
@@ -68,26 +68,20 @@ public:
 
     Pattern() {}
 
-    Pattern(Pattern const & other):
-        data_host(other.data_host)
+#ifdef SEQAN_CXX11_STANDARD
+    template <typename TNeedle2>
+    Pattern(TNeedle2 && ndl, SEQAN_CTOR_DISABLE_IF(IsSameType<typename std::remove_reference<TNeedle2>::type const &, Pattern const &>))
     {
+        setHost(*this, ndl);
+        ignoreUnusedVariableWarning(dummy);
     }
-
+#else
     template <typename TNeedle2>
     Pattern(TNeedle2 const & ndl)
     {
         setHost(*this, ndl);
     }
-
-    ~Pattern(){}
-
-    Pattern const &
-    operator = (Pattern const & other)
-    {
-        data_host = other.data_host;
-        return *this;
-    }
-
+#endif  // SEQAN_CXX11_STANDARD
 //____________________________________________________________________________
 };
 
@@ -95,19 +89,6 @@ public:
 //////////////////////////////////////////////////////////////////////////////
 // Functions
 //////////////////////////////////////////////////////////////////////////////
-
-template <typename TNeedle, typename TNeedle2>
-void setHost (Pattern<TNeedle, Simple> & me,
-              TNeedle2 & needle)
-{
-    setValue(me.data_host, needle);
-}
-template <typename TNeedle, typename TNeedle2>
-void setHost (Pattern<TNeedle, Simple> & me,
-              TNeedle2 const & needle)
-{
-    setValue(me.data_host, needle);
-}
 
 //____________________________________________________________________________
 

--- a/include/seqan/find/find_wild_shiftand.h
+++ b/include/seqan/find/find_wild_shiftand.h
@@ -103,12 +103,23 @@ public:
         : _valid(false)
         {}
 
+#ifdef SEQAN_CXX11_STANDARD
+    template <typename TNeedle2>
+    Pattern(TNeedle2 && ndl,
+            SEQAN_CTOR_DISABLE_IF(IsSameType<typename std::remove_reference<TNeedle2>::type const &, Pattern const &>))
+        : _valid(false)
+    {
+        setHost(*this, std::forward<TNeedle2>(ndl));
+        ignoreUnusedVariableWarning(dummy);
+    }
+#else
+
     template <typename TNeedle2>
     Pattern(TNeedle2 const & ndl)
         : _valid(false) {
         setHost(*this, ndl);
     }
-
+#endif // SEQAN_CXX11_STANDARD
 //____________________________________________________________________________
 };
 
@@ -328,17 +339,20 @@ SEQAN_CHECKPOINT
 
 
 template <typename TNeedle, typename TNeedle2>
-void setHost (Pattern<TNeedle, WildShiftAnd> & me, TNeedle2 const & needle) {
+void _reinitPattern(Pattern<TNeedle, WildShiftAnd> & me,
+                    TNeedle2 const & ndl)
+{
 SEQAN_CHECKPOINT
-    me._valid = _validate(needle);
+
+    me._valid = _validate(ndl);
 
     if(!valid(me)) return;
 
     typedef unsigned TWord;
     typedef typename Value<TNeedle>::Type TValue;
 
-    me.needleLength = length(needle);
-    me.character_count = _lengthWithoutWildcards(needle);
+    me.needleLength = length(ndl);
+    me.character_count = _lengthWithoutWildcards(ndl);
 
     if (me.character_count<1) me.blockCount=1;
     else me.blockCount=((me.character_count-1) / BitsPerValue<TWord>::VALUE)+1;
@@ -357,30 +371,30 @@ SEQAN_CHECKPOINT
     TWord j=0;
     while(j < me.needleLength){
 SEQAN_CHECKPOINT
-        if (convert<char>(getValue(needle,j)) == '+'){
+        if (convert<char>(getValue(ndl,j)) == '+'){
 SEQAN_CHECKPOINT
             TWord len = length(last_char);
             for (unsigned int k = 0; k < len; ++k)
                 me.s_table[me.blockCount*last_char[k] + i / BitsPerValue<TWord>::VALUE] |= (1<<(i%BitsPerValue<TWord>::VALUE));
         }
-        else if (convert<char>(getValue(needle,j)) == '?'){
+        else if (convert<char>(getValue(ndl,j)) == '?'){
 SEQAN_CHECKPOINT
             me.a_table[i / BitsPerValue<TWord>::VALUE] |= (1<<(i%BitsPerValue<TWord>::VALUE));
         }
-        else if (convert<char>(getValue(needle,j)) == '*'){
+        else if (convert<char>(getValue(ndl,j)) == '*'){
 SEQAN_CHECKPOINT
             TWord len = length(last_char);
             for (unsigned int k = 0; k < len; ++k)
                 me.s_table[me.blockCount*last_char[k] + i / BitsPerValue<TWord>::VALUE] |= (1<<(i%BitsPerValue<TWord>::VALUE));
             me.a_table[i / BitsPerValue<TWord>::VALUE] |= (1<<(i%BitsPerValue<TWord>::VALUE));
         }
-        else if(convert<char>(getValue(needle,j)) == '['){
+        else if(convert<char>(getValue(ndl,j)) == '['){
 SEQAN_CHECKPOINT
             /* find characters in class */
             TWord e = j;
-            while(convert<char>(getValue(needle,e)) != ']') ++e;
+            while(convert<char>(getValue(ndl,e)) != ']') ++e;
             /* get character codes of class */
-            last_char = _getCharacterClass<TValue>(needle,j+1,e);
+            last_char = _getCharacterClass<TValue>(ndl,j+1,e);
             TWord len = length(last_char);
 
             /* add class to the mask */
@@ -391,7 +405,7 @@ SEQAN_CHECKPOINT
             }
             j = e;
         }
-        else if(convert<char>(getValue(needle,j)) == '.'){ // matches all characters in the current alphabet
+        else if(convert<char>(getValue(ndl,j)) == '.'){ // matches all characters in the current alphabet
 SEQAN_CHECKPOINT
             clear(last_char);
             ++i;
@@ -401,34 +415,34 @@ SEQAN_CHECKPOINT
             }
 
         }
-        else if(convert<char>(getValue(needle,j)) == '\\'){ // handle escape characters
+        else if(convert<char>(getValue(ndl,j)) == '\\'){ // handle escape characters
 SEQAN_CHECKPOINT
             /* goto next character use this for the bit mask */
             ++i;++j;
             clear(last_char);
-            append(last_char, convert<TWord>(convert<TValue>(getValue(needle,j))));
+            append(last_char, convert<TWord>(convert<TValue>(getValue(ndl,j))));
             me.table[me.blockCount*last_char[0] + i / BitsPerValue<TWord>::VALUE] |= (1<<(i%BitsPerValue<TWord>::VALUE));
         }
-        else if(convert<char>(getValue(needle,j)) == '{'){ // handle bounded character repeats
+        else if(convert<char>(getValue(ndl,j)) == '{'){ // handle bounded character repeats
 SEQAN_CHECKPOINT
             String <char> number;
             TWord n,m,r;
             TWord len = length(last_char);
             n = m = 0;
             ++j;
-            while(convert<char>(getValue(needle,j)) != '}' && convert<char>(getValue(needle,j)) != ',') {
+            while(convert<char>(getValue(ndl,j)) != '}' && convert<char>(getValue(ndl,j)) != ',') {
 SEQAN_CHECKPOINT
-                append(number,convert<char>(getValue(needle,j)));
+                append(number,convert<char>(getValue(ndl,j)));
                 ++j;
             }
             n = atoi(toCString(number));
-            if (convert<char>(getValue(needle,j)) == ','){
+            if (convert<char>(getValue(ndl,j)) == ','){
 SEQAN_CHECKPOINT
                 ++j;
                 clear(number);
-                while(convert<char>(getValue(needle,j)) != '}') {
+                while(convert<char>(getValue(ndl,j)) != '}') {
 SEQAN_CHECKPOINT
-                    append(number,convert<char>(getValue(needle,j)));
+                    append(number,convert<char>(getValue(ndl,j)));
                     ++j;
                 }
                 m = atoi(toCString(number));
@@ -463,7 +477,7 @@ SEQAN_CHECKPOINT
 SEQAN_CHECKPOINT
             // determine character position in array table
             clear(last_char);
-            append(last_char, convert<TWord>(convert<TValue>(getValue(needle,j))));
+            append(last_char, convert<TWord>(convert<TValue>(getValue(ndl,j))));
             ++i;
             me.table[me.blockCount*last_char[0] + i / BitsPerValue<TWord>::VALUE] |= (1<<(i%BitsPerValue<TWord>::VALUE));
         }
@@ -516,8 +530,6 @@ SEQAN_CHECKPOINT
         }
     }
 
-    setValue(me.data_host, needle);
-
 #ifdef SEQAN_WILD_SHIFTAND_DEBUG
     // Debug code
     std::cout << "Alphabet size: " << ValueSize<TValue>::VALUE << std::endl;
@@ -525,7 +537,7 @@ SEQAN_CHECKPOINT
     std::cout << "Needle length (wo wildcards): " << me.character_count << std::endl;
     std::cout << "Block count: " << me.blockCount << std::endl;
 
-    std::cout << "Needle:" << needle << std::endl;
+    std::cout << "Needle:" << ndl << std::endl;
 
     _printMask(me.f_table,0,"F ");
     _printMask(me.i_table,0,"I ");
@@ -546,12 +558,37 @@ SEQAN_CHECKPOINT
 
 }
 
+//____________________________________________________________________________
+
+// Need to overload setHost, since we cannot convert the needle if TNeedle of pattern is a different alphabet,
+// which does not handle wildcard characters.
+
+#ifdef SEQAN_CXX11_STANDARD
 template <typename TNeedle, typename TNeedle2>
-inline void setHost (Pattern<TNeedle, WildShiftAnd> & me, TNeedle2 & needle)
+inline void setHost(Pattern<TNeedle, WildShiftAnd> & me,
+                    TNeedle2 && ndl)
 {
-    setHost(me, reinterpret_cast<TNeedle2 const &>(needle));
+    _reinitPattern(me, ndl);
+    setValue(_dataHost(me), std::forward<TNeedle2>(ndl));
+}
+#else
+template <typename TNeedle, typename TNeedle2>
+inline void setHost(Pattern<TNeedle, WildShiftAnd> & me,
+                    TNeedle2 & ndl)
+{
+    _reinitPattern(me, ndl);
+    setValue(_dataHost(me), ndl);
 }
 
+template <typename TNeedle, typename TNeedle2>
+inline void setHost(Pattern<TNeedle, WildShiftAnd> & me,
+                    TNeedle2 const & ndl)
+{
+    _reinitPattern(me, ndl);
+    setValue(_dataHost(me), ndl);
+}
+
+#endif
 //____________________________________________________________________________
 
 
@@ -586,33 +623,16 @@ SEQAN_CHECKPOINT
 //____________________________________________________________________________
 
 
-template <typename TNeedle>
-inline typename Host<Pattern<TNeedle, WildShiftAnd>const>::Type &
-host(Pattern<TNeedle, WildShiftAnd> & me)
-{
-SEQAN_CHECKPOINT
-    return value(me.data_host);
-}
-
-template <typename TNeedle>
-inline typename Host<Pattern<TNeedle, WildShiftAnd>const>::Type &
-host(Pattern<TNeedle, WildShiftAnd> const & me)
-{
-SEQAN_CHECKPOINT
-    return value(me.data_host);
-}
-
-//____________________________________________________________________________
-
-
 template <typename TFinder, typename TNeedle>
 inline bool _findShiftAndSmallNeedle(TFinder & finder, Pattern<TNeedle, WildShiftAnd> & me) {
 SEQAN_CHECKPOINT
+    typedef typename Value<TNeedle>::Type TNdlAlphabet;
     typedef unsigned TWord;
+
     TWord compare = (1 << (me.character_count-1));
     while (!atEnd(finder)) {
 SEQAN_CHECKPOINT
-        TWord pos = convert<TWord>(*finder);
+        TWord pos = convert<TWord>(convert<TNdlAlphabet>(*finder));
         /* added  | (me.prefSufMatch[0] & me.s_table[me.blockCount*pos]) at the end of the line */
         me.prefSufMatch[0] = (((me.prefSufMatch[0] << 1) | 1) & me.table[me.blockCount*pos]) | (me.prefSufMatch[0] & me.s_table[me.blockCount*pos]) ;
 
@@ -631,13 +651,14 @@ SEQAN_CHECKPOINT
 template <typename TFinder, typename TNeedle>
 inline bool _findShiftAndLargeNeedle(TFinder & finder, Pattern<TNeedle, WildShiftAnd> & me) {
 SEQAN_CHECKPOINT
+    typedef typename Value<TNeedle>::Type TNdlAlphabet;
     typedef unsigned TWord;
     const TWord all1 = ~0;
     TWord compare = (1 << ((me.character_count-1) % BitsPerValue<TWord>::VALUE));
 
     while (!atEnd(finder)) {
 SEQAN_CHECKPOINT
-        TWord pos = convert<TWord>(*finder);
+        TWord pos = convert<TWord>(convert<TNdlAlphabet>(*finder));
         TWord carry = 1;
         TWord wc_carry = 0;
         // shift of blocks with carry

--- a/include/seqan/index/find_quasar.h
+++ b/include/seqan/index/find_quasar.h
@@ -66,54 +66,29 @@ public:
     Pattern() {
     }
 
+#ifdef SEQAN_CXX11_STANDARD
+    template <typename TNeedle2>
+    Pattern(TNeedle2 && ndl,
+            SEQAN_CTOR_DISABLE_IF(IsSameType<typename std::remove_reference<TNeedle2>::type const &, Pattern const &>))
+    {
+        ignoreUnusedVariableWarning(dummy);
+        setHost(*this, std::forward<TNeedle2>(ndl));
+    }
+#else
     template <typename TNeedle2>
     Pattern(TNeedle2 const & ndl)
     {
 SEQAN_CHECKPOINT
         setHost(*this, ndl);
     }
-
-    ~Pattern() {
-        SEQAN_CHECKPOINT
-    }
+#endif  // SEQAN_CXX11_STANDARD
 //____________________________________________________________________________
-};
-
-//////////////////////////////////////////////////////////////////////////////
-// Host Metafunctions
-//////////////////////////////////////////////////////////////////////////////
-
-template <typename TNeedle>
-struct Host< Pattern<TNeedle, Quasar> >
-{
-    typedef TNeedle Type;
-};
-
-template <typename TNeedle>
-struct Host< Pattern<TNeedle, Quasar> const>
-{
-    typedef TNeedle const Type;
 };
 
 
 //////////////////////////////////////////////////////////////////////////////
 // Functions
 //////////////////////////////////////////////////////////////////////////////
-
-template <typename TNeedle, typename TNeedle2>
-inline void
-setHost (Pattern<TNeedle, Quasar> & me, TNeedle2 const& needle)
-{
-    SEQAN_CHECKPOINT
-    setValue(me.data_host, needle);
-}
-
-template <typename TNeedle, typename TNeedle2>
-inline void
-setHost (Pattern<TNeedle, Quasar> & me, TNeedle2 & needle)
-{
-    setHost(me, reinterpret_cast<TNeedle2 const &>(needle));
-}
 
 //____________________________________________________________________________
 
@@ -124,24 +99,6 @@ inline void _patternInit (Pattern<TNeedle, Quasar> & /*me*/)
 SEQAN_CHECKPOINT
 }
 
-
-//____________________________________________________________________________
-
-template <typename TNeedle>
-inline typename Host<Pattern<TNeedle, Quasar>const>::Type &
-host(Pattern<TNeedle, Quasar> & me)
-{
-SEQAN_CHECKPOINT
-    return value(me.data_host);
-}
-
-template <typename TNeedle>
-inline typename Host<Pattern<TNeedle, Quasar>const>::Type &
-host(Pattern<TNeedle, Quasar> const & me)
-{
-SEQAN_CHECKPOINT
-    return value(me.data_host);
-}
 
 //____________________________________________________________________________
 

--- a/include/seqan/journaled_set/journaled_set_impl.h
+++ b/include/seqan/journaled_set/journaled_set_impl.h
@@ -212,9 +212,24 @@ inline void assignValue(
 
     assign(journalSet[pos], newElement);
 }
+
 // ----------------------------------------------------------------------------
 // Function host()
 // ----------------------------------------------------------------------------
+
+template <typename TString>
+inline Holder<typename Host<StringSet<TString, Owner<JournaledSet> > >::Type> const &
+_dataHost(StringSet<TString, Owner<JournaledSet> > const & set)
+{
+    return set._globalRefHolder;
+}
+
+template <typename TString>
+inline Holder<typename Host<StringSet<TString, Owner<JournaledSet> > >::Type>  &
+_dataHost(StringSet<TString, Owner<JournaledSet> > & set)
+{
+    return set._globalRefHolder;
+}
 
 /*!
  * @fn JournaledSet#host
@@ -226,21 +241,6 @@ inline void assignValue(
  *
  * @return THost Reference to the host.
  */
-
-template <typename TString>
-inline typename Host<StringSet<TString, Owner<JournaledSet> > >::Type const &
-host(StringSet<TString, Owner<JournaledSet> > const & journalSet)
-{
-    return value(journalSet._globalRefHolder);
-}
-
-
-template <typename TString>
-inline typename Host<StringSet<TString, Owner<JournaledSet> > >::Type &
-host(StringSet<TString, Owner<JournaledSet> > & journalSet)
-{
-    return value(journalSet._globalRefHolder);
-}
 
 // ----------------------------------------------------------------------------
 // Function setHost()
@@ -260,14 +260,6 @@ host(StringSet<TString, Owner<JournaledSet> > & journalSet)
  * Uses an @link Holder @endlink to store a reference to the new global reference sequence instead of copying it.
  */
 
-template <typename TString, typename THost>
-inline void
-setHost(StringSet<TString, Owner<JournaledSet> > & journalSet,
-        THost & newGlobalRef)
-{
-    setValue(journalSet._globalRefHolder, newGlobalRef);
-}
-
 // ----------------------------------------------------------------------------
 // Function createHost()
 // ----------------------------------------------------------------------------
@@ -282,14 +274,6 @@ setHost(StringSet<TString, Owner<JournaledSet> > & journalSet,
  * @param[in]     ref       The new reference sequence of the JournaledSet.  Stores a copy of the passed global
  *                          reference sequence.
  */
-
-template <typename TString>
-inline void
-createHost(StringSet<TString, Owner<JournaledSet> > & journalSet,
-                   typename Host<TString>::Type const & newGlobalRef)
-{
-    create(journalSet._globalRefHolder, newGlobalRef);
-}
 
 }  // namespace seqan
 

--- a/include/seqan/sequence_journaled/sequence_journaled.h
+++ b/include/seqan/sequence_journaled/sequence_journaled.h
@@ -515,6 +515,18 @@ set(String<TValue, Journaled<THostSpec, TJournalSpec, TBufferSpec> > & target,
  * @param[in]     str The string to set as the host.
  */
 
+#ifdef SEQAN_CXX11_STANDARD
+template <typename TValue, typename THostSpec, typename TJournalSpec, typename TBufferSpec, typename TSequence2>
+inline
+void
+setHost(String<TValue, Journaled<THostSpec, TJournalSpec, TBufferSpec> > & journaledString,
+        TSequence2 && str)
+{
+    setValue(journaledString._holder, str);
+    journaledString._length = length(str);
+    reinit(journaledString._journalEntries, length(str));
+}
+#else
 template <typename TValue, typename THostSpec, typename TJournalSpec, typename TBufferSpec, typename TSequence2>
 inline
 void
@@ -525,7 +537,7 @@ setHost(String<TValue, Journaled<THostSpec, TJournalSpec, TBufferSpec> > & journ
     journaledString._length = length(str);
     reinit(journaledString._journalEntries, length(str));
 }
-
+#endif  // SEQAN_CXX11_STANDARD
 // ----------------------------------------------------------------------------
 // Function host
 // ----------------------------------------------------------------------------

--- a/tests/align/test_alignment_dp_matrix.h
+++ b/tests/align/test_alignment_dp_matrix.h
@@ -46,8 +46,8 @@ void testAlignmentDPMatrixDataHostMF()
     typedef DPMatrix_<char, FullDPMatrix> TDPMatrix;
     typedef DPMatrix_<char, FullDPMatrix> const TDPMatrixConst;
 
-    typedef DataHost_<TDPMatrix>::Type TDataHost;
-    typedef DataHost_<TDPMatrixConst>::Type TDataHostConst;
+    typedef Member<TDPMatrix, DPMatrixMember>::Type TDataHost;
+    typedef Member<TDPMatrixConst, DPMatrixMember>::Type TDataHostConst;
 
     bool result1 = IsSameType<Matrix<char, 2>, TDataHost>::VALUE;
     bool result2 = IsSameType<Matrix<char, 2> const, TDataHostConst>::VALUE;
@@ -80,18 +80,18 @@ void testAlignmentDPMatrixDataHost()
     typedef DPMatrix_<char, FullDPMatrix> TDPMatrix;
     typedef DPMatrix_<char, FullDPMatrix> const TDPMatrixConst;
 
-    typedef DataHost_<TDPMatrix>::Type TDataHost;
-    typedef DataHost_<TDPMatrixConst>::Type TDataHostConst;
+    typedef Member<TDPMatrix, DPMatrixMember>::Type TDataHost;
+    typedef Member<TDPMatrixConst, DPMatrixMember>::Type TDataHostConst;
 
     TDPMatrix dpMatrix;
 
-    value(dpMatrix._dataHost).data_lengths[0] = 10;
-    value(dpMatrix._dataHost).data_lengths[1] = 20;
+    value(dpMatrix.data_host).data_lengths[0] = 10;
+    value(dpMatrix.data_host).data_lengths[1] = 20;
 
     TDPMatrixConst dpMatrixConst(dpMatrix);
 
-    TDataHost dataHost = _dataHost(dpMatrix);
-    TDataHostConst dataHostConst = _dataHost(dpMatrixConst);
+    TDataHost dataHost = value(dpMatrix.data_host);
+    TDataHostConst dataHostConst = value(dpMatrixConst.data_host);
 
     SEQAN_ASSERT_EQ(dataHost.data_lengths[0], 10u);
     SEQAN_ASSERT_EQ(dataHost.data_lengths[1], 20u);
@@ -108,8 +108,8 @@ void testAlignmentDPMatrixDataLengths()
 
     TDPMatrix dpMatrix;
 
-    value(dpMatrix._dataHost).data_lengths[0] = 10;
-    value(dpMatrix._dataHost).data_lengths[1] = 20;
+    value(dpMatrix.data_host).data_lengths[0] = 10;
+    value(dpMatrix.data_host).data_lengths[1] = 20;
 
     TDPMatrixConst dpMatrixConst(dpMatrix);
 
@@ -128,8 +128,8 @@ void testAlignmentDPMatrixDataFactors()
 
     TDPMatrix dpMatrix;
 
-    value(dpMatrix._dataHost).data_factors[0] = 10;
-    value(dpMatrix._dataHost).data_factors[1] = 20;
+    value(dpMatrix.data_host).data_factors[0] = 10;
+    value(dpMatrix.data_host).data_factors[1] = 20;
 
     TDPMatrixConst dpMatrixConst(dpMatrix);
 
@@ -173,8 +173,8 @@ void testAlignmentDPMatrixLengthDimension(TSpec const &)
 
     DPMatrix_<char, TSpec> dpMatrix;
 
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_lengths[DPMatrixDimension_::HORIZONTAL], 0u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_lengths[DPMatrixDimension_::VERTICAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_lengths[DPMatrixDimension_::HORIZONTAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_lengths[DPMatrixDimension_::VERTICAL], 0u);
 
     setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 4);
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 3);
@@ -212,17 +212,17 @@ void testAlignmentDPMatrixClear()
     resize(dpMatrix);
 
     String<char> str = "Hello World!";
-    setValue(_dataHost(dpMatrix).data_host, str);
-    SEQAN_ASSERT_EQ(dependent(_dataHost(dpMatrix).data_host), true);
+    setValue(value(dpMatrix.data_host).data_host, str);
+    SEQAN_ASSERT_EQ(dependent(value(dpMatrix.data_host).data_host), true);
     SEQAN_ASSERT_EQ(empty(dpMatrix), false);
-    SEQAN_ASSERT_EQ(host(_dataHost(dpMatrix)), "Hello World!");
+    SEQAN_ASSERT_EQ(host(value(dpMatrix.data_host)), "Hello World!");
     clear(dpMatrix);
 
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_lengths[DPMatrixDimension_::HORIZONTAL], 0u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_lengths[DPMatrixDimension_::VERTICAL], 0u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_factors[DPMatrixDimension_::HORIZONTAL], 0u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_factors[DPMatrixDimension_::VERTICAL], 1u);
-    SEQAN_ASSERT_EQ(empty(_dataHost(dpMatrix).data_host), false);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_lengths[DPMatrixDimension_::HORIZONTAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_lengths[DPMatrixDimension_::VERTICAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_factors[DPMatrixDimension_::HORIZONTAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_factors[DPMatrixDimension_::VERTICAL], 1u);
+    SEQAN_ASSERT_EQ(empty(value(dpMatrix.data_host).data_host), false);
     SEQAN_ASSERT_EQ(empty(dpMatrix), true);
 }
 
@@ -443,12 +443,12 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_full_constructor)
 
     DPMatrix_<int, FullDPMatrix> dpMatrix;
 
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_lengths[DPMatrixDimension_::HORIZONTAL], 0u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_lengths[DPMatrixDimension_::VERTICAL], 0u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_factors[DPMatrixDimension_::HORIZONTAL], 0u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_factors[DPMatrixDimension_::VERTICAL], 1u);
-    SEQAN_ASSERT_EQ(empty(_dataHost(dpMatrix).data_host), false);
-    SEQAN_ASSERT_EQ(dependent(_dataHost(dpMatrix).data_host), false);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_lengths[DPMatrixDimension_::HORIZONTAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_lengths[DPMatrixDimension_::VERTICAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_factors[DPMatrixDimension_::HORIZONTAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_factors[DPMatrixDimension_::VERTICAL], 1u);
+    SEQAN_ASSERT_EQ(empty(value(dpMatrix.data_host).data_host), false);
+    SEQAN_ASSERT_EQ(dependent(value(dpMatrix.data_host).data_host), false);
 }
 
 SEQAN_DEFINE_TEST(test_alignment_dp_matrix_full_copy_constructor)
@@ -457,34 +457,34 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_full_copy_constructor)
 
     DPMatrix_<int, FullDPMatrix> dpMatrix;
 
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_lengths[DPMatrixDimension_::HORIZONTAL], 0u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_lengths[DPMatrixDimension_::VERTICAL], 0u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_factors[DPMatrixDimension_::HORIZONTAL], 0u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_factors[DPMatrixDimension_::VERTICAL], 1u);
-    SEQAN_ASSERT_EQ(empty(_dataHost(dpMatrix).data_host), false);
-    SEQAN_ASSERT_EQ(dependent(_dataHost(dpMatrix).data_host), false);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_lengths[DPMatrixDimension_::HORIZONTAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_lengths[DPMatrixDimension_::VERTICAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_factors[DPMatrixDimension_::HORIZONTAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_factors[DPMatrixDimension_::VERTICAL], 1u);
+    SEQAN_ASSERT_EQ(empty(value(dpMatrix.data_host).data_host), false);
+    SEQAN_ASSERT_EQ(dependent(value(dpMatrix.data_host).data_host), false);
 
-    _dataHost(dpMatrix).data_lengths[DPMatrixDimension_::HORIZONTAL] = 10;
-    _dataHost(dpMatrix).data_lengths[DPMatrixDimension_::VERTICAL] = 20;
-    _dataHost(dpMatrix).data_factors[DPMatrixDimension_::HORIZONTAL] = 20;
+    value(dpMatrix.data_host).data_lengths[DPMatrixDimension_::HORIZONTAL] = 10;
+    value(dpMatrix.data_host).data_lengths[DPMatrixDimension_::VERTICAL] = 20;
+    value(dpMatrix.data_host).data_factors[DPMatrixDimension_::HORIZONTAL] = 20;
 
     DPMatrix_<int, FullDPMatrix> dpMatrixCopy1 = dpMatrix;
 
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrixCopy1).data_lengths[DPMatrixDimension_::HORIZONTAL], 10u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrixCopy1).data_lengths[DPMatrixDimension_::VERTICAL], 20u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrixCopy1).data_factors[DPMatrixDimension_::HORIZONTAL], 20u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrixCopy1).data_factors[DPMatrixDimension_::VERTICAL], 1u);
-    SEQAN_ASSERT_EQ(empty(_dataHost(dpMatrixCopy1).data_host), false);
-    SEQAN_ASSERT_EQ(dependent(_dataHost(dpMatrixCopy1).data_host), false);
+    SEQAN_ASSERT_EQ(value(dpMatrixCopy1.data_host).data_lengths[DPMatrixDimension_::HORIZONTAL], 10u);
+    SEQAN_ASSERT_EQ(value(dpMatrixCopy1.data_host).data_lengths[DPMatrixDimension_::VERTICAL], 20u);
+    SEQAN_ASSERT_EQ(value(dpMatrixCopy1.data_host).data_factors[DPMatrixDimension_::HORIZONTAL], 20u);
+    SEQAN_ASSERT_EQ(value(dpMatrixCopy1.data_host).data_factors[DPMatrixDimension_::VERTICAL], 1u);
+    SEQAN_ASSERT_EQ(empty(value(dpMatrixCopy1.data_host).data_host), false);
+    SEQAN_ASSERT_EQ(dependent(value(dpMatrixCopy1.data_host).data_host), false);
 
     DPMatrix_<int, FullDPMatrix> const dpMatrixCopy2 = dpMatrix;
 
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrixCopy2).data_lengths[DPMatrixDimension_::HORIZONTAL], 10u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrixCopy2).data_lengths[DPMatrixDimension_::VERTICAL], 20u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrixCopy2).data_factors[DPMatrixDimension_::HORIZONTAL], 20u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrixCopy2).data_factors[DPMatrixDimension_::VERTICAL], 1u);
-    SEQAN_ASSERT_EQ(empty(_dataHost(dpMatrixCopy2).data_host), false);
-    SEQAN_ASSERT_EQ(dependent(_dataHost(dpMatrixCopy2).data_host), false);
+    SEQAN_ASSERT_EQ(value(dpMatrixCopy2.data_host).data_lengths[DPMatrixDimension_::HORIZONTAL], 10u);
+    SEQAN_ASSERT_EQ(value(dpMatrixCopy2.data_host).data_lengths[DPMatrixDimension_::VERTICAL], 20u);
+    SEQAN_ASSERT_EQ(value(dpMatrixCopy2.data_host).data_factors[DPMatrixDimension_::HORIZONTAL], 20u);
+    SEQAN_ASSERT_EQ(value(dpMatrixCopy2.data_host).data_factors[DPMatrixDimension_::VERTICAL], 1u);
+    SEQAN_ASSERT_EQ(empty(value(dpMatrixCopy2.data_host).data_host), false);
+    SEQAN_ASSERT_EQ(dependent(value(dpMatrixCopy2.data_host).data_host), false);
 }
 
 SEQAN_DEFINE_TEST(test_alignment_dp_matrix_full_assigment)
@@ -493,26 +493,26 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_full_assigment)
 
     DPMatrix_<int, FullDPMatrix> dpMatrix;
 
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_lengths[DPMatrixDimension_::HORIZONTAL], 0u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_lengths[DPMatrixDimension_::VERTICAL], 0u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_factors[DPMatrixDimension_::HORIZONTAL], 0u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_factors[DPMatrixDimension_::VERTICAL], 1u);
-    SEQAN_ASSERT_EQ(empty(_dataHost(dpMatrix).data_host), false);
-    SEQAN_ASSERT_EQ(dependent(_dataHost(dpMatrix).data_host), false);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_lengths[DPMatrixDimension_::HORIZONTAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_lengths[DPMatrixDimension_::VERTICAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_factors[DPMatrixDimension_::HORIZONTAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_factors[DPMatrixDimension_::VERTICAL], 1u);
+    SEQAN_ASSERT_EQ(empty(value(dpMatrix.data_host).data_host), false);
+    SEQAN_ASSERT_EQ(dependent(value(dpMatrix.data_host).data_host), false);
 
-    _dataHost(dpMatrix).data_lengths[DPMatrixDimension_::HORIZONTAL] = 10;
-    _dataHost(dpMatrix).data_lengths[DPMatrixDimension_::VERTICAL] = 20;
-    _dataHost(dpMatrix).data_factors[DPMatrixDimension_::HORIZONTAL] = 20;
+    value(dpMatrix.data_host).data_lengths[DPMatrixDimension_::HORIZONTAL] = 10;
+    value(dpMatrix.data_host).data_lengths[DPMatrixDimension_::VERTICAL] = 20;
+    value(dpMatrix.data_host).data_factors[DPMatrixDimension_::HORIZONTAL] = 20;
 
     DPMatrix_<int, FullDPMatrix> dpMatrixCopy1;
     dpMatrixCopy1 = dpMatrix;
 
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrixCopy1).data_lengths[DPMatrixDimension_::HORIZONTAL], 10u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrixCopy1).data_lengths[DPMatrixDimension_::VERTICAL], 20u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrixCopy1).data_factors[DPMatrixDimension_::HORIZONTAL], 20u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrixCopy1).data_factors[DPMatrixDimension_::VERTICAL], 1u);
-    SEQAN_ASSERT_EQ(empty(_dataHost(dpMatrixCopy1).data_host), false);
-    SEQAN_ASSERT_EQ(dependent(_dataHost(dpMatrixCopy1).data_host), false);
+    SEQAN_ASSERT_EQ(value(dpMatrixCopy1.data_host).data_lengths[DPMatrixDimension_::HORIZONTAL], 10u);
+    SEQAN_ASSERT_EQ(value(dpMatrixCopy1.data_host).data_lengths[DPMatrixDimension_::VERTICAL], 20u);
+    SEQAN_ASSERT_EQ(value(dpMatrixCopy1.data_host).data_factors[DPMatrixDimension_::HORIZONTAL], 20u);
+    SEQAN_ASSERT_EQ(value(dpMatrixCopy1.data_host).data_factors[DPMatrixDimension_::VERTICAL], 1u);
+    SEQAN_ASSERT_EQ(empty(value(dpMatrixCopy1.data_host).data_host), false);
+    SEQAN_ASSERT_EQ(dependent(value(dpMatrixCopy1.data_host).data_host), false);
 }
 
 SEQAN_DEFINE_TEST(test_alignment_dp_matrix_sparse_constructor)
@@ -521,12 +521,12 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_sparse_constructor)
 
     DPMatrix_<int, SparseDPMatrix> dpMatrix;
 
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_lengths[DPMatrixDimension_::HORIZONTAL], 0u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_lengths[DPMatrixDimension_::VERTICAL], 0u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_factors[DPMatrixDimension_::HORIZONTAL], 0u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_factors[DPMatrixDimension_::VERTICAL], 1u);
-    SEQAN_ASSERT_EQ(empty(_dataHost(dpMatrix).data_host), false);
-    SEQAN_ASSERT_EQ(dependent(_dataHost(dpMatrix).data_host), false);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_lengths[DPMatrixDimension_::HORIZONTAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_lengths[DPMatrixDimension_::VERTICAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_factors[DPMatrixDimension_::HORIZONTAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_factors[DPMatrixDimension_::VERTICAL], 1u);
+    SEQAN_ASSERT_EQ(empty(value(dpMatrix.data_host).data_host), false);
+    SEQAN_ASSERT_EQ(dependent(value(dpMatrix.data_host).data_host), false);
 }
 
 SEQAN_DEFINE_TEST(test_alignment_dp_matrix_sparse_copy_constructor)
@@ -535,33 +535,33 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_sparse_copy_constructor)
 
     DPMatrix_<int, SparseDPMatrix> dpMatrix;
 
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_lengths[DPMatrixDimension_::HORIZONTAL], 0u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_lengths[DPMatrixDimension_::VERTICAL], 0u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_factors[DPMatrixDimension_::HORIZONTAL], 0u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_factors[DPMatrixDimension_::VERTICAL], 1u);
-    SEQAN_ASSERT_EQ(empty(_dataHost(dpMatrix).data_host), false);
-    SEQAN_ASSERT_EQ(dependent(_dataHost(dpMatrix).data_host), false);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_lengths[DPMatrixDimension_::HORIZONTAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_lengths[DPMatrixDimension_::VERTICAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_factors[DPMatrixDimension_::HORIZONTAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_factors[DPMatrixDimension_::VERTICAL], 1u);
+    SEQAN_ASSERT_EQ(empty(value(dpMatrix.data_host).data_host), false);
+    SEQAN_ASSERT_EQ(dependent(value(dpMatrix.data_host).data_host), false);
 
-    _dataHost(dpMatrix).data_lengths[DPMatrixDimension_::HORIZONTAL] = 10;
-    _dataHost(dpMatrix).data_lengths[DPMatrixDimension_::VERTICAL] = 20;
+    value(dpMatrix.data_host).data_lengths[DPMatrixDimension_::HORIZONTAL] = 10;
+    value(dpMatrix.data_host).data_lengths[DPMatrixDimension_::VERTICAL] = 20;
 
     DPMatrix_<int, SparseDPMatrix> dpMatrixCopy1 = dpMatrix;
 
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrixCopy1).data_lengths[DPMatrixDimension_::HORIZONTAL], 10u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrixCopy1).data_lengths[DPMatrixDimension_::VERTICAL], 20u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrixCopy1).data_factors[DPMatrixDimension_::HORIZONTAL], 0u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrixCopy1).data_factors[DPMatrixDimension_::VERTICAL], 1u);
-    SEQAN_ASSERT_EQ(empty(_dataHost(dpMatrixCopy1).data_host), false);
-    SEQAN_ASSERT_EQ(dependent(_dataHost(dpMatrixCopy1).data_host), false);
+    SEQAN_ASSERT_EQ(value(dpMatrixCopy1.data_host).data_lengths[DPMatrixDimension_::HORIZONTAL], 10u);
+    SEQAN_ASSERT_EQ(value(dpMatrixCopy1.data_host).data_lengths[DPMatrixDimension_::VERTICAL], 20u);
+    SEQAN_ASSERT_EQ(value(dpMatrixCopy1.data_host).data_factors[DPMatrixDimension_::HORIZONTAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrixCopy1.data_host).data_factors[DPMatrixDimension_::VERTICAL], 1u);
+    SEQAN_ASSERT_EQ(empty(value(dpMatrixCopy1.data_host).data_host), false);
+    SEQAN_ASSERT_EQ(dependent(value(dpMatrixCopy1.data_host).data_host), false);
 
     DPMatrix_<int, SparseDPMatrix> const dpMatrixCopy2 = dpMatrix;
 
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrixCopy2).data_lengths[DPMatrixDimension_::HORIZONTAL], 10u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrixCopy2).data_lengths[DPMatrixDimension_::VERTICAL], 20u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrixCopy2).data_factors[DPMatrixDimension_::HORIZONTAL], 0u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrixCopy2).data_factors[DPMatrixDimension_::VERTICAL], 1u);
-    SEQAN_ASSERT_EQ(empty(_dataHost(dpMatrixCopy2).data_host), false);
-    SEQAN_ASSERT_EQ(dependent(_dataHost(dpMatrixCopy2).data_host), false);
+    SEQAN_ASSERT_EQ(value(dpMatrixCopy2.data_host).data_lengths[DPMatrixDimension_::HORIZONTAL], 10u);
+    SEQAN_ASSERT_EQ(value(dpMatrixCopy2.data_host).data_lengths[DPMatrixDimension_::VERTICAL], 20u);
+    SEQAN_ASSERT_EQ(value(dpMatrixCopy2.data_host).data_factors[DPMatrixDimension_::HORIZONTAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrixCopy2.data_host).data_factors[DPMatrixDimension_::VERTICAL], 1u);
+    SEQAN_ASSERT_EQ(empty(value(dpMatrixCopy2.data_host).data_host), false);
+    SEQAN_ASSERT_EQ(dependent(value(dpMatrixCopy2.data_host).data_host), false);
 }
 
 SEQAN_DEFINE_TEST(test_alignment_dp_matrix_sparse_assigment)
@@ -570,25 +570,25 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_sparse_assigment)
 
     DPMatrix_<int, SparseDPMatrix> dpMatrix;
 
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_lengths[DPMatrixDimension_::HORIZONTAL], 0u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_lengths[DPMatrixDimension_::VERTICAL], 0u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_factors[DPMatrixDimension_::HORIZONTAL], 0u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_factors[DPMatrixDimension_::VERTICAL], 1u);
-    SEQAN_ASSERT_EQ(empty(_dataHost(dpMatrix).data_host), false);
-    SEQAN_ASSERT_EQ(dependent(_dataHost(dpMatrix).data_host), false);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_lengths[DPMatrixDimension_::HORIZONTAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_lengths[DPMatrixDimension_::VERTICAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_factors[DPMatrixDimension_::HORIZONTAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_factors[DPMatrixDimension_::VERTICAL], 1u);
+    SEQAN_ASSERT_EQ(empty(value(dpMatrix.data_host).data_host), false);
+    SEQAN_ASSERT_EQ(dependent(value(dpMatrix.data_host).data_host), false);
 
-    _dataHost(dpMatrix).data_lengths[DPMatrixDimension_::HORIZONTAL] = 10;
-    _dataHost(dpMatrix).data_lengths[DPMatrixDimension_::VERTICAL] = 20;
+    value(dpMatrix.data_host).data_lengths[DPMatrixDimension_::HORIZONTAL] = 10;
+    value(dpMatrix.data_host).data_lengths[DPMatrixDimension_::VERTICAL] = 20;
 
     DPMatrix_<int, SparseDPMatrix> dpMatrixCopy1;
     dpMatrixCopy1 = dpMatrix;
 
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrixCopy1).data_lengths[DPMatrixDimension_::HORIZONTAL], 10u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrixCopy1).data_lengths[DPMatrixDimension_::VERTICAL], 20u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrixCopy1).data_factors[DPMatrixDimension_::HORIZONTAL], 0u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrixCopy1).data_factors[DPMatrixDimension_::VERTICAL], 1u);
-    SEQAN_ASSERT_EQ(empty(_dataHost(dpMatrixCopy1).data_host), false);
-    SEQAN_ASSERT_EQ(dependent(_dataHost(dpMatrixCopy1).data_host), false);
+    SEQAN_ASSERT_EQ(value(dpMatrixCopy1.data_host).data_lengths[DPMatrixDimension_::HORIZONTAL], 10u);
+    SEQAN_ASSERT_EQ(value(dpMatrixCopy1.data_host).data_lengths[DPMatrixDimension_::VERTICAL], 20u);
+    SEQAN_ASSERT_EQ(value(dpMatrixCopy1.data_host).data_factors[DPMatrixDimension_::HORIZONTAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrixCopy1.data_host).data_factors[DPMatrixDimension_::VERTICAL], 1u);
+    SEQAN_ASSERT_EQ(empty(value(dpMatrixCopy1.data_host).data_host), false);
+    SEQAN_ASSERT_EQ(dependent(value(dpMatrixCopy1.data_host).data_host), false);
 }
 
 // ----------------------------------------------------------------------------
@@ -781,12 +781,12 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_full_value)
 
     value(dpMatrix, 1) = 'a';
     SEQAN_ASSERT_EQ(value(dpMatrix, 1), 'a');
-    SEQAN_ASSERT_EQ(value(_dataHost(dpMatrix).data_host), "xaxxxxxxxxxx");
+    SEQAN_ASSERT_EQ(value(value(dpMatrix.data_host).data_host), "xaxxxxxxxxxx");
 
     DPMatrix_<char, FullDPMatrix> const dpMatrixConst(dpMatrix);
 
     SEQAN_ASSERT_EQ(value(dpMatrixConst, 1), 'a');
-    SEQAN_ASSERT_EQ(value(_dataHost(dpMatrixConst).data_host), "xaxxxxxxxxxx");
+    SEQAN_ASSERT_EQ(value(value(dpMatrixConst.data_host).data_host), "xaxxxxxxxxxx");
 }
 
 SEQAN_DEFINE_TEST(test_alignment_dp_matrix_sparse_value)
@@ -807,12 +807,12 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_sparse_value)
 
     value(dpMatrix, 1) = 'a';
     SEQAN_ASSERT_EQ(value(dpMatrix, 1), 'a');
-    SEQAN_ASSERT_EQ(value(_dataHost(dpMatrix).data_host), "xaxx");
+    SEQAN_ASSERT_EQ(value(value(dpMatrix.data_host).data_host), "xaxx");
 
     DPMatrix_<char, SparseDPMatrix> const dpMatrixConst(dpMatrix);
 
     SEQAN_ASSERT_EQ(value(dpMatrixConst, 1), 'a');
-    SEQAN_ASSERT_EQ(value(_dataHost(dpMatrixConst).data_host), "xaxx");
+    SEQAN_ASSERT_EQ(value(value(dpMatrixConst.data_host).data_host), "xaxx");
 }
 
 SEQAN_DEFINE_TEST(test_alignment_dp_matrix_full_value_with_coordinates)
@@ -834,13 +834,13 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_full_value_with_coordinates)
     value(dpMatrix, 3, 2) = 'o';
     SEQAN_ASSERT_EQ(value(dpMatrix, 1, 0), 'a');
     SEQAN_ASSERT_EQ(value(dpMatrix, 3, 2), 'o');
-    SEQAN_ASSERT_EQ(value(_dataHost(dpMatrix).data_host), "xaxxxxxxxxxo");
+    SEQAN_ASSERT_EQ(value(value(dpMatrix.data_host).data_host), "xaxxxxxxxxxo");
 
     DPMatrix_<char, FullDPMatrix> const dpMatrixConst(dpMatrix);
 
     SEQAN_ASSERT_EQ(value(dpMatrixConst, 1, 0), 'a');
     SEQAN_ASSERT_EQ(value(dpMatrixConst, 3, 2), 'o');
-    SEQAN_ASSERT_EQ(value(_dataHost(dpMatrixConst).data_host), "xaxxxxxxxxxo");
+    SEQAN_ASSERT_EQ(value(value(dpMatrixConst.data_host).data_host), "xaxxxxxxxxxo");
 }
 
 SEQAN_DEFINE_TEST(test_alignment_dp_matrix_sparse_value_with_coordinates)
@@ -862,13 +862,13 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_sparse_value_with_coordinates)
     value(dpMatrix, 3, 2) = 'o';
     SEQAN_ASSERT_EQ(value(dpMatrix, 1, 0), 'a');
     SEQAN_ASSERT_EQ(value(dpMatrix, 3, 2), 'o');
-    SEQAN_ASSERT_EQ(value(_dataHost(dpMatrix).data_host), "xaxo");
+    SEQAN_ASSERT_EQ(value(value(dpMatrix.data_host).data_host), "xaxo");
 
     DPMatrix_<char, SparseDPMatrix> const dpMatrixConst(dpMatrix);
 
     SEQAN_ASSERT_EQ(value(dpMatrixConst, 1, 0), 'a');
     SEQAN_ASSERT_EQ(value(dpMatrixConst, 3, 2), 'o');
-    SEQAN_ASSERT_EQ(value(_dataHost(dpMatrixConst).data_host), "xaxo");
+    SEQAN_ASSERT_EQ(value(value(dpMatrixConst.data_host).data_host), "xaxo");
 }
 
 SEQAN_DEFINE_TEST(test_alignment_dp_matrix_check_dimension)
@@ -902,8 +902,8 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_full_length)
 
     DPMatrix_<char, FullDPMatrix> dpMatrix;
 
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_lengths[DPMatrixDimension_::HORIZONTAL], 0u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_lengths[DPMatrixDimension_::VERTICAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_lengths[DPMatrixDimension_::HORIZONTAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_lengths[DPMatrixDimension_::VERTICAL], 0u);
 
     setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 4);
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 3);
@@ -919,8 +919,8 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_sparse_length)
 
     DPMatrix_<char, SparseDPMatrix> dpMatrix;
 
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_lengths[DPMatrixDimension_::HORIZONTAL], 0u);
-    SEQAN_ASSERT_EQ(_dataHost(dpMatrix).data_lengths[DPMatrixDimension_::VERTICAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_lengths[DPMatrixDimension_::HORIZONTAL], 0u);
+    SEQAN_ASSERT_EQ(value(dpMatrix.data_host).data_lengths[DPMatrixDimension_::VERTICAL], 0u);
 
     setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 4);
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 3);

--- a/tests/find/test_find.cpp
+++ b/tests/find/test_find.cpp
@@ -1783,6 +1783,26 @@ SEQAN_DEFINE_TEST(test_pattern_moveassign) {
 }
 #endif  // SEQAN_CXX11_STANDARD
 
+template <TNeedle>
+struct Foo
+{
+    TNeedle * data_host;
+
+    Foo(TNeedle && ndl) :
+    {
+        data_host = *ndl;
+    }
+};
+
+SEQAN_DEFINE_TEST(pointer_to_types)
+{
+    String<Dna> dnaString;
+    auto revString = reverseString(dnaString);
+
+
+
+}
+
 SEQAN_BEGIN_TESTSUITE(test_find) {
 //     SEQAN_CALL_TEST(test_myers_trigger_bug);
     SEQAN_CALL_TEST(test_myers_find_begin);

--- a/tests/find/test_find.cpp
+++ b/tests/find/test_find.cpp
@@ -1693,6 +1693,8 @@ void test_pattern_copycon() {
     typedef Pattern<CharString, TPatternSpec> TPattern;
     TPattern p1("Some needle");
     TPattern p2(p1);
+    TPattern const p3(p2);
+    TPattern const p4(p3);
 }
 
 template <typename TPatternSpec>
@@ -1701,8 +1703,35 @@ void test_pattern_assign() {
     typedef Pattern<CharString, TPatternSpec> TPattern;
     TPattern p1("Some needle");
     TPattern p2;
+    TPattern const p3(p1);
+    TPattern p4;
     p2 = p1;
+    p4 = p3;
 }
+
+#ifdef SEQAN_CXX11_STANDARD
+
+template <typename TPatternSpec>
+void test_pattern_movecon() {
+    typedef Pattern<CharString, TPatternSpec> TPattern;
+    TPattern p1("Some needle");
+    TPattern p2(std::move(p1));
+    TPattern const p3(std::move(p2));
+    TPattern const p4(std::move(p3));
+}
+
+template <typename TPatternSpec>
+void test_pattern_moveassign() {
+    SEQAN_CHECKPOINT;
+    typedef Pattern<CharString, TPatternSpec> TPattern;
+    TPattern p1("Some needle");
+    TPattern p2;
+    TPattern const p3(p1);
+    TPattern p4;
+    p2 = std::move(p1);
+    p4 = std::move(p3);
+}
+#endif  // SEQAN_CXX11_STANDARD
 
 SEQAN_DEFINE_TEST(test_pattern_copycon) {
     // Test whether the needle is preserved in copying a pattern.
@@ -1730,6 +1759,29 @@ SEQAN_DEFINE_TEST(test_pattern_assign) {
     test_pattern_assign<Bfam<Trie> >();
 }
 
+#ifdef SEQAN_CXX11_STANDARD
+SEQAN_DEFINE_TEST(test_pattern_movecon) {
+    test_pattern_movecon<Simple>();
+    test_pattern_movecon<Horspool>();
+    test_pattern_movecon<ShiftAnd>();
+    test_pattern_movecon<ShiftOr>();
+    test_pattern_copycon<HammingSimple>();
+    test_pattern_copycon<WildShiftAnd>();
+    test_pattern_copycon<Bfam<Oracle> >();
+    test_pattern_copycon<Bfam<Trie> >();
+}
+
+SEQAN_DEFINE_TEST(test_pattern_moveassign) {
+    test_pattern_moveassign<Simple>();
+    test_pattern_moveassign<Horspool>();
+    test_pattern_moveassign<ShiftAnd>();
+    test_pattern_moveassign<ShiftOr>();
+    test_pattern_assign<HammingSimple>();
+    test_pattern_assign<WildShiftAnd>();
+    test_pattern_assign<Bfam<Oracle> >();
+    test_pattern_assign<Bfam<Trie> >();
+}
+#endif  // SEQAN_CXX11_STANDARD
 
 SEQAN_BEGIN_TESTSUITE(test_find) {
 //     SEQAN_CALL_TEST(test_myers_trigger_bug);
@@ -1783,6 +1835,11 @@ SEQAN_BEGIN_TESTSUITE(test_find) {
 
     SEQAN_CALL_TEST(test_pattern_copycon);
     SEQAN_CALL_TEST(test_pattern_assign);
+
+#ifdef SEQAN_CXX11_STANDARD
+    SEQAN_CALL_TEST(test_pattern_movecon);
+    SEQAN_CALL_TEST(test_pattern_moveassign);
+#endif  // SEQAN_CXX11_STANDARD
 
     // Verify checkpoints in all files in this module.
     SEQAN_VERIFY_CHECKPOINTS("include/seqan/find/find_hamming_simple.h");

--- a/tests/find/test_find.cpp
+++ b/tests/find/test_find.cpp
@@ -1783,26 +1783,6 @@ SEQAN_DEFINE_TEST(test_pattern_moveassign) {
 }
 #endif  // SEQAN_CXX11_STANDARD
 
-template <TNeedle>
-struct Foo
-{
-    TNeedle * data_host;
-
-    Foo(TNeedle && ndl) :
-    {
-        data_host = *ndl;
-    }
-};
-
-SEQAN_DEFINE_TEST(pointer_to_types)
-{
-    String<Dna> dnaString;
-    auto revString = reverseString(dnaString);
-
-
-
-}
-
 SEQAN_BEGIN_TESTSUITE(test_find) {
 //     SEQAN_CALL_TEST(test_myers_trigger_bug);
     SEQAN_CALL_TEST(test_myers_find_begin);


### PR DESCRIPTION
Adds setHost with move semantics to replace old non-const and const version which was misused in many places, especially in the Pattern implementation If 
If c++11 is enabled! The setHost of Pattern delegates now correctly to a Holder, meaning that temporaries are copied and lvalue refs are set dependent.