### PR TITLE
Fix CMake Java detection

### DIFF
--- a/include/seqan/basic/basic_exception.h
+++ b/include/seqan/basic/basic_exception.h
@@ -350,7 +350,7 @@ struct AssertFunctor
 // Function globalExceptionHandler()
 // ----------------------------------------------------------------------------
 
-#if defined(SEQAN_EXCEPTIONS) && !defined(SEQAN_NO_GLOBAL_EXCEPTION_HANDLER)
+#if defined(SEQAN_EXCEPTIONS) && defined(SEQAN_GLOBAL_EXCEPTION_HANDLER)
 // Declare global exception handler.
 static void globalExceptionHandler();
 
@@ -372,7 +372,7 @@ inline static void globalExceptionHandler()
         SEQAN_FAIL("Uncaught exception of unknown type.\n");
     }
 }
-#endif  // #if defined(SEQAN_EXCEPTIONS) && !defined(SEQAN_NO_GLOBAL_EXCEPTION_HANDLER)
+#endif  // #if defined(SEQAN_EXCEPTIONS) && defined(SEQAN_GLOBAL_EXCEPTION_HANDLER)
 
 }  // namespace seqan
 

--- a/util/cmake/CMakeFindJavaCommon.cmake
+++ b/util/cmake/CMakeFindJavaCommon.cmake
@@ -1,0 +1,40 @@
+#=============================================================================
+# Copyright 2013-2014 Kitware, Inc.
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+# Do not include this module directly from code outside CMake!
+set(_JAVA_HOME "")
+if(JAVA_HOME AND IS_DIRECTORY "${JAVA_HOME}")
+  set(_JAVA_HOME "${JAVA_HOME}")
+  set(_JAVA_HOME_EXPLICIT 1)
+else()
+  set(_ENV_JAVA_HOME "")
+  if(DEFINED ENV{JAVA_HOME})
+    file(TO_CMAKE_PATH "$ENV{JAVA_HOME}" _ENV_JAVA_HOME)
+  endif()
+  if(_ENV_JAVA_HOME AND IS_DIRECTORY "${_ENV_JAVA_HOME}")
+    set(_JAVA_HOME "${_ENV_JAVA_HOME}")
+    set(_JAVA_HOME_EXPLICIT 1)
+  else()
+    set(_CMD_JAVA_HOME "")
+    if(APPLE AND EXISTS /usr/libexec/java_home)
+      execute_process(COMMAND /usr/libexec/java_home
+        OUTPUT_VARIABLE _CMD_JAVA_HOME OUTPUT_STRIP_TRAILING_WHITESPACE)
+    endif()
+    if(_CMD_JAVA_HOME AND IS_DIRECTORY "${_CMD_JAVA_HOME}")
+      set(_JAVA_HOME "${_CMD_JAVA_HOME}")
+      set(_JAVA_HOME_EXPLICIT 0)
+    endif()
+    unset(_CMD_JAVA_HOME)
+  endif()
+  unset(_ENV_JAVA_HOME)
+endif()

--- a/util/cmake/FindJava.cmake
+++ b/util/cmake/FindJava.cmake
@@ -1,0 +1,228 @@
+#.rst:
+# FindJava
+# --------
+#
+# Find Java
+#
+# This module finds if Java is installed and determines where the
+# include files and libraries are.  The caller may set variable JAVA_HOME
+# to specify a Java installation prefix explicitly.
+#
+# This module sets the following result variables:
+#
+# ::
+#
+#   Java_JAVA_EXECUTABLE    = the full path to the Java runtime
+#   Java_JAVAC_EXECUTABLE   = the full path to the Java compiler
+#   Java_JAVAH_EXECUTABLE   = the full path to the Java header generator
+#   Java_JAVADOC_EXECUTABLE = the full path to the Java documention generator
+#   Java_JAR_EXECUTABLE     = the full path to the Java archiver
+#   Java_VERSION_STRING     = Version of java found, eg. 1.6.0_12
+#   Java_VERSION_MAJOR      = The major version of the package found.
+#   Java_VERSION_MINOR      = The minor version of the package found.
+#   Java_VERSION_PATCH      = The patch version of the package found.
+#   Java_VERSION_TWEAK      = The tweak version of the package found (after '_')
+#   Java_VERSION            = This is set to: $major.$minor.$patch(.$tweak)
+#
+#
+#
+# The minimum required version of Java can be specified using the
+# standard CMake syntax, e.g.  find_package(Java 1.5)
+#
+# NOTE: ${Java_VERSION} and ${Java_VERSION_STRING} are not guaranteed to
+# be identical.  For example some java version may return:
+# Java_VERSION_STRING = 1.5.0_17 and Java_VERSION = 1.5.0.17
+#
+# another example is the Java OEM, with: Java_VERSION_STRING = 1.6.0-oem
+# and Java_VERSION = 1.6.0
+#
+# For these components the following variables are set:
+#
+# ::
+#
+#   Java_FOUND                    - TRUE if all components are found.
+#   Java_INCLUDE_DIRS             - Full paths to all include dirs.
+#   Java_LIBRARIES                - Full paths to all libraries.
+#   Java_<component>_FOUND        - TRUE if <component> is found.
+#
+#
+#
+# Example Usages:
+#
+# ::
+#
+#   find_package(Java)
+#   find_package(Java COMPONENTS Runtime)
+#   find_package(Java COMPONENTS Development)
+
+#=============================================================================
+# Copyright 2002-2009 Kitware, Inc.
+# Copyright 2009-2011 Mathieu Malaterre <mathieu.malaterre@gmail.com>
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+include(${CMAKE_CURRENT_LIST_DIR}/CMakeFindJavaCommon.cmake)
+
+# The HINTS option should only be used for values computed from the system.
+set(_JAVA_HINTS)
+if(_JAVA_HOME)
+  list(APPEND _JAVA_HINTS ${_JAVA_HOME}/bin)
+endif()
+list(APPEND _JAVA_HINTS
+  "[HKEY_LOCAL_MACHINE\\SOFTWARE\\JavaSoft\\Java Development Kit\\2.0;JavaHome]/bin"
+  "[HKEY_LOCAL_MACHINE\\SOFTWARE\\JavaSoft\\Java Development Kit\\1.9;JavaHome]/bin"
+  "[HKEY_LOCAL_MACHINE\\SOFTWARE\\JavaSoft\\Java Development Kit\\1.8;JavaHome]/bin"
+  "[HKEY_LOCAL_MACHINE\\SOFTWARE\\JavaSoft\\Java Development Kit\\1.7;JavaHome]/bin"
+  "[HKEY_LOCAL_MACHINE\\SOFTWARE\\JavaSoft\\Java Development Kit\\1.6;JavaHome]/bin"
+  "[HKEY_LOCAL_MACHINE\\SOFTWARE\\JavaSoft\\Java Development Kit\\1.5;JavaHome]/bin"
+  "[HKEY_LOCAL_MACHINE\\SOFTWARE\\JavaSoft\\Java Development Kit\\1.4;JavaHome]/bin"
+  "[HKEY_LOCAL_MACHINE\\SOFTWARE\\JavaSoft\\Java Development Kit\\1.3;JavaHome]/bin"
+  )
+# Hard-coded guesses should still go in PATHS. This ensures that the user
+# environment can always override hard guesses.
+set(_JAVA_PATHS
+  /usr/lib/java/bin
+  /usr/share/java/bin
+  /usr/local/java/bin
+  /usr/local/java/share/bin
+  /usr/java/j2sdk1.4.2_04
+  /usr/lib/j2sdk1.4-sun/bin
+  /usr/java/j2sdk1.4.2_09/bin
+  /usr/lib/j2sdk1.5-sun/bin
+  /opt/sun-jdk-1.5.0.04/bin
+  /usr/local/jdk-1.7.0/bin
+  /usr/local/jdk-1.6.0/bin
+  )
+find_program(Java_JAVA_EXECUTABLE
+  NAMES java
+  HINTS ${_JAVA_HINTS}
+  PATHS ${_JAVA_PATHS}
+)
+
+if(Java_JAVA_EXECUTABLE)
+    execute_process(COMMAND ${Java_JAVA_EXECUTABLE} -version
+      RESULT_VARIABLE res
+      OUTPUT_VARIABLE var
+      ERROR_VARIABLE var # sun-java output to stderr
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_STRIP_TRAILING_WHITESPACE)
+    if( res )
+      if(var MATCHES "No Java runtime present, requesting install")
+        set_property(CACHE Java_JAVA_EXECUTABLE
+          PROPERTY VALUE "Java_JAVA_EXECUTABLE-NOTFOUND")
+      elseif(${Java_FIND_REQUIRED})
+        message( FATAL_ERROR "Error executing java -version" )
+      else()
+        message( STATUS "Warning, could not run java -version")
+      endif()
+    else()
+      # extract major/minor version and patch level from "java -version" output
+      # Tested on linux using
+      # 1. Sun / Sun OEM
+      # 2. OpenJDK 1.6
+      # 3. GCJ 1.5
+      # 4. Kaffe 1.4.2
+      # 5. OpenJDK 1.7.x on OpenBSD
+      if(var MATCHES "java version \"([0-9]+\\.[0-9]+\\.[0-9_.]+.*)\"")
+        # This is most likely Sun / OpenJDK, or maybe GCJ-java compat layer
+        set(Java_VERSION_STRING "${CMAKE_MATCH_1}")
+      elseif(var MATCHES "java full version \"kaffe-([0-9]+\\.[0-9]+\\.[0-9_]+)\"")
+        # Kaffe style
+        set(Java_VERSION_STRING "${CMAKE_MATCH_1}")
+      elseif(var MATCHES "openjdk version \"([0-9]+\\.[0-9]+\\.[0-9_]+.*)\"")
+        # OpenJDK ver 1.7.x on OpenBSD
+        set(Java_VERSION_STRING "${CMAKE_MATCH_1}")
+      else()
+        if(NOT Java_FIND_QUIETLY)
+          message(WARNING "regex not supported: ${var}. Please report")
+        endif()
+      endif()
+      string( REGEX REPLACE "([0-9]+).*" "\\1" Java_VERSION_MAJOR "${Java_VERSION_STRING}" )
+      string( REGEX REPLACE "[0-9]+\\.([0-9]+).*" "\\1" Java_VERSION_MINOR "${Java_VERSION_STRING}" )
+      string( REGEX REPLACE "[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1" Java_VERSION_PATCH "${Java_VERSION_STRING}" )
+      # warning tweak version can be empty:
+      string( REGEX REPLACE "[0-9]+\\.[0-9]+\\.[0-9]+[_\\.]?([0-9]*).*$" "\\1" Java_VERSION_TWEAK "${Java_VERSION_STRING}" )
+      if( Java_VERSION_TWEAK STREQUAL "" ) # check case where tweak is not defined
+        set(Java_VERSION ${Java_VERSION_MAJOR}.${Java_VERSION_MINOR}.${Java_VERSION_PATCH})
+      else()
+        set(Java_VERSION ${Java_VERSION_MAJOR}.${Java_VERSION_MINOR}.${Java_VERSION_PATCH}.${Java_VERSION_TWEAK})
+      endif()
+    endif()
+
+endif()
+
+
+find_program(Java_JAR_EXECUTABLE
+  NAMES jar
+  HINTS ${_JAVA_HINTS}
+  PATHS ${_JAVA_PATHS}
+)
+
+find_program(Java_JAVAC_EXECUTABLE
+  NAMES javac
+  HINTS ${_JAVA_HINTS}
+  PATHS ${_JAVA_PATHS}
+)
+
+find_program(Java_JAVAH_EXECUTABLE
+  NAMES javah
+  HINTS ${_JAVA_HINTS}
+  PATHS ${_JAVA_PATHS}
+)
+
+find_program(Java_JAVADOC_EXECUTABLE
+  NAMES javadoc
+  HINTS ${_JAVA_HINTS}
+  PATHS ${_JAVA_PATHS}
+)
+
+include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
+if(Java_FIND_COMPONENTS)
+  foreach(component ${Java_FIND_COMPONENTS})
+    # User just want to execute some Java byte-compiled
+    if(component STREQUAL "Runtime")
+      find_package_handle_standard_args(Java
+        REQUIRED_VARS Java_JAVA_EXECUTABLE
+        VERSION_VAR Java_VERSION
+        )
+    elseif(component STREQUAL "Development")
+      find_package_handle_standard_args(Java
+        REQUIRED_VARS Java_JAVA_EXECUTABLE Java_JAR_EXECUTABLE Java_JAVAC_EXECUTABLE
+                      Java_JAVAH_EXECUTABLE Java_JAVADOC_EXECUTABLE
+        VERSION_VAR Java_VERSION
+        )
+    else()
+      message(FATAL_ERROR "Comp: ${component} is not handled")
+    endif()
+    set(Java_${component}_FOUND TRUE)
+  endforeach()
+else()
+  # Check for everything
+  find_package_handle_standard_args(Java
+    REQUIRED_VARS Java_JAVA_EXECUTABLE Java_JAR_EXECUTABLE Java_JAVAC_EXECUTABLE
+                  Java_JAVAH_EXECUTABLE Java_JAVADOC_EXECUTABLE
+    VERSION_VAR Java_VERSION
+    )
+endif()
+
+
+mark_as_advanced(
+  Java_JAVA_EXECUTABLE
+  Java_JAR_EXECUTABLE
+  Java_JAVAC_EXECUTABLE
+  Java_JAVAH_EXECUTABLE
+  Java_JAVADOC_EXECUTABLE
+  )
+
+# LEGACY
+set(JAVA_RUNTIME ${Java_JAVA_EXECUTABLE})
+set(JAVA_ARCHIVE ${Java_JAR_EXECUTABLE})
+set(JAVA_COMPILE ${Java_JAVAC_EXECUTABLE})

--- a/util/cmake/FindJava.cmake
+++ b/util/cmake/FindJava.cmake
@@ -69,7 +69,7 @@
 # (To distribute this file outside of CMake, substitute the full
 #  License text for the above reference.)
 
-include(${CMAKE_MODULE_PATH}/CMakeFindJavaCommon.cmake)
+include(${CMAKE_ROOT}/Modules/CMakeFindJavaCommon.cmake)
 
 # The HINTS option should only be used for values computed from the system.
 set(_JAVA_HINTS)
@@ -184,7 +184,7 @@ find_program(Java_JAVADOC_EXECUTABLE
   PATHS ${_JAVA_PATHS}
 )
 
-include(${CMAKE_MODULE_PATH}/FindPackageHandleStandardArgs.cmake)
+include(${CMAKE_ROOT}/Modules/FindPackageHandleStandardArgs.cmake)
 if(Java_FIND_COMPONENTS)
   foreach(component ${Java_FIND_COMPONENTS})
     # User just want to execute some Java byte-compiled

--- a/util/cmake/FindJava.cmake
+++ b/util/cmake/FindJava.cmake
@@ -69,7 +69,7 @@
 # (To distribute this file outside of CMake, substitute the full
 #  License text for the above reference.)
 
-include(${CMAKE_ROOT}/Modules/CMakeFindJavaCommon.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/CMakeFindJavaCommon.cmake)
 
 # The HINTS option should only be used for values computed from the system.
 set(_JAVA_HINTS)
@@ -184,7 +184,7 @@ find_program(Java_JAVADOC_EXECUTABLE
   PATHS ${_JAVA_PATHS}
 )
 
-include(${CMAKE_ROOT}/Modules/FindPackageHandleStandardArgs.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
 if(Java_FIND_COMPONENTS)
   foreach(component ${Java_FIND_COMPONENTS})
     # User just want to execute some Java byte-compiled

--- a/util/cmake/FindJava.cmake
+++ b/util/cmake/FindJava.cmake
@@ -69,7 +69,6 @@
 # (To distribute this file outside of CMake, substitute the full
 #  License text for the above reference.)
 
-#include(${CMAKE_CURRENT_LIST_DIR}/CMakeFindJavaCommon.cmake)
 include(${CMAKE_MODULE_PATH}/CMakeFindJavaCommon.cmake)
 
 # The HINTS option should only be used for values computed from the system.
@@ -185,7 +184,7 @@ find_program(Java_JAVADOC_EXECUTABLE
   PATHS ${_JAVA_PATHS}
 )
 
-include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
+include(${CMAKE_MODULE_PATH}/FindPackageHandleStandardArgs.cmake)
 if(Java_FIND_COMPONENTS)
   foreach(component ${Java_FIND_COMPONENTS})
     # User just want to execute some Java byte-compiled

--- a/util/cmake/FindJava.cmake
+++ b/util/cmake/FindJava.cmake
@@ -69,7 +69,8 @@
 # (To distribute this file outside of CMake, substitute the full
 #  License text for the above reference.)
 
-include(${CMAKE_CURRENT_LIST_DIR}/CMakeFindJavaCommon.cmake)
+#include(${CMAKE_CURRENT_LIST_DIR}/CMakeFindJavaCommon.cmake)
+include(${CMAKE_MODULE_PATH}/CMakeFindJavaCommon.cmake)
 
 # The HINTS option should only be used for values computed from the system.
 set(_JAVA_HINTS)

--- a/util/cmake/SeqAnBuildSystem.cmake
+++ b/util/cmake/SeqAnBuildSystem.cmake
@@ -152,6 +152,9 @@ macro (seqan_register_apps)
       set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++")
     endif ()
 
+    # Enable global exception handler for all seqan apps.
+    set (SEQAN_DEFINITIONS "${SEQAN_DEFINITIONS} -DSEQAN_GLOBAL_EXCEPTION_HANDLER")
+
     # Get all direct entries of the current source directory into ENTRIES.
     file (GLOB ENTRIES
           RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
@@ -581,6 +584,9 @@ macro (seqan_install_demos_release)
           ${CMAKE_CURRENT_SOURCE_DIR}/[!.]*.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/[!.]*.cu)
 
+    # Set global definitions set for demos.
+    add_definitions (${SEQAN_DEFINITIONS})
+
     # Get path to current source directory, relative from root.  Will be used to install demos in.
     file (RELATIVE_PATH INSTALL_DIR "${SEQAN_ROOT_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}")
 
@@ -646,6 +652,9 @@ function (seqan_register_demos)
         set (PREFIX "")
     endif (${ARGC} GREATER 0)
 
+    # Enable global exception handler for demos.
+    set (SEQAN_DEFINITIONS "${SEQAN_DEFINITIONS} -DSEQAN_GLOBAL_EXCEPTION_HANDLER")
+
     # Install demo source files when releasing and build demos when developing.
     if ("${SEQAN_BUILD_SYSTEM}" STREQUAL "SEQAN_RELEASE")
         seqan_install_demos_release ()
@@ -680,6 +689,9 @@ macro (seqan_register_tests)
             CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
     string (REGEX REPLACE "-DNDEBUG" ""
             CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+
+    # Add global exception handler
+    set (SEQAN_DEFINITIONS "${SEQAN_DEFINITIONS} -DSEQAN_GLOBAL_EXCEPTION_HANDLER")
 
     # Conditionally enable coverage mode by setting the appropriate flags.
     if (MODEL STREQUAL "NightlyCoverage")


### PR DESCRIPTION
This is a patch for fixing the bug (https://bugs.debian.org/772631) in cmake's findJava module. This is a temporary fix until the new cmake version, which has already the bug taken care of, becomes stable. 

This fixes issue #967. 