### PR TITLE
Fix FragmentStore parsing of Gff3 files

### DIFF
--- a/tests/store/example.gff
+++ b/tests/store/example.gff
@@ -1,3 +1,3 @@
-ctg123	.	mRNA	1300	9000	.	+	.	ID=mrna0001;Name="sonichedgehog;hehe"
+ctg123	.	mRNA	1300	9000	.	+	.	ID=mrna0001;Name="sonichedgehog;hehe";transcript_id=001
 ctg123	.	exon	1300	1500	.	+	.	ID=exon00001;Parent=mrna0001
 ctg123	.	exon	1050	1500	.	+	.	ID=exon00002;Parent=mrna0001


### PR DESCRIPTION
FragmentStore constructs a wrong AnnotationTree when parsing Gff3 files containing transcript_id fields. See #583.