### PR TITLE
Fix some issues with the nosetest of the dox engine

### DIFF
--- a/manual/source/StyleGuide/DoxApiDocs.rst
+++ b/manual/source/StyleGuide/DoxApiDocs.rst
@@ -661,7 +661,7 @@ metafunction then use a ``TXyz`` return type in ``@return`` and document
 
 **Signature** ``@return Exception Label``
 
-Add note on a function or macro throwing ane xception.
+Add note on a function or macro throwing an exception.
 
 .. code-block:: cpp
 
@@ -675,6 +675,28 @@ Add note on a function or macro throwing ane xception.
      * @throw std::runtime_error If something goes wrong.
      */
     void myFunction(char const * filename);
+
+@datarace
+^^^^^^^^^
+
+**Signature** ``@datarace Description``
+
+Describe possible data races for functions and macros.
+If this value is not specified it defaults to ``Thread safety unknown!``
+
+.. code-block:: cpp
+
+    /*!
+     * @fn myFunction
+     * @brief Writes things to a file.
+     * @signature void myFunction(char const * filename);
+     *
+     * @param[in] filename File to write to.
+     *
+     * @datarace This function is not thread safe and concurrent writes to the file might invalidate the output.
+     */
+    void myFunction(char const * filename);
+
 
 @section
 ^^^^^^^^

--- a/util/py_lib/seqan/dox/raw_doc.py
+++ b/util/py_lib/seqan/dox/raw_doc.py
@@ -681,7 +681,7 @@ class RawMacro(RawCodeEntry):
     def addThrow(self, t):
         self.throws.append(t)
     
-    def addDataRaces(self, d):
+    def addDataRace(self, d):
         self.dataraces.append(d)
 
     def getType(self):
@@ -1403,7 +1403,7 @@ class RawDataRace(object):
         return 'datarace'
 
     def getFormatted(self, formatter):
-        return formatter.formatCommand('datarace', self.text.text, self.name.text)
+        return formatter.formatCommand('datarace', self.text.text)
 
 
 class RawSignature(object):

--- a/util/py_lib/seqan/dox/test/test_proc_doc.py
+++ b/util/py_lib/seqan/dox/test/test_proc_doc.py
@@ -804,7 +804,7 @@ class TestConvertFunction(TestConverterBase):
                '@tparam    T1      The type of the first template parameter.\n'
                '@return    TReturn The return value.\n'
                '@throw     Excpetion The exception type.\n'
-               '@dataraces This function is thread safe.\n'
+               '@datarace This function is thread safe.\n'
                '\n'
                'This is the first paragraph.\n'
                '@section First <em>heading</em>\n'
@@ -922,7 +922,7 @@ class TestConvertMacro(TestConverterBase):
         self.assertEqual(proc_macro.throws[0].desc.toHtmlLike(), txt)
         # dataraces
         self.assertEqual(len(proc_macro.dataraces), 1)
-        txt = '<div>This function is not thred safe.</div>'
+        txt = '<div>This function is not thread safe.</div>'
         self.assertEqual(proc_macro.dataraces[0].desc.toHtmlLike(), txt)
         # brief
         txt = '<div>This is the <i>very important</i> macro brief.</div>'
@@ -979,7 +979,7 @@ class TestConvertMacro(TestConverterBase):
         self.assertEqual(proc_macro.throws[0].desc.toHtmlLike(), txt)
         # dataraces
         self.assertEqual(len(proc_macro.dataraces), 1)
-        txt = '<div>This function is not thred safe.</div>'
+        txt = '<div>This function is not thread safe.</div>'
         self.assertEqual(proc_macro.dataraces[0].desc.toHtmlLike(), txt)
         # brief
         txt = '<div>This is the <i>very important</i> class brief.</div>'

--- a/util/py_lib/seqan/dox/test/test_raw_doc.py
+++ b/util/py_lib/seqan/dox/test/test_raw_doc.py
@@ -587,16 +587,16 @@ class DataRaceTest(unittest.TestCase):
         self.formatter = raw_doc.DoxFormatter()
 
     def testCreation(self):
-        ret = raw_doc.RawThrow(self.tok, self.txt_text)
-        self.assertEqual(ret.text, self.txt_text)
+        dataRace = raw_doc.RawDataRace(self.tok, self.txt_text)
+        self.assertEqual(dataRace.text, self.txt_text)
 
     def testGetType(self):
-        ret = raw_doc.RawThrow(self.tok, self.txt_text)
-        self.assertEqual(ret.getType(), 'datarace')
+        dataRace = raw_doc.RawDataRace(self.tok, self.txt_text)
+        self.assertEqual(dataRace.getType(), 'datarace')
 
     def testGetFormatted(self):
-        ret = raw_doc.RawThrow(self.tok, self.txt_text)
-        self.assertEqual(ret.getFormatted(self.formatter), '@throw text\n')
+        dataRace = raw_doc.RawDataRace(self.tok, self.txt_text)
+        self.assertEqual(dataRace.getFormatted(self.formatter), '@datarace text\n')
 
 
 class SignatureTest(unittest.TestCase):


### PR DESCRIPTION
Tests for the seqan.dox engine are disabled and failed in nightlies. 
This fixes the nose tests.