### PR TITLE
Fixes failing splazers test.

### DIFF
--- a/apps/splazers/razers_spliced.h
+++ b/apps/splazers/razers_spliced.h
@@ -775,7 +775,7 @@ extendMatch(TReadSet &readSet, TSize rseqNo, TInf & inf, TMatch &m, TOptions &op
 
     TQueryPrefix queryPrefix = prefix(readSet[rseqNo], beginPositionH(seed));
     TDatabasePrefix databasePrefix = prefix(inf, beginPositionV(seed));
-    extScore = _extendSeedGappedXDropOneDirection(seed, queryPrefix, databasePrefix, EXTEND_LEFT, scoreMatrix, scoreDropOff);
+    extScore = _extendSeedGappedXDropOneDirection(seed, databasePrefix, queryPrefix, EXTEND_LEFT, scoreMatrix, scoreDropOff);
     
 //	m.gBegin = leftDim1(seed) + beginPosition(inf);
 //	m.mScore = rightDim0(seed) - leftDim0(seed) + 1;
@@ -837,7 +837,7 @@ extendMatch(TReadSet &readSet, TSize rseqNo, TInf & inf, TMatch &m, TOptions &op
 
     TQuerySuffix querySuffix = suffix(readSet[rseqNo], endPositionH(seed));
     TDatabaseSuffix databaseSuffix = suffix(inf, endPositionV(seed));
-    extScore = _extendSeedGappedXDropOneDirection(seed, querySuffix, databaseSuffix, EXTEND_RIGHT, scoreMatrix, scoreDropOff);
+    extScore = _extendSeedGappedXDropOneDirection(seed, databaseSuffix, querySuffix, EXTEND_RIGHT, scoreMatrix, scoreDropOff);
 
 
 	//extendSeedScore(seed,extScore,scoreDropOff,scoreMatrix, readSet[rseqNo],inf,1,GappedXDrop());


### PR DESCRIPTION
This fixes the splazerS test when running with the GappedXDrop extension.

The problem here is, that the function ```_extendSeedGappedXDropOneDirection ``` expects the query and data base sequence in opposite order to the seed definition.
So what comes first into the seed comes last into the extension function. :scream: 