### PR TITLE
[FIX] records size was not checked. If buffers was big enough, but re…

### DIFF
--- a/include/seqan/bam_io/bam_file.h
+++ b/include/seqan/bam_io/bam_file.h
@@ -247,9 +247,9 @@ inline SEQAN_FUNC_ENABLE_IF(And<IsSameType<typename Value<TRecords>::Type, BamAl
 readRecords(TRecords & records, FormattedFile<Bam, Input, TSpec> & file, TSize maxRecords)
 {
     String<CharString> & buffers = context(file).buffers;
-    if ((TSize)length(buffers) < maxRecords)
+    if (static_cast<TSize>(length(buffers)) < maxRecords)
         resize(buffers, maxRecords, Exact());
-    if ((TSize)length(records) < maxRecords)
+    if (static_cast<TSize>(length(records)) < maxRecords)
         resize(records, maxRecords, Exact());
 
 

--- a/include/seqan/bam_io/bam_file.h
+++ b/include/seqan/bam_io/bam_file.h
@@ -248,10 +248,10 @@ readRecords(TRecords & records, FormattedFile<Bam, Input, TSpec> & file, TSize m
 {
     String<CharString> & buffers = context(file).buffers;
     if ((TSize)length(buffers) < maxRecords)
-    {
         resize(buffers, maxRecords, Exact());
+    if ((TSize)length(records) < maxRecords)
         resize(records, maxRecords, Exact());
-    }
+
 
     TSize numRecords = 0;
     for (; numRecords < maxRecords && !atEnd(file.iter); ++numRecords)


### PR DESCRIPTION
…cords not, then there was an index out of range

(cherry picked from commit 37cbf3c8d37b1232f76fb51003db3bc30c0c4b5b)