### PR TITLE
BAM index file (.bai) can be saved via _saveIndex()

### DIFF
--- a/include/seqan/bam_io/bam_index_bai.h
+++ b/include/seqan/bam_io/bam_index_bai.h
@@ -529,7 +529,7 @@ open(BamIndex<Bai> & index, char * filename)
 
 inline bool _saveIndex(BamIndex<Bai> const & index, char const * filename)
 {
-    std::cerr << "WRITE INDEX TO " << filename << std::endl;
+    //std::cerr << "WRITE INDEX TO " << filename << std::endl;
     // Open output file.
     std::ofstream out(filename, std::ios::binary | std::ios::out);
 
@@ -570,7 +570,7 @@ inline bool _saveIndex(BamIndex<Bai> const & index, char const * filename)
         }
 
         // Write out linear index.
-        __int32 numIntervals = length(index._linearIndices);
+        __int32 numIntervals = length(linearIndex);
         out.write(reinterpret_cast<char *>(&numIntervals), 4);
         typedef Iterator<String<__uint64> const, Rooted>::Type TLinearIndexIter;
         for (TLinearIndexIter it = begin(linearIndex, Rooted()); !atEnd(it); goNext(it))
@@ -578,7 +578,7 @@ inline bool _saveIndex(BamIndex<Bai> const & index, char const * filename)
     }
 
     // Write the number of unaligned reads if set.
-    std::cerr << "UNALIGNED\t" << index._unalignedCount << std::endl;
+    //std::cerr << "UNALIGNED\t" << index._unalignedCount << std::endl;
     if (index._unalignedCount != maxValue<__uint64>())
         out.write(reinterpret_cast<char const *>(&index._unalignedCount), 8);
 

--- a/tests/bam_io/test_bam_index.h
+++ b/tests/bam_io/test_bam_index.h
@@ -80,4 +80,21 @@ SEQAN_DEFINE_TEST(test_bam_io_bam_index_bai)
     SEQAN_ASSERT_NOT(found);
 }
 
+SEQAN_DEFINE_TEST(test_bam_io_bam_index_write_bai)
+{
+    using namespace seqan;
+
+    CharString baiFilename;
+    append(baiFilename, SEQAN_PATH_TO_ROOT());
+    append(baiFilename, "/tests/bam_io/small.bam.bai");
+    BamIndex<Bai> baiIndex;
+    SEQAN_ASSERT(open(baiIndex, toCString(baiFilename)));
+
+    CharString outPath = SEQAN_TEMP_FILENAME();
+    append(outPath, ".bai");
+    _saveIndex(baiIndex, toCString(outPath));
+
+    SEQAN_ASSERT(_compareBinaryFiles(toCString(outPath), toCString(baiFilename)));
+}
+
 #endif  // TESTS_BAM_IO_TEST_BAM_INDEX_H_

--- a/tests/bam_io/test_bam_io.cpp
+++ b/tests/bam_io/test_bam_io.cpp
@@ -177,6 +177,7 @@ SEQAN_BEGIN_TESTSUITE(test_bam_io)
 
     // Test BAM indices.
     SEQAN_CALL_TEST(test_bam_io_bam_index_bai);
+    SEQAN_CALL_TEST(test_bam_io_bam_index_write_bai);
 #endif
 }
 SEQAN_END_TESTSUITE


### PR DESCRIPTION
This will close #1081 .
However, this is a internal function(with "_") which should not be used directly. 
We must work on "buildIndex" and other functions to support BAM index properly.
