### PR TITLE
Fix windows build warnings

### DIFF
--- a/include/seqan/find/find_multiple_bfam.h
+++ b/include/seqan/find/find_multiple_bfam.h
@@ -110,7 +110,7 @@ public:
     {
     }
 
-#if defined(SEQAN_CXX11_STANDARD) && (!_MSC_VER || _MSC_VER >= 1900) && (!PLATFORM_WINDOWS_MINGW)
+#if defined(SEQAN_CXX11_CORE)
     Pattern(Pattern && other) = delete;
     Pattern & operator=(Pattern && other) = delete;
 
@@ -129,7 +129,7 @@ public:
         SEQAN_CHECKPOINT
         setHost(*this, ndl);
     }
-# endif
+# endif  // SEQAN_CXX11_CORE
 
     ~Pattern()
     {}

--- a/include/seqan/find/find_multiple_bfam.h
+++ b/include/seqan/find/find_multiple_bfam.h
@@ -110,10 +110,7 @@ public:
     {
     }
 
-#if defined(SEQAN_CXX11_CORE)
-    Pattern(Pattern && other) = delete;
-    Pattern & operator=(Pattern && other) = delete;
-
+#if defined(SEQAN_CXX11_STANDARD)
     template <typename TNeedle2>
     Pattern(TNeedle2 && ndl,
             SEQAN_CTOR_DISABLE_IF(IsSameType<typename std::remove_reference<TNeedle2>::type const &, Pattern const &>))
@@ -121,7 +118,6 @@ public:
         setHost(*this, std::forward<TNeedle2>(ndl));
         ignoreUnusedVariableWarning(dummy);
     }
-
 #else
     template <typename TNeedle2>
     Pattern(TNeedle2 const & ndl)
@@ -129,7 +125,7 @@ public:
         SEQAN_CHECKPOINT
         setHost(*this, ndl);
     }
-# endif  // SEQAN_CXX11_CORE
+# endif  // SEQAN_CXX11_STANDARD
 
     ~Pattern()
     {}
@@ -138,7 +134,10 @@ public:
 private:
     Pattern(Pattern const& other);
     Pattern const & operator=(Pattern const & other);
-
+#if defined(SEQAN_CXX11_STANDARD)
+    Pattern(Pattern && other);
+    Pattern & operator=(Pattern && other);
+#endif  // SEQAN_CXX11_STANDARD
 //____________________________________________________________________________
 };
 

--- a/include/seqan/find/find_multiple_bfam.h
+++ b/include/seqan/find/find_multiple_bfam.h
@@ -110,7 +110,7 @@ public:
     {
     }
 
-#ifdef SEQAN_CXX11_STANDARD
+#if defined(SEQAN_CXX11_STANDARD) && (!_MSC_VER || _MSC_VER >= 1900) && (!PLATFORM_WINDOWS_MINGW)
     Pattern(Pattern && other) = delete;
     Pattern & operator=(Pattern && other) = delete;
 

--- a/include/seqan/find/find_wumanber.h
+++ b/include/seqan/find/find_wumanber.h
@@ -90,7 +90,7 @@ public:
     {
     }
 
-#if defined(SEQAN_CXX11_STANDARD) && (!_MSC_VER || _MSC_VER >= 1900) && (!PLATFORM_WINDOWS_MINGW)
+#if defined(SEQAN_CXX11_CORE)
     Pattern(Pattern && other) = delete;
     Pattern & operator=(Pattern && other) = delete;
 
@@ -108,7 +108,7 @@ public:
         SEQAN_CHECKPOINT
         setHost(*this, ndl);
     }
-#endif  // SEQAN_CXX11_STANDARD
+#endif  // SEQAN_CXX11_CORE
 
     ~Pattern()
     {

--- a/include/seqan/find/find_wumanber.h
+++ b/include/seqan/find/find_wumanber.h
@@ -90,10 +90,7 @@ public:
     {
     }
 
-#if defined(SEQAN_CXX11_CORE)
-    Pattern(Pattern && other) = delete;
-    Pattern & operator=(Pattern && other) = delete;
-
+#if defined(SEQAN_CXX11_STANDARD)
     template <typename TNeedle2>
     Pattern(TNeedle2 && ndl,
             SEQAN_CTOR_DISABLE_IF(IsSameType<typename std::remove_reference<TNeedle2>::type const &, Pattern const &>))
@@ -108,7 +105,7 @@ public:
         SEQAN_CHECKPOINT
         setHost(*this, ndl);
     }
-#endif  // SEQAN_CXX11_CORE
+#endif  // SEQAN_CXX11_STANDARD
 
     ~Pattern()
     {
@@ -118,7 +115,10 @@ public:
 private:
     Pattern(Pattern const& other);
     Pattern const & operator=(Pattern const & other);
-
+#if defined(SEQAN_CXX11_STANDARD)
+    Pattern(Pattern && other);
+    Pattern & operator=(Pattern && other);
+#endif  // SEQAN_CXX11_STANDARD
 //____________________________________________________________________________
 };
 

--- a/include/seqan/find/find_wumanber.h
+++ b/include/seqan/find/find_wumanber.h
@@ -90,7 +90,7 @@ public:
     {
     }
 
-#ifdef SEQAN_CXX11_STANDARD
+#if defined(SEQAN_CXX11_STANDARD) && (!_MSC_VER || _MSC_VER >= 1900) && (!PLATFORM_WINDOWS_MINGW)
     Pattern(Pattern && other) = delete;
     Pattern & operator=(Pattern && other) = delete;
 

--- a/include/seqan/platform.h
+++ b/include/seqan/platform.h
@@ -83,6 +83,11 @@
 #define SEQAN_CXX11_STL
 #endif
 
+// Are the C++11 core language features available (for instance variadic templates, dfaulted and deleted move constructor functions, constexpr, etc.)?
+#if defined(SEQAN_CXX11_STANDARD) && (!defined(_MSC_VER) || _MSC_VER >= 1900) && !defined(PLATFORM_WINDOWS_MINGW)
+#define SEQAN_CXX11_CORE
+#endif
+
 // C++ restrict keyword, see e.g. platform_gcc.h
 #ifndef SEQAN_RESTRICT
 #define SEQAN_RESTRICT

--- a/include/seqan/platform.h
+++ b/include/seqan/platform.h
@@ -83,11 +83,6 @@
 #define SEQAN_CXX11_STL
 #endif
 
-// Are the C++11 core language features available (for instance variadic templates, dfaulted and deleted move constructor functions, constexpr, etc.)?
-#if defined(SEQAN_CXX11_STANDARD) && (!defined(_MSC_VER) || _MSC_VER >= 1900) && !defined(PLATFORM_WINDOWS_MINGW)
-#define SEQAN_CXX11_CORE
-#endif
-
 // C++ restrict keyword, see e.g. platform_gcc.h
 #ifndef SEQAN_RESTRICT
 #define SEQAN_RESTRICT


### PR DESCRIPTION
Fixes build errors on VS 10 and VS 11 which did not support delete and default for move constructor and assignment function.