### PR TITLE
argument parser updates

### DIFF
--- a/include/seqan/arg_parse/arg_parse_ctd_support.h
+++ b/include/seqan/arg_parse/arg_parse_ctd_support.h
@@ -339,6 +339,11 @@ writeCTD(ArgumentParser const & me, std::ostream & ctdfile)
          ++optionMapIterator)
     {
         ArgParseOption const & opt = *optionMapIterator;
+
+        // exclude hidden
+        if (isHidden(opt))
+            continue;
+
         std::string optionIdentifier = _getPrefixedOptionName(opt);
         std::string refName = toolname + "." + _getOptionName(opt);
 
@@ -377,6 +382,10 @@ writeCTD(ArgumentParser const & me, std::ostream & ctdfile)
 
         // exclude help, version, etc.
         if (!_includeInCTD(opt))
+            continue;
+
+        // exclude hidden
+        if (isHidden(opt))
             continue;
 
         // prefer short name for options
@@ -425,7 +434,7 @@ writeCTD(ArgumentParser const & me, std::ostream & ctdfile)
             ctdfile << "supported_formats=\"" << xmlEscape(_join(supported_formats, ",")) << "\" ";
 
         ctdfile << "required=\"" << (isRequired(opt) ? "true" : "false") << "\" ";
-        ctdfile << "advanced=\"" << (isHidden(opt) ? "true" : "false") << "\" ";
+        ctdfile << "advanced=\"" << (isAdvanced(opt) ? "true" : "false") << "\" ";
 
         // Write out tags attribute.
         if (!opt.tags.empty())

--- a/include/seqan/arg_parse/arg_parse_doc.h
+++ b/include/seqan/arg_parse/arg_parse_doc.h
@@ -595,7 +595,11 @@ inline void printShortHelp(ArgumentParser const & me)
 inline void printVersion(ArgumentParser const & me, std::ostream & stream)
 {
     stream << getAppName(me) << " version: " << getVersion(me) << std::endl;
-    stream << "SeqAn version: " << std::string(SEQAN_VERSION_STRING) << std::endl;
+    stream << "SeqAn version: " << SEQAN_VERSION_MAJOR << '.' <<  SEQAN_VERSION_MINOR << '.'
+           << SEQAN_VERSION_PATCH;
+    if (SEQAN_VERSION_PRE_RELEASE != 0)
+        stream << "-pre" << SEQAN_VERSION_PRE_RELEASE;
+    stream << "\n";
 }
 
 inline void printVersion(ArgumentParser const & me)

--- a/include/seqan/arg_parse/arg_parse_doc.h
+++ b/include/seqan/arg_parse/arg_parse_doc.h
@@ -619,13 +619,13 @@ inline void printVersion(ArgumentParser const & me)
 
 inline void printLongCopyright(ArgumentParser const & me, std::ostream & stream)
 {
-    stream << "Copyright information for " << getAppName(me) << ":" << std::endl;
-    stream << "=============================================================================" << std::endl;
-    stream << me._toolDoc._longCopyright << std::endl;
     stream << "=============================================================================" << std::endl
-           << "" << std::endl
+           << "Copyright information for " << getAppName(me) << ":" << std::endl
+           << "-----------------------------------------------------------------------------" << std::endl
+           << me._toolDoc._longCopyright << std::endl << std::endl
+           << "=============================================================================" << std::endl
            << "This program contains SeqAn code licensed under the following terms:" << std::endl
-           << "" << std::endl
+           << "-----------------------------------------------------------------------------" << std::endl
            << " Copyright (c) 2006-2015, Knut Reinert, FU Berlin" << std::endl
            << " All rights reserved." << std::endl
            << "" << std::endl

--- a/include/seqan/arg_parse/arg_parse_doc.h
+++ b/include/seqan/arg_parse/arg_parse_doc.h
@@ -583,16 +583,20 @@ inline void _addValidValuesRestrictions(std::string & text, ArgParseOption const
 
 /*!
  * @fn ArgumentParser#printHelp
- * @brief Prints the complete help message for the parser.
+ * @brief Prints the help message for the parser.
  *
- * @signature void printHelp(parser, out, format);
+ * @signature void printHelp(parser, out, format, showAdvancedOptions);
  *
- * @param[in,out] parser The ArgumentParser print the help for.
- * @param[out]    out    The output stream to print to (<tt>std::ostream</tt>).
- * @param[in]     format The format to print, one of "html", "man", and "txt".
+ * @param[in,out] parser                The ArgumentParser print the help for.
+ * @param[out]    out                   The output stream to print to (<tt>std::ostream</tt>).
+ * @param[in]     format                The format to print, one of "html", "man", and "txt".
+ * @param[in]     showAdvancedOptions   Also show advanced options to user (default = false).
  */
 
-inline void printHelp(ArgumentParser const & me, std::ostream & stream, CharString const & format)
+inline void printHelp(ArgumentParser const & me,
+                      std::ostream & stream,
+                      CharString const & format,
+                      bool const showAdvancedOptions)
 {
     ToolDoc toolDoc(me._toolDoc);
     clearEntries(toolDoc);  // We will append me._toolDoc later.
@@ -619,8 +623,9 @@ inline void printHelp(ArgumentParser const & me, std::ostream & stream, CharStri
             std::string title = opt._helpText;
             append(title, ":");
             addSubSection(toolDoc, title);
+            //TODO(h-2): don't add empty sections
         }
-        else if (!isHidden(opt))
+        else if (!isHidden(opt) && (!isAdvanced(opt) || showAdvancedOptions))
         {
             // Build list item term.
             std::string term;
@@ -678,14 +683,19 @@ inline void printHelp(ArgumentParser const & me, std::ostream & stream, CharStri
     print(stream, toolDoc, format);
 }
 
+inline void printHelp(ArgumentParser const & me, std::ostream & stream, CharString const & format)
+{
+    printHelp(me, stream, format, false);
+}
+
 inline void printHelp(ArgumentParser const & me, std::ostream & stream)
 {
-    printHelp(me, stream, "txt");
+    printHelp(me, stream, "txt", false);
 }
 
 inline void printHelp(ArgumentParser const & me)
 {
-    printHelp(me, std::cerr, "txt");
+    printHelp(me, std::cerr, "txt", false);
 }
 
 }  // namespace seqan

--- a/include/seqan/arg_parse/arg_parse_doc.h
+++ b/include/seqan/arg_parse/arg_parse_doc.h
@@ -289,6 +289,126 @@ inline CharString const & getVersion(ArgumentParser const & me)
     return getVersion(me._toolDoc);
 }
 
+// ----------------------------------------------------------------------------
+// Function setShortCopyright()
+// ----------------------------------------------------------------------------
+
+/*!
+ * @fn ArgumentParser#setShortCopyright
+ * @brief Sets short copyright of ArgumentParser.
+ *
+ * @signature void setShortCopyright(parser, short copyright);
+ *
+ * @param[in,out] parser  The ArgumentParser to set the short copyright of.
+ * @param[in]     short copyright The short copyright string to set, <tt>std::string</tt>.
+ */
+
+inline void setShortCopyright(ArgumentParser & me, CharString const & shortCopyrightString)
+{
+    setShortCopyright(me._toolDoc, shortCopyrightString);
+}
+
+// --------------------------------------------------------------------------
+// Function getShortCopyright()
+// --------------------------------------------------------------------------
+
+/*!
+ * @fn ArgumentParser#getShortCopyright
+ * @brief Returns the short copyright string.
+ *
+ * @signature TCharStringRef getShortCopyright(parser);
+ *
+ * @param[in,out] parser The ArgumentParser to get the short copyright string from.
+ *
+ * @return TCharString A const-ref to a @link CharString @endlink with the short copyright string.
+ */
+
+inline CharString const & getShortCopyright(ArgumentParser const & me)
+{
+    return getShortCopyright(me._toolDoc);
+}
+
+// ----------------------------------------------------------------------------
+// Function setLongCopyright()
+// ----------------------------------------------------------------------------
+
+/*!
+ * @fn ArgumentParser#setLongCopyright
+ * @brief Sets long copyright of ArgumentParser.
+ *
+ * @signature void setLongCopyright(parser, long copyright);
+ *
+ * @param[in,out] parser  The ArgumentParser to set the long copyright of.
+ * @param[in]     long copyright The long copyright string to set, <tt>std::string</tt>.
+ */
+
+inline void setLongCopyright(ArgumentParser & me, CharString const & longCopyrightString)
+{
+    setLongCopyright(me._toolDoc, longCopyrightString);
+    if (!hasOption(me, "copyright"))
+        addOption(me, ArgParseOption("", "copyright", "Display long copyright information."));
+}
+
+// --------------------------------------------------------------------------
+// Function getLongCopyright()
+// --------------------------------------------------------------------------
+
+/*!
+ * @fn ArgumentParser#getLongCopyright
+ * @brief Returns the long copyright string.
+ *
+ * @signature TCharStringRef getLongCopyright(parser);
+ *
+ * @param[in,out] parser The ArgumentParser to get the long copyright string from.
+ *
+ * @return TCharString A const-ref to a @link CharString @endlink with the long copyright string.
+ */
+
+inline CharString const & getLongCopyright(ArgumentParser const & me)
+{
+    return getLongCopyright(me._toolDoc);
+}
+
+
+// ----------------------------------------------------------------------------
+// Function setCitation()
+// ----------------------------------------------------------------------------
+
+/*!
+ * @fn ArgumentParser#setCitation
+ * @brief Sets citation of ArgumentParser.
+ *
+ * @signature void setCitation(parser, citation);
+ *
+ * @param[in,out] parser  The ArgumentParser to set the citation of.
+ * @param[in]     citation The citation string to set, <tt>std::string</tt>.
+ */
+
+inline void setCitation(ArgumentParser & me, CharString const & citationString)
+{
+    setCitation(me._toolDoc, citationString);
+}
+
+// --------------------------------------------------------------------------
+// Function getCitation()
+// --------------------------------------------------------------------------
+
+/*!
+ * @fn ArgumentParser#getCitation
+ * @brief Returns the citation string.
+ *
+ * @signature TCharStringRef getCitation(parser);
+ *
+ * @param[in,out] parser The ArgumentParser to get the citation string from.
+ *
+ * @return TCharString A const-ref to a @link CharString @endlink with the citation string.
+ */
+
+inline CharString const & getCitation(ArgumentParser const & me)
+{
+    return getCitation(me._toolDoc);
+}
+
 // --------------------------------------------------------------------------
 // Function setCategory()
 // --------------------------------------------------------------------------
@@ -474,7 +594,8 @@ inline void printShortHelp(ArgumentParser const & me)
 
 inline void printVersion(ArgumentParser const & me, std::ostream & stream)
 {
-    stream << getAppName(me) << " version " << getVersion(me) << std::endl;
+    stream << getAppName(me) << " version: " << getVersion(me) << std::endl;
+    stream << "SeqAn version: " << std::string(SEQAN_VERSION_STRING) << std::endl;
 }
 
 inline void printVersion(ArgumentParser const & me)
@@ -483,9 +604,64 @@ inline void printVersion(ArgumentParser const & me)
 }
 
 // ----------------------------------------------------------------------------
-// Function _addNumericalRestriction()
+// Function printLongCopyright()
 // ----------------------------------------------------------------------------
 
+/*!
+ * @fn ArgumentParser#printLongCopyright
+ * @brief Prints the long copyright information of the parser to a stream.
+ *
+ * @signature void printLongCopyright(parser, stream);
+ *
+ * @param[in,out] parser The ArgumenParser to print for.
+ * @param[in,out] stream The <tt>std::ostream</tt> to print to.
+ */
+
+inline void printLongCopyright(ArgumentParser const & me, std::ostream & stream)
+{
+    stream << "Copyright information for " << getAppName(me) << ":" << std::endl;
+    stream << "=============================================================================" << std::endl;
+    stream << me._toolDoc._longCopyright << std::endl;
+    stream << "=============================================================================" << std::endl
+           << "" << std::endl
+           << "This program contains SeqAn code licensed under the following terms:" << std::endl
+           << "" << std::endl
+           << " Copyright (c) 2006-2015, Knut Reinert, FU Berlin" << std::endl
+           << " All rights reserved." << std::endl
+           << "" << std::endl
+           << " Redistribution and use in source and binary forms, with or without" << std::endl
+           << " modification, are permitted provided that the following conditions are met:" << std::endl
+           << "" << std::endl
+           << "     * Redistributions of source code must retain the above copyright" << std::endl
+           << "       notice, this list of conditions and the following disclaimer." << std::endl
+           << "     * Redistributions in binary form must reproduce the above copyright" << std::endl
+           << "       notice, this list of conditions and the following disclaimer in the" << std::endl
+           << "       documentation and/or other materials provided with the distribution." << std::endl
+           << "     * Neither the name of Knut Reinert or the FU Berlin nor the names of" << std::endl
+           << "       its contributors may be used to endorse or promote products derived" << std::endl
+           << "       from this software without specific prior written permission." << std::endl
+           << "" << std::endl
+           << " THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\"" << std::endl
+           << " AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE" << std::endl
+           << " IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE" << std::endl
+           << " ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE" << std::endl
+           << " FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL" << std::endl
+           << " DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR" << std::endl
+           << " SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER" << std::endl
+           << " CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT" << std::endl
+           << " LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY" << std::endl
+           << " OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH" << std::endl
+           << " DAMAGE." << std::endl;
+}
+
+inline void printLongCopyright(ArgumentParser const & me)
+{
+    printLongCopyright(me, std::cerr);
+}
+
+// ----------------------------------------------------------------------------
+// Function _addNumericalRestriction()
+// ----------------------------------------------------------------------------
 
 inline void _addNumericalRestriction(std::string & text, ArgParseOption const & opt)
 {
@@ -620,10 +796,20 @@ inline void printHelp(ArgumentParser const & me,
                 continue;  // Skip empty lines.
 
             // Is command line parser section, maps to ToolDoc subsection.
-            std::string title = opt._helpText;
-            append(title, ":");
-            addSubSection(toolDoc, title);
-            //TODO(h-2): don't add empty sections
+            for (unsigned j = i + 1; j < length(me.optionMap); ++j)
+            {
+                ArgParseOption const & nextopt = me.optionMap[j];
+                if (empty(nextopt.shortName) && empty(nextopt.longName))
+                    break;
+                // has visible children
+                if (!isHidden(nextopt) && (!isAdvanced(nextopt) || showAdvancedOptions))
+                {
+                    std::string title = opt._helpText;
+                    append(title, ":");
+                    addSubSection(toolDoc, title);
+                    break;
+                }
+            }
         }
         else if (!isHidden(opt) && (!isAdvanced(opt) || showAdvancedOptions))
         {

--- a/include/seqan/arg_parse/arg_parse_option.h
+++ b/include/seqan/arg_parse/arg_parse_option.h
@@ -108,6 +108,8 @@ public:
     bool                _isRequired;  // true if this ArgParseOption must be set
     bool                _isHidden;    // true if this ArgParseOption should not be
                                       // shown on the command line
+    bool                _isAdvanced;  // true if this ArgParseOption should only
+                                      // be shown in the full help
 
     // ----------------------------------------------------------------------------
     // Constructors
@@ -124,7 +126,8 @@ public:
         longName(_longName),
         _isFlag(false),
         _isRequired(false),
-        _isHidden(false)
+        _isHidden(false),
+        _isAdvanced(false)
     {
         _helpText = _help;
     }
@@ -137,7 +140,8 @@ public:
         longName(_longName),
         _isFlag(true),
         _isRequired(false),
-        _isHidden(false)
+        _isHidden(false),
+        _isAdvanced(false)
     {
         defaultValue.push_back("false");
         setValidValues(*this, "true false");
@@ -219,6 +223,49 @@ inline bool isHidden(ArgParseOption const & me)
 inline void hideOption(ArgParseOption & me, bool hide = true)
 {
     me._isHidden = hide;
+}
+
+// ----------------------------------------------------------------------------
+// Function isHidden()
+// ----------------------------------------------------------------------------
+
+/*!
+ * @fn ArgParseOption#isAdvanced
+ * @headerfile <seqan/arg_parse.h>
+ * @brief Return whether an option is only shown in the full help screen.
+ *
+ * @signature bool isAdvanced(option);
+ *
+ * @param[in] option The ArgParseOption object to query.
+ *
+ * @return bool <tt>true</tt> if it is hidden, <tt>false</tt> otherwise.
+ *
+ * By default, options are not marked as advanced.
+ */
+
+inline bool isAdvanced(ArgParseOption const & me)
+{
+    return me._isAdvanced;
+}
+
+// ----------------------------------------------------------------------------
+// Function hideOption()
+// ----------------------------------------------------------------------------
+
+/*!
+ * @fn ArgParseOption#setAdvanced
+ * @headerfile <seqan/arg_parse.h>
+ * @brief Shows the ArgParseOption only on the full help screen.
+ *
+ * @signature void setAdvanced(option[, advanced]);
+ *
+ * @param[in,out] option The ArgParseOption object to set the advanced flag of.
+ * @param[in]     advanced   <tt>bool</tt> that indicates whether to hide the flag (default: <tt>true</tt>)
+ */
+
+inline void setAdvanced(ArgParseOption & me, bool advanced = true)
+{
+    me._isAdvanced = advanced;
 }
 
 // ----------------------------------------------------------------------------

--- a/include/seqan/arg_parse/arg_parse_parse.h
+++ b/include/seqan/arg_parse/arg_parse_parse.h
@@ -313,6 +313,11 @@ ArgumentParser::ParseResult parse(ArgumentParser & me,
         printVersion(me, outputStream);
         return ArgumentParser::PARSE_VERSION;
     }
+    else if (hasOption(me, "copyright") && isSet(me, "copyright"))
+    {
+        printLongCopyright(me, outputStream);
+        return ArgumentParser::PARSE_COPYRIGHT;
+    }
     else if (hasOption(me, "write-ctd") && isSet(me, "write-ctd"))
     {
         if (writeCTD(me))

--- a/include/seqan/arg_parse/arg_parse_parse.h
+++ b/include/seqan/arg_parse/arg_parse_parse.h
@@ -339,7 +339,7 @@ ArgumentParser::ParseResult parse(ArgumentParser & me,
     {
         std::string format;
         getOptionValue(format, me, "export-help");
-        printHelp(me, outputStream, format);
+        printHelp(me, outputStream, format, true);
         return ArgumentParser::PARSE_EXPORT_HELP;
     }
     else if (argc == 1 && !(_allRequiredSet(me) && _allArgumentsSet(me)))

--- a/include/seqan/arg_parse/arg_parse_parse.h
+++ b/include/seqan/arg_parse/arg_parse_parse.h
@@ -325,6 +325,11 @@ ArgumentParser::ParseResult parse(ArgumentParser & me,
         printHelp(me, outputStream);
         return ArgumentParser::PARSE_HELP;
     }
+    else if (isSet(me, "full-help"))
+    {
+        printHelp(me, outputStream, "txt", true);
+        return ArgumentParser::PARSE_HELP;
+    }
     else if (isSet(me, "export-help"))
     {
         std::string format;

--- a/include/seqan/arg_parse/argument_parser.h
+++ b/include/seqan/arg_parse/argument_parser.h
@@ -130,10 +130,13 @@ inline ArgParseArgument & getArgument(ArgumentParser & me, unsigned position);
  * @brief There were errors parsing the arguments.
  *
  * @val ArgumentParser::ParseResult ArgumentParser::PARSE_HELP;
- * @brief Parsing was successful, built-in <tt>--help</tt> option was used.
+ * @brief Parsing was successful, built-in <tt>--help</tt> or <tt>--full-help</tt> option was used.
  *
  * @val ArgumentParser::ParseResult ArgumentParser::PARSE_VERSION;
  * @brief Parsing was successful, built-in <tt>--version</tt> option was used.
+ *
+ * @val ArgumentParser::ParseResult ArgumentParser::PARSE_COPYRIGHT;
+ * @brief Parsing was successful, built-in <tt>--copyright</tt> option was used.
  *
  * @val ArgumentParser::ParseResult ArgumentParser::PARSE_WRITE_CTD;
  * @brief Parsing was successful, built-in <tt>--write-ctd</tt> option was used.
@@ -157,6 +160,7 @@ public:
         PARSE_ERROR,
         PARSE_HELP,
         PARSE_VERSION,
+        PARSE_COPYRIGHT,
         PARSE_WRITE_CTD,
         PARSE_EXPORT_HELP
     };
@@ -199,7 +203,9 @@ public:
 
     void init()
     {
-        addOption(*this, ArgParseOption("h", "help", "Displays this help message."));
+        addOption(*this, ArgParseOption("h", "help", "Display a help message."));
+        addOption(*this, ArgParseOption("hh", "full-help", "Display a help message with advanced options."));
+        hideOption(*this, "full-help", true); // hidden by default
 
         // hidden flags used for export of man pages and ctd formats
         addOption(*this, ArgParseOption("",
@@ -491,6 +497,31 @@ inline void hideOption(ArgumentParser & me, std::string const & name, bool hide)
 {
     SEQAN_CHECK(hasOption(me, name), "Unknown option: %s", toCString(name));
     hideOption(getOption(me, name), hide);
+}
+
+// ----------------------------------------------------------------------------
+// Function setAdvanced()
+// ----------------------------------------------------------------------------
+
+/*!
+ * @fn ArgumentParser#setAdvanced
+ * @headerfile <seqan/arg_parse.h>
+ * @brief Sets whether or not the option with the givne name is advanced.
+ *
+ * @signature void setAdvanced(parser, name[, required]).
+ *
+ * @param[in,out] parser   The ArgumentParser to set the flag of.
+ * @param[in]     name     The short or long name of the option (<tt>std::string</tt>).
+ * @param[in]     required Whether or not the option is required (<tt>bool</tt>, default to <tt>true</tt>).
+ */
+
+inline void setAdvanced(ArgumentParser & me, std::string const & name, bool advanced = true)
+{
+    SEQAN_CHECK(hasOption(me, name), "Unknown option: %s", toCString(name));
+    setAdvanced(getOption(me, name), advanced);
+    // make sure the full-help options is visible so advanced options can be shown
+    if (advanced)
+        hideOption(me, "full-help", false);
 }
 
 // ----------------------------------------------------------------------------

--- a/include/seqan/arg_parse/argument_parser.h
+++ b/include/seqan/arg_parse/argument_parser.h
@@ -203,8 +203,8 @@ public:
 
     void init()
     {
-        addOption(*this, ArgParseOption("h", "help", "Display a help message."));
-        addOption(*this, ArgParseOption("hh", "full-help", "Display a help message with advanced options."));
+        addOption(*this, ArgParseOption("h", "help", "Display the help message."));
+        addOption(*this, ArgParseOption("hh", "full-help", "Display the help message with advanced options."));
         hideOption(*this, "full-help", true); // hidden by default
 
         // hidden flags used for export of man pages and ctd formats

--- a/include/seqan/arg_parse/tool_doc.h
+++ b/include/seqan/arg_parse/tool_doc.h
@@ -39,6 +39,7 @@
 
 #include <seqan/misc/terminal.h>
 #include <seqan/arg_parse/xml_support.h>
+#include <seqan/version.h>
 
 namespace seqan {
 
@@ -1412,7 +1413,11 @@ void TextToolDocPrinter_::print(std::ostream & stream, ToolDoc const & doc)
     std::fill_n(out, _layout.leftPadding, ' ');
     stream << "Last update: " << doc._date << "\n";
     std::fill_n(out, _layout.leftPadding, ' ');
-    stream << "SeqAn version: " << std::string(SEQAN_VERSION_STRING) << "\n";
+    stream << "SeqAn version: " << SEQAN_VERSION_MAJOR << '.' <<  SEQAN_VERSION_MINOR << '.'
+           << SEQAN_VERSION_PATCH;
+    if (SEQAN_VERSION_PRE_RELEASE != 0)
+        stream << "-pre" << SEQAN_VERSION_PRE_RELEASE;
+    stream << "\n";
 
     // Print legal stuff
     if ((!empty(doc._shortCopyright)) || (!empty(doc._longCopyright)) || (!empty(doc._citation)))

--- a/include/seqan/arg_parse/tool_doc.h
+++ b/include/seqan/arg_parse/tool_doc.h
@@ -1334,10 +1334,33 @@ void HtmlToolDocPrinter_::print(std::ostream & stream, ToolDoc const & doc)
 
     // Print version and date.
     stream << "<h2>Version</h2>\n"
-           << "<p>Last update: " << _toHtml(doc._date) << ", " << doc._name
-           << " version: " << doc._version << "</p>\n";
+           << "<strong>Last update:</strong> " << _toHtml(doc._date) << "<br>\n<strong>"
+           << doc._name << " version:</strong> " << doc._version << "<br>\n"
+           << "<strong>SeqAn version:</strong> " << SEQAN_VERSION_MAJOR << '.' <<  SEQAN_VERSION_MINOR << '.'
+           << SEQAN_VERSION_PATCH;
+    if (SEQAN_VERSION_PRE_RELEASE != 0)
+        stream << "-pre" << SEQAN_VERSION_PRE_RELEASE;
+    stream << "<br>\n";
 
-    //TODO(h-2): add legal
+    // Print legal stuff
+    if ((!empty(doc._shortCopyright)) || (!empty(doc._longCopyright)) || (!empty(doc._citation)))
+    {
+        stream << "<h2>Legal</h2>\n<strong>";
+
+        if (!empty(doc._shortCopyright))
+            stream << doc._name << " Copyright: </strong>"
+                   << doc._shortCopyright << "<br>\n<strong>";
+
+        stream << "SeqAn Copyright:</strong> 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.<br>\n<strong>";
+
+        if (!empty(doc._citation))
+            stream << "In your academic works please cite:</strong> " << doc._citation << "<br>\n";
+        else
+            stream << "</strong>";
+
+        if (!empty(doc._longCopyright))
+            stream << "For full copyright and/or warranty information see <tt>--copyright</tt>.\n";
+    }
 
     // Print HTML boilerplate footer.
     stream << "</body></html>";
@@ -1409,9 +1432,9 @@ void TextToolDocPrinter_::print(std::ostream & stream, ToolDoc const & doc)
     // Print version and date.
     stream << "\n" << _toText("\\fB") << "VERSION" << _toText("\\fP") << "\n";
     std::fill_n(out, _layout.leftPadding, ' ');
-    stream << doc._name << " version: " << doc._version << "\n";
-    std::fill_n(out, _layout.leftPadding, ' ');
     stream << "Last update: " << doc._date << "\n";
+    std::fill_n(out, _layout.leftPadding, ' ');
+    stream << doc._name << " version: " << doc._version << "\n";
     std::fill_n(out, _layout.leftPadding, ' ');
     stream << "SeqAn version: " << SEQAN_VERSION_MAJOR << '.' <<  SEQAN_VERSION_MINOR << '.'
            << SEQAN_VERSION_PATCH;
@@ -1513,7 +1536,23 @@ void ManToolDocPrinter_::print(std::ostream & stream, ToolDoc const & doc)
         break;
         }
     }
-    //TODO(h-2): add legal... version missing too?
+
+    // Print legal stuff
+    if ((!empty(doc._shortCopyright)) || (!empty(doc._longCopyright)) || (!empty(doc._citation)))
+    {
+        stream << ".SH LEGAL\n";
+
+        if (!empty(doc._shortCopyright))
+            stream << "\\fB" << doc._name << " Copyright:\\fR " << doc._shortCopyright << "\n.br\n";
+
+        stream << "\\fBSeqAn Copyright:\\fR 2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.\n.br\n";
+
+        if (!empty(doc._citation))
+            stream << "\\fBIn your academic works please cite:\\fR " << doc._citation << "\n.br\n";
+
+        if (!empty(doc._longCopyright))
+            stream << "For full copyright and/or warranty information see \\fB--copyright\\fR.\n";
+    }
 }
 
 }  // namespace seqan

--- a/include/seqan/arg_parse/tool_doc.h
+++ b/include/seqan/arg_parse/tool_doc.h
@@ -633,6 +633,9 @@ public:
     CharString _shortDescription;
     CharString _date;
     CharString _version;
+    CharString _shortCopyright;
+    CharString _longCopyright;
+    CharString _citation;
     CharString _manTitle;
     CharString _category;
     unsigned _manSection;
@@ -646,7 +649,8 @@ public:
 
     ToolDoc(ToolDoc const & toolDoc) :
         _name(toolDoc._name), _shortDescription(toolDoc._shortDescription),
-        _date(toolDoc._date), _version(toolDoc._version), _manTitle(toolDoc._manTitle),
+        _date(toolDoc._date), _version(toolDoc._version), _shortCopyright(toolDoc._shortCopyright),
+        _longCopyright(toolDoc._longCopyright), _citation(toolDoc._citation), _manTitle(toolDoc._manTitle),
         _category(toolDoc._category), _manSection(1)
     {
         append(*this, toolDoc);
@@ -918,7 +922,7 @@ inline CharString const & getDate(ToolDoc const & doc)
  * @headerfile <seqan/arg_parse.h>
  * @brief Set the tool version string.
  *
- * @signature void setName(toolDoc, str);
+ * @signature void setVersion(toolDoc, str);
  *
  * @param[in,out] toolDoc The ToolDoc object to the set the version string for.
  * @param[in]     str     The version string of the tool (@link CharString @endlink).
@@ -949,6 +953,130 @@ inline CharString const & getVersion(ToolDoc const & doc)
 {
     return doc._version;
 }
+
+// --------------------------------------------------------------------------
+// Function setShortCopyright()                                              ToolDoc
+// --------------------------------------------------------------------------
+
+/*!
+ * @fn ToolDoc#setShortCopyright
+ * @headerfile <seqan/arg_parse.h>
+ * @brief Set the tool short copyright string.
+ *
+ * @signature void setShortCopyright(toolDoc, str);
+ *
+ * @param[in,out] toolDoc The ToolDoc object to the set the short copyright string for.
+ * @param[in]     str     The short copyright string of the tool (@link CharString @endlink).
+ */
+
+inline void setShortCopyright(ToolDoc & doc, CharString const & shortCopyright)
+{
+    doc._shortCopyright = shortCopyright;
+}
+
+// --------------------------------------------------------------------------
+// Function getShortCopyright()                                              ToolDoc
+// --------------------------------------------------------------------------
+
+/*!
+ * @fn ToolDoc#getShortCopyright
+ * @headerfile <seqan/arg_parse.h>
+ * @brief Get the tool short copyright string.
+ *
+ * @signature CharString getShortCopyright(toolDoc);
+ *
+ * @param[in] toolDoc The ToolDoc object to the get the short copyright string.
+ *
+ * @return CharString Resulting short copyright string (@link CharString @endlink).
+ */
+
+inline CharString const & getShortCopyright(ToolDoc const & doc)
+{
+    return doc._shortCopyright;
+}
+
+// --------------------------------------------------------------------------
+// Function setLongCopyright()                                              ToolDoc
+// --------------------------------------------------------------------------
+
+/*!
+ * @fn ToolDoc#setLongCopyright
+ * @headerfile <seqan/arg_parse.h>
+ * @brief Set the tool long copyright string.
+ *
+ * @signature void setLongCopyright(toolDoc, str);
+ *
+ * @param[in,out] toolDoc The ToolDoc object to the set the long copyright string for.
+ * @param[in]     str     The long copyright string of the tool (@link CharString @endlink).
+ */
+
+inline void setLongCopyright(ToolDoc & doc, CharString const & longCopyright)
+{
+    doc._longCopyright = longCopyright;
+}
+
+// --------------------------------------------------------------------------
+// Function getLongCopyright()                                              ToolDoc
+// --------------------------------------------------------------------------
+
+/*!
+ * @fn ToolDoc#getLongCopyright
+ * @headerfile <seqan/arg_parse.h>
+ * @brief Get the tool long copyright string.
+ *
+ * @signature CharString getLongCopyright(toolDoc);
+ *
+ * @param[in] toolDoc The ToolDoc object to the get the long copyright string.
+ *
+ * @return CharString Resulting long copyright string (@link CharString @endlink).
+ */
+
+inline CharString const & getLongCopyright(ToolDoc const & doc)
+{
+    return doc._longCopyright;
+}
+
+// --------------------------------------------------------------------------
+// Function setCitation()                                              ToolDoc
+// --------------------------------------------------------------------------
+
+/*!
+ * @fn ToolDoc#setCitation
+ * @headerfile <seqan/arg_parse.h>
+ * @brief Set the tool citation string.
+ *
+ * @signature void setCitation(toolDoc, str);
+ *
+ * @param[in,out] toolDoc The ToolDoc object to the set the citation string for.
+ * @param[in]     str     The citation string of the tool (@link CharString @endlink).
+ */
+
+inline void setCitation(ToolDoc & doc, CharString const & citation)
+{
+    doc._citation = citation;
+}
+
+// --------------------------------------------------------------------------
+// Function getCitation()                                              ToolDoc
+// --------------------------------------------------------------------------
+
+/*!
+ * @fn ToolDoc#getCitation
+ * @headerfile <seqan/arg_parse.h>
+ * @brief Get the tool citation string.
+ *
+ * @signature CharString getCitation(toolDoc);
+ *
+ * @param[in] toolDoc The ToolDoc object to the get the citation string.
+ *
+ * @return CharString Resulting citation string (@link CharString @endlink).
+ */
+
+inline CharString const & getCitation(ToolDoc const & doc)
+{
+    return doc._citation;
+}
+
 
 // --------------------------------------------------------------------------
 // Function setManTitle()                                             ToolDoc
@@ -1208,6 +1336,8 @@ void HtmlToolDocPrinter_::print(std::ostream & stream, ToolDoc const & doc)
            << "<p>Last update: " << _toHtml(doc._date) << ", " << doc._name
            << " version: " << doc._version << "</p>\n";
 
+    //TODO(h-2): add legal
+
     // Print HTML boilerplate footer.
     stream << "</body></html>";
 }
@@ -1280,7 +1410,37 @@ void TextToolDocPrinter_::print(std::ostream & stream, ToolDoc const & doc)
     std::fill_n(out, _layout.leftPadding, ' ');
     stream << doc._name << " version: " << doc._version << "\n";
     std::fill_n(out, _layout.leftPadding, ' ');
-    stream << "Last update " << doc._date << "\n";
+    stream << "Last update: " << doc._date << "\n";
+    std::fill_n(out, _layout.leftPadding, ' ');
+    stream << "SeqAn version: " << std::string(SEQAN_VERSION_STRING) << "\n";
+
+    // Print legal stuff
+    if ((!empty(doc._shortCopyright)) || (!empty(doc._longCopyright)) || (!empty(doc._citation)))
+    {
+        stream << "\n" << _toText("\\fB") << "LEGAL" << _toText("\\fP") << "\n";
+
+        if (!empty(doc._shortCopyright))
+        {
+            std::fill_n(out, _layout.leftPadding, ' ');
+            stream << doc._name << " Copyright: ";
+            for (int i = 0; i < 25 - static_cast<int>(length(doc._name)); ++i)
+                stream << ' ';
+            stream << doc._shortCopyright << "\n";
+        }
+        std::fill_n(out, _layout.leftPadding, ' ');
+        stream << "SeqAn Copyright:                     2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.\n";
+        if (!empty(doc._citation))
+        {
+            std::fill_n(out, _layout.leftPadding, ' ');
+            stream << "In your academic works please cite:  " << doc._citation << "\n";
+        }
+        if (!empty(doc._longCopyright))
+        {
+            std::fill_n(out, _layout.leftPadding, ' ');
+            stream << "For full copyright and/or warranty information see " << _toText("\\fB")
+                   << "--copyright" << _toText("\\fP") << ".\n";
+        }
+    }
 }
 
 inline
@@ -1348,6 +1508,7 @@ void ManToolDocPrinter_::print(std::ostream & stream, ToolDoc const & doc)
         break;
         }
     }
+    //TODO(h-2): add legal... version missing too?
 }
 
 }  // namespace seqan

--- a/include/seqan/arg_parse/tool_doc.h
+++ b/include/seqan/arg_parse/tool_doc.h
@@ -1432,12 +1432,12 @@ void TextToolDocPrinter_::print(std::ostream & stream, ToolDoc const & doc)
     // Print version and date.
     stream << "\n" << _toText("\\fB") << "VERSION" << _toText("\\fP") << "\n";
     std::fill_n(out, _layout.leftPadding, ' ');
-    stream << "Last update: " << doc._date << "\n";
+    stream << _toText("\\fB") << "Last update: " << _toText("\\fP") << doc._date << "\n";
     std::fill_n(out, _layout.leftPadding, ' ');
-    stream << doc._name << " version: " << doc._version << "\n";
+    stream << _toText("\\fB") << doc._name << " version: " << _toText("\\fP") << doc._version << "\n";
     std::fill_n(out, _layout.leftPadding, ' ');
-    stream << "SeqAn version: " << SEQAN_VERSION_MAJOR << '.' <<  SEQAN_VERSION_MINOR << '.'
-           << SEQAN_VERSION_PATCH;
+    stream << _toText("\\fB") << "SeqAn version: " << _toText("\\fP") << SEQAN_VERSION_MAJOR << '.'
+           <<  SEQAN_VERSION_MINOR << '.' << SEQAN_VERSION_PATCH;
     if (SEQAN_VERSION_PRE_RELEASE != 0)
         stream << "-pre" << SEQAN_VERSION_PRE_RELEASE;
     stream << "\n";
@@ -1450,17 +1450,17 @@ void TextToolDocPrinter_::print(std::ostream & stream, ToolDoc const & doc)
         if (!empty(doc._shortCopyright))
         {
             std::fill_n(out, _layout.leftPadding, ' ');
-            stream << doc._name << " Copyright: ";
-            for (int i = 0; i < 25 - static_cast<int>(length(doc._name)); ++i)
-                stream << ' ';
-            stream << doc._shortCopyright << "\n";
+            stream << _toText("\\fB") << doc._name << " Copyright: "
+                   << _toText("\\fP") << doc._shortCopyright << "\n";
         }
         std::fill_n(out, _layout.leftPadding, ' ');
-        stream << "SeqAn Copyright:                     2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.\n";
+        stream << _toText("\\fB") << "SeqAn Copyright: " << _toText("\\fP")
+               << "2006-2015 Knut Reinert, FU-Berlin; released under the 3-clause BSDL.\n";
         if (!empty(doc._citation))
         {
             std::fill_n(out, _layout.leftPadding, ' ');
-            stream << "In your academic works please cite:  " << doc._citation << "\n";
+            stream << _toText("\\fB") << "In your academic works please cite: " << _toText("\\fP")
+                   << doc._citation << "\n";
         }
         if (!empty(doc._longCopyright))
         {

--- a/tests/arg_parse/test_app.ctd
+++ b/tests/arg_parse/test_app.ctd
@@ -6,8 +6,8 @@
 The second one contains formating &lt;bla&gt;.
 </manual>
 	<cli>
-		<clielement optionIdentifier="--write-ctd-file-ext" isList="false">
-			<mapping referenceName="test_app.write-ctd-file-ext" />
+		<clielement optionIdentifier="--full-help" isList="false">
+			<mapping referenceName="test_app.full-help" />
 		</clielement>
 		<clielement optionIdentifier="--double" isList="false">
 			<mapping referenceName="test_app.double" />
@@ -24,14 +24,8 @@ The second one contains formating &lt;bla&gt;.
 		<clielement optionIdentifier="--in" isList="false">
 			<mapping referenceName="test_app.in" />
 		</clielement>
-		<clielement optionIdentifier="--in-file-ext" isList="false">
-			<mapping referenceName="test_app.in-file-ext" />
-		</clielement>
 		<clielement optionIdentifier="--out" isList="false">
 			<mapping referenceName="test_app.out" />
-		</clielement>
-		<clielement optionIdentifier="--out-file-ext" isList="false">
-			<mapping referenceName="test_app.out-file-ext" />
 		</clielement>
 		<clielement optionIdentifier="--input-prefix-option" isList="false">
 			<mapping referenceName="test_app.input-prefix-option" />
@@ -39,11 +33,8 @@ The second one contains formating &lt;bla&gt;.
 		<clielement optionIdentifier="--output-prefix-option" isList="false">
 			<mapping referenceName="test_app.output-prefix-option" />
 		</clielement>
-		<clielement optionIdentifier="--hidden" isList="false">
-			<mapping referenceName="test_app.hidden" />
-		</clielement>
-		<clielement optionIdentifier="--arg-4-file-ext" isList="false">
-			<mapping referenceName="test_app.arg-4-file-ext" />
+		<clielement optionIdentifier="--advanced" isList="false">
+			<mapping referenceName="test_app.advanced" />
 		</clielement>
 		<!-- Following clielements are arguments. You should consider providing a help text to ease understanding. -->
 		<clielement optionIdentifier="" isList="false">
@@ -61,20 +52,17 @@ The second one contains formating &lt;bla&gt;.
 	</cli>
 	<PARAMETERS version="1.6.2" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/Param_1_6_2.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 		<NODE name="test_app" description="This is a test-app.">
-			<ITEM name="write-ctd-file-ext" value="" type="string" description="Override file extension for --write-ctd" required="false" advanced="true" tags="file-ext-override,gkn-ignore" />
+			<ITEM name="full-help" value="false" type="string" description="Display the help message with advanced options." restrictions="true,false" required="false" advanced="false" />
 			<ITEM name="double" value="" type="double" description="set a double option" required="false" advanced="false" />
 			<ITEM name="integer" value="" type="int" description="set an integer option" restrictions="1:10" required="false" advanced="false" />
 			<ITEM name="int64" value="" type="int" description="set a 64 bit integer option" required="false" advanced="false" />
 			<ITEMLIST name="string" type="string" description="set a string option" restrictions="a,b,c" required="false" advanced="false" >
 			</ITEMLIST>
 			<ITEM name="in" value="" type="input-file" description="set an input file" supported_formats="*.fasta" required="false" advanced="false" />
-			<ITEM name="in-file-ext" value="" type="string" description="Override file extension for --in" restrictions="fasta" required="false" advanced="true" tags="file-ext-override,gkn-ignore" />
 			<ITEM name="out" value="" type="output-file" description="set an output file" supported_formats="*.sam" required="false" advanced="false" />
-			<ITEM name="out-file-ext" value="" type="string" description="Override file extension for --out" restrictions="sam" required="false" advanced="true" tags="file-ext-override,gkn-ignore" />
 			<ITEM name="input-prefix-option" value="" type="input-prefix" description="set an input prefix" supported_formats="*.btx" required="false" advanced="false" />
 			<ITEM name="output-prefix-option" value="" type="output-prefix" description="set an output prefix" supported_formats="*.blub" required="false" advanced="false" />
-			<ITEM name="hidden" value="" type="string" description="a hidden option - will be advanced in the ctd" required="false" advanced="true" />
-			<ITEM name="arg-4-file-ext" value="" type="string" description="Override file extension for argument 4" required="false" advanced="true" tags="file-ext-override,gkn-ignore" />
+			<ITEM name="advanced" value="" type="string" description="an advanced option - will appear as advanced in the ctd, too" required="false" advanced="true" />
 			<ITEM name="argument-0" value="" type="double" description="Double Argument" required="true" advanced="false" />
 			<ITEM name="argument-1" value="" type="string" description="String Argument" required="true" advanced="false" />
 			<ITEM name="argument-2" value="" type="string" description="Documentated Argument with formating" required="true" advanced="false" />

--- a/tests/arg_parse/test_arg_parse_ctd_support.h
+++ b/tests/arg_parse/test_arg_parse_ctd_support.h
@@ -70,9 +70,12 @@ SEQAN_DEFINE_TEST(test_arg_parse_ctd_support)
     setValidValues(parser, "ip", "btx");
     addOption(parser, seqan::ArgParseOption("op", "output-prefix-option", "set an output prefix", seqan::ArgParseArgument::OUTPUT_PREFIX));
     setValidValues(parser, "output-prefix-option", "blub");
-    addOption(parser, seqan::ArgParseOption("hi", "hidden", "a hidden option - will be advanced in the ctd", seqan::ArgParseArgument::STRING));
 
+    addOption(parser, seqan::ArgParseOption("hi", "hidden", "a hidden option - will not appear in the ctd", seqan::ArgParseArgument::STRING));
     hideOption(parser, "hi");
+
+    addOption(parser, seqan::ArgParseOption("ad", "advanced", "an advanced option - will appear as advanced in the ctd, too", seqan::ArgParseArgument::STRING));
+    setAdvanced(parser, "advanced");
 
     addArgument(parser, seqan::ArgParseArgument(ArgParseArgument::DOUBLE, "DOUBLE"));
     setHelpText(parser, 0, "Double Argument");
@@ -84,7 +87,7 @@ SEQAN_DEFINE_TEST(test_arg_parse_ctd_support)
     setHelpText(parser, 3, "Testing output file arguments");
 
     // export ctd
-    seqan::CharString outPath = SEQAN_TEMP_FILENAME();
+    seqan::CharString outPath = "/tmp/test.ctd";//SEQAN_TEMP_FILENAME();
     append(outPath, ".ctd");
 
     std::ofstream ofstream(toCString(outPath), std::ofstream::out | std::ofstream::binary);

--- a/tests/arg_parse/test_arg_parse_ctd_support.h
+++ b/tests/arg_parse/test_arg_parse_ctd_support.h
@@ -87,7 +87,7 @@ SEQAN_DEFINE_TEST(test_arg_parse_ctd_support)
     setHelpText(parser, 3, "Testing output file arguments");
 
     // export ctd
-    seqan::CharString outPath = "/tmp/test.ctd";//SEQAN_TEMP_FILENAME();
+    seqan::CharString outPath = SEQAN_TEMP_FILENAME();
     append(outPath, ".ctd");
 
     std::ofstream ofstream(toCString(outPath), std::ofstream::out | std::ofstream::binary);


### PR DESCRIPTION
adds a couple of features to the arg-parser:
  * abilitiy to set options as "advanced", advanced options are hidden when looking at `--help`
  * add `--full-help` which shows the advanced options as well
  * shortCopyright field and citation field which are shown in new LEGAL section of the default `--help`-page
  * longCopyright field which enables a `--copyright` option that display the field (useful for license texts et cetera)
  * SeqAn copyright information is automatically added to both fields if they are used
  * fixes #536

~~Don't merge yet, as the functions for html and man-export are not yet adapted.~~