### PR TITLE
Enables global exception handler only if macro is defined 

### DIFF
--- a/include/seqan/basic/basic_exception.h
+++ b/include/seqan/basic/basic_exception.h
@@ -350,7 +350,7 @@ struct AssertFunctor
 // Function globalExceptionHandler()
 // ----------------------------------------------------------------------------
 
-#if defined(SEQAN_EXCEPTIONS) && defined(SEQAN_INSTALL_GLOBAL_EXCEPTION_HANDLER)
+#if defined(SEQAN_EXCEPTIONS) && defined(SEQAN_GLOBAL_EXCEPTION_HANDLER)
 // Declare global exception handler.
 static void globalExceptionHandler();
 
@@ -372,7 +372,7 @@ inline static void globalExceptionHandler()
         SEQAN_FAIL("Uncaught exception of unknown type.\n");
     }
 }
-#endif  // #if defined(SEQAN_EXCEPTIONS) && defined(SEQAN_INSTALL_GLOBAL_EXCEPTION_HANDLER)
+#endif  // #if defined(SEQAN_EXCEPTIONS) && defined(SEQAN_GLOBAL_EXCEPTION_HANDLER)
 
 }  // namespace seqan
 

--- a/include/seqan/basic/basic_exception.h
+++ b/include/seqan/basic/basic_exception.h
@@ -350,7 +350,7 @@ struct AssertFunctor
 // Function globalExceptionHandler()
 // ----------------------------------------------------------------------------
 
-#if defined(SEQAN_EXCEPTIONS) && !defined(SEQAN_NO_GLOBAL_EXCEPTION_HANDLER)
+#if defined(SEQAN_EXCEPTIONS) && defined(SEQAN_INSTALL_GLOBAL_EXCEPTION_HANDLER)
 // Declare global exception handler.
 static void globalExceptionHandler();
 

--- a/include/seqan/basic/basic_exception.h
+++ b/include/seqan/basic/basic_exception.h
@@ -372,7 +372,7 @@ inline static void globalExceptionHandler()
         SEQAN_FAIL("Uncaught exception of unknown type.\n");
     }
 }
-#endif  // #if defined(SEQAN_EXCEPTIONS) && !defined(SEQAN_NO_GLOBAL_EXCEPTION_HANDLER)
+#endif  // #if defined(SEQAN_EXCEPTIONS) && defined(SEQAN_INSTALL_GLOBAL_EXCEPTION_HANDLER)
 
 }  // namespace seqan
 

--- a/util/cmake/SeqAnBuildSystem.cmake
+++ b/util/cmake/SeqAnBuildSystem.cmake
@@ -153,7 +153,7 @@ macro (seqan_register_apps)
     endif ()
 
     # Enable global exception handler for all seqan apps.
-    set (SEQAN_DEFINITIONS "${SEQAN_DEFINITIONS} -DSEQAN_INSTALL_GLOBAL_EXCEPTION_HANDLER")
+    set (SEQAN_DEFINITIONS "${SEQAN_DEFINITIONS} -DSEQAN_GLOBAL_EXCEPTION_HANDLER")
 
     # Get all direct entries of the current source directory into ENTRIES.
     file (GLOB ENTRIES
@@ -653,7 +653,7 @@ function (seqan_register_demos)
     endif (${ARGC} GREATER 0)
 
     # Enable global exception handler for demos.
-    set (SEQAN_DEFINITIONS "${SEQAN_DEFINITIONS} -DSEQAN_INSTALL_GLOBAL_EXCEPTION_HANDLER")
+    set (SEQAN_DEFINITIONS "${SEQAN_DEFINITIONS} -DSEQAN_GLOBAL_EXCEPTION_HANDLER")
 
     # Install demo source files when releasing and build demos when developing.
     if ("${SEQAN_BUILD_SYSTEM}" STREQUAL "SEQAN_RELEASE")
@@ -691,7 +691,7 @@ macro (seqan_register_tests)
             CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
 
     # Add global exception handler
-    set (SEQAN_DEFINITIONS "${SEQAN_DEFINITIONS} -DSEQAN_INSTALL_GLOBAL_EXCEPTION_HANDLER")
+    set (SEQAN_DEFINITIONS "${SEQAN_DEFINITIONS} -DSEQAN_GLOBAL_EXCEPTION_HANDLER")
 
     # Conditionally enable coverage mode by setting the appropriate flags.
     if (MODEL STREQUAL "NightlyCoverage")

--- a/util/cmake/SeqAnBuildSystem.cmake
+++ b/util/cmake/SeqAnBuildSystem.cmake
@@ -152,6 +152,9 @@ macro (seqan_register_apps)
       set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++")
     endif ()
 
+    # Enable global exception handler for all seqan apps.
+    set (SEQAN_DEFINITIONS "${SEQAN_DEFINITIONS} SEQAN_INSTALL_GLOBAL_EXCEPTION_HANDLER")
+
     # Get all direct entries of the current source directory into ENTRIES.
     file (GLOB ENTRIES
           RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
@@ -581,6 +584,9 @@ macro (seqan_install_demos_release)
           ${CMAKE_CURRENT_SOURCE_DIR}/[!.]*.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/[!.]*.cu)
 
+    # Set global definitions set for demos.
+    add_definitions (${SEQAN_DEFINITIONS})
+
     # Get path to current source directory, relative from root.  Will be used to install demos in.
     file (RELATIVE_PATH INSTALL_DIR "${SEQAN_ROOT_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}")
 
@@ -646,6 +652,9 @@ function (seqan_register_demos)
         set (PREFIX "")
     endif (${ARGC} GREATER 0)
 
+    # Enable global exception handler for demos.
+    set (SEQAN_DEFINITIONS "${SEQAN_DEFINITIONS} SEQAN_INSTALL_GLOBAL_EXCEPTION_HANDLER")
+
     # Install demo source files when releasing and build demos when developing.
     if ("${SEQAN_BUILD_SYSTEM}" STREQUAL "SEQAN_RELEASE")
         seqan_install_demos_release ()
@@ -680,6 +689,9 @@ macro (seqan_register_tests)
             CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
     string (REGEX REPLACE "-DNDEBUG" ""
             CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+
+    # Add global exception handler
+    set (SEQAN_DEFINITIONS "${SEQAN_DEFINITIONS} SEQAN_INSTALL_GLOBAL_EXCEPTION_HANDLER")
 
     # Conditionally enable coverage mode by setting the appropriate flags.
     if (MODEL STREQUAL "NightlyCoverage")

--- a/util/cmake/SeqAnBuildSystem.cmake
+++ b/util/cmake/SeqAnBuildSystem.cmake
@@ -153,7 +153,7 @@ macro (seqan_register_apps)
     endif ()
 
     # Enable global exception handler for all seqan apps.
-    set (SEQAN_DEFINITIONS "${SEQAN_DEFINITIONS} SEQAN_INSTALL_GLOBAL_EXCEPTION_HANDLER")
+    set (SEQAN_DEFINITIONS "${SEQAN_DEFINITIONS} -DSEQAN_INSTALL_GLOBAL_EXCEPTION_HANDLER")
 
     # Get all direct entries of the current source directory into ENTRIES.
     file (GLOB ENTRIES
@@ -653,7 +653,7 @@ function (seqan_register_demos)
     endif (${ARGC} GREATER 0)
 
     # Enable global exception handler for demos.
-    set (SEQAN_DEFINITIONS "${SEQAN_DEFINITIONS} SEQAN_INSTALL_GLOBAL_EXCEPTION_HANDLER")
+    set (SEQAN_DEFINITIONS "${SEQAN_DEFINITIONS} -DSEQAN_INSTALL_GLOBAL_EXCEPTION_HANDLER")
 
     # Install demo source files when releasing and build demos when developing.
     if ("${SEQAN_BUILD_SYSTEM}" STREQUAL "SEQAN_RELEASE")
@@ -691,7 +691,7 @@ macro (seqan_register_tests)
             CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
 
     # Add global exception handler
-    set (SEQAN_DEFINITIONS "${SEQAN_DEFINITIONS} SEQAN_INSTALL_GLOBAL_EXCEPTION_HANDLER")
+    set (SEQAN_DEFINITIONS "${SEQAN_DEFINITIONS} -DSEQAN_INSTALL_GLOBAL_EXCEPTION_HANDLER")
 
     # Conditionally enable coverage mode by setting the appropriate flags.
     if (MODEL STREQUAL "NightlyCoverage")


### PR DESCRIPTION
The old behaviour was to set the macro ```SEQAN_NO_GLOBAL_EXCEPTION_HANDLER``` in order to disable it. Now we have to define the macro ```SEQAN_INSTALL_GLOBAL_EXCEPTION_HANDLER``` in order to enable it.
The build scripts are updated to set this macro for demos, tests and apps within the SeqAn library automatically. External apps and libraries have to set this macro explicitly. 