### PR TITLE
Comments lines in .gff will be skipped properly

### DIFF
--- a/include/seqan/gff_io/gff_io_base.h
+++ b/include/seqan/gff_io/gff_io_base.h
@@ -354,7 +354,7 @@ void readRecord(GffRecord & record, CharString & buffer, TFwdIterator & iter)
         skipLine(iter);
 
     clear(record);
-    skipUntil(iter, NotFunctor<IsWhitespace>());  //skip empty linesa
+    skipUntil(iter, NotFunctor<IsWhitespace>());  //skip empty lines
 
     // read column 1: seqid
     readUntil(record.ref, iter, OrFunctor<IsTab, AssertFunctor<NotFunctor<IsNewline>, ParseError, Gff> >());

--- a/include/seqan/gff_io/gff_io_base.h
+++ b/include/seqan/gff_io/gff_io_base.h
@@ -349,9 +349,12 @@ void readRecord(GffRecord & record, CharString & buffer, TFwdIterator & iter)
 {
     IsNewline isNewline;
 
-    clear(record);
+    // skip commented lines
+    while (!atEnd(iter) && value(iter) == '#')
+        skipLine(iter);
 
-    skipUntil(iter, NotFunctor<OrFunctor<EqualsChar<'#'>, IsWhitespace> >());  //skip commments and empty lines
+    clear(record);
+    skipUntil(iter, NotFunctor<IsWhitespace>());  //skip empty linesa
 
     // read column 1: seqid
     readUntil(record.ref, iter, OrFunctor<IsTab, AssertFunctor<NotFunctor<IsNewline>, ParseError, Gff> >());

--- a/tests/gff_io/example_with_comments.gff
+++ b/tests/gff_io/example_with_comments.gff
@@ -1,0 +1,6 @@
+# comment 1
+ctg123	.	mRNA	1300	9000	.	+	.	ID=mrna0001;Name="sonichedgehog;hehe"
+# comment 2
+ctg123	.	exon	1300	1500	.	+	.	ID=exon00001;Parent=mrn a0001;Name
+ctg123	.	exon	1050	1500	.	+	.	ID=exon00002;Name;Parent=mrna0001
+# comment 3

--- a/tests/gff_io/test_gff_io.cpp
+++ b/tests/gff_io/test_gff_io.cpp
@@ -42,11 +42,12 @@
 SEQAN_BEGIN_TESTSUITE(test_gff_io)
 {
     // GFF tests
-	SEQAN_CALL_TEST(test_store_io_read_record_context_gff);
-	SEQAN_CALL_TEST(test_store_io_write_record_context_gff);
+    SEQAN_CALL_TEST(test_store_io_read_record_context_gff);
+    SEQAN_CALL_TEST(test_store_io_write_record_context_gff);
+    SEQAN_CALL_TEST(test_store_io_comment_processing_context_gff);
 
-	// GTF tests
-	SEQAN_CALL_TEST(test_store_io_read_record_context_gtf);
+    // GTF tests
+    SEQAN_CALL_TEST(test_store_io_read_record_context_gtf);
     SEQAN_CALL_TEST(test_store_io_read_record_gtf_pseudogenes);
     SEQAN_CALL_TEST(test_store_io_write_record_context_gtf);
 

--- a/tests/gff_io/test_gff_io.h
+++ b/tests/gff_io/test_gff_io.h
@@ -133,6 +133,66 @@ SEQAN_DEFINE_TEST(test_store_io_write_record_context_gff)
     SEQAN_ASSERT_EQ(goldString, compare);
 }
 
+SEQAN_DEFINE_TEST(test_store_io_comment_processing_context_gff)
+{
+    CharString gffPath = SEQAN_PATH_TO_ROOT();
+
+    // slightly modified version of "example.gff". 3 lines of comments are included.
+    append(gffPath, "/tests/gff_io/example_with_comments.gff");
+
+    String<char, MMap<> > inString;
+    open(inString, toCString(gffPath));
+    Iterator<String<char, MMap<> >, Rooted>::Type iter = begin(inString);
+
+    CharString buffer;
+
+    GffRecord record;
+    readRecord(record, buffer, iter);
+
+    SEQAN_ASSERT_EQ(record.ref, "ctg123");
+    SEQAN_ASSERT_EQ(record.source, "");
+    SEQAN_ASSERT_EQ(record.type, "mRNA");
+    SEQAN_ASSERT_EQ(record.beginPos, 1299u);
+    SEQAN_ASSERT_EQ(record.endPos, 9000u);
+    SEQAN_ASSERT_NEQ(record.score, record.score);
+    SEQAN_ASSERT_EQ(record.strand, '+');
+    SEQAN_ASSERT_EQ(record.phase, '.');
+    SEQAN_ASSERT_EQ(record.tagNames[0], "ID");
+    SEQAN_ASSERT_EQ(record.tagValues[0], "mrna0001");
+    SEQAN_ASSERT_EQ(record.tagNames[1], "Name");
+    SEQAN_ASSERT_EQ(record.tagValues[1], "sonichedgehog;hehe");
+
+    readRecord(record, buffer, iter);
+    SEQAN_ASSERT_EQ(record.ref, "ctg123");
+    SEQAN_ASSERT_EQ(record.source, "");
+    SEQAN_ASSERT_EQ(record.type, "exon");
+    SEQAN_ASSERT_EQ(record.beginPos, 1299u);
+    SEQAN_ASSERT_EQ(record.endPos, 1500u);
+    SEQAN_ASSERT_NEQ(record.score, record.score);
+    SEQAN_ASSERT_EQ(record.strand, '+');
+    SEQAN_ASSERT_EQ(record.phase, '.');
+    SEQAN_ASSERT_EQ(record.tagNames[0], "ID");
+    SEQAN_ASSERT_EQ(record.tagValues[0], "exon00001");
+    SEQAN_ASSERT_EQ(record.tagNames[1], "Parent");
+    SEQAN_ASSERT_EQ(record.tagValues[1], "mrn a0001");
+
+    readRecord(record, buffer, iter);
+    SEQAN_ASSERT_EQ(record.ref, "ctg123");
+    SEQAN_ASSERT_EQ(record.source, "");
+    SEQAN_ASSERT_EQ(record.type, "exon");
+    SEQAN_ASSERT_EQ(record.beginPos, 1049u);
+    SEQAN_ASSERT_EQ(record.endPos, 1500u);
+    SEQAN_ASSERT_NEQ(record.score, record.score);
+    SEQAN_ASSERT_EQ(record.strand, '+');
+    SEQAN_ASSERT_EQ(record.phase, '.');
+    SEQAN_ASSERT_EQ(record.tagNames[0], "ID");
+    SEQAN_ASSERT_EQ(record.tagValues[0], "exon00002");
+    SEQAN_ASSERT_EQ(record.tagNames[1], "Name");
+    SEQAN_ASSERT_EQ(record.tagValues[1], "");
+    SEQAN_ASSERT_EQ(record.tagNames[2], "Parent");
+}
+
+
 // Complex GTF format, from pseudogenes.org
 SEQAN_DEFINE_TEST(test_store_io_read_record_gtf_pseudogenes)
 {

--- a/tests/store/example.gff
+++ b/tests/store/example.gff
@@ -1,3 +1,3 @@
-ctg123	.	mRNA	1300	9000	.	+	.	ID=mrna0001;Name="sonichedgehog;hehe"
+ctg123	.	mRNA	1300	9000	.	+	.	ID=mrna0001;Name="sonichedgehog;hehe";transcript_id=001
 ctg123	.	exon	1300	1500	.	+	.	ID=exon00001;Parent=mrna0001
 ctg123	.	exon	1050	1500	.	+	.	ID=exon00002;Parent=mrna0001

--- a/util/py_lib/seqan/dox/tpl/js/common.js
+++ b/util/py_lib/seqan/dox/tpl/js/common.js
@@ -58,7 +58,7 @@
         // adds a close link to the search/list frame
 		if(window != window.parent && window.name == 'list') {
 			try {
-        		$('<button class="close" style="position: absolute; top: 5px; right: 5px; line-height: .7em;">&times;</button>').prependTo('body').click(function() {
+        		$('<button class="close" style="position: absolute; top: 5px; right: 5px; z-index: 999; line-height: .7em;">&times;</button>').prependTo('body').click(function() {
         			window.parent.location = window.parent['main'].location;
         		});
     		} catch(e) {


### PR DESCRIPTION
Lines start with "#" will be passed.
This fix is related with #898, #948. 