### PR TITLE
use gaps internally for align_extend and integrateAlign

### DIFF
--- a/include/seqan/align/alignment_operations.h
+++ b/include/seqan/align/alignment_operations.h
@@ -55,6 +55,47 @@ namespace seqan {
 // Functions
 // ============================================================================
 
+template <typename TSource0, typename TGapSpec0,
+          typename TSource1, typename TGapSpec1,
+          typename TPos>
+inline void
+integrateGaps(Gaps<TSource0, TGapSpec0> & targetRow,
+              Gaps<TSource1, TGapSpec1> const & sourceRow,
+              TPos const viewPos)
+{
+    typedef typename Iterator<Gaps<TSource0, TGapSpec0> >::Type TTargetIt;
+    typedef typename Iterator<Gaps<TSource1, TGapSpec1> const, Standard>::Type TSourceIt;
+
+    // This assertion ensures that the number of sequence characters after viewPos is greater than or equal to
+    // the number of source characters in the clipped infix row.
+    SEQAN_ASSERT_GEQ(endPosition(targetRow) - toSourcePosition(targetRow, viewPos),
+                     endPosition(sourceRow) - beginPosition(sourceRow));
+
+    // init iterators
+    TTargetIt it = iter(targetRow, viewPos);
+
+    // walk through Gaps containers and copy gaps
+    for (TSourceIt infixIt = begin(sourceRow, Standard()); !atEnd(infixIt);)
+    {
+        TPos gapSize = countGaps(infixIt);
+        insertGaps(it, gapSize);
+        goFurther(it, gapSize+1);
+        goFurther(infixIt, gapSize+1);
+    }
+}
+
+template <typename TSource0, typename TGapSpec0,
+          typename TSource1, typename TGapSpec1>
+inline void
+integrateGaps(Gaps<TSource0, TGapSpec0> & targetRow,
+              Gaps<TSource1, TGapSpec1> const & sourceRow)
+{
+    typename Position<TSource0>::Type viewPos = beginPosition(source(sourceRow))
+                                              - beginPosition(source(targetRow))
+                                              + beginPosition(sourceRow); // correct for infixes
+    integrateGaps(targetRow, sourceRow, toViewPosition(targetRow, viewPos));
+}
+
 // ----------------------------------------------------------------------------
 // Function integrateAlign()
 // ----------------------------------------------------------------------------
@@ -84,58 +125,21 @@ void integrateAlign(Align<TSource1, TSpec1> & align,
                     Align<TSource2, TSpec2> const & infixAlign,
                     String<TPos> const & viewPos)
 {
-    typedef Align<TSource1, TSpec1> TAlign;
-    typedef Align<TSource2, TSpec2> TInfixAlign;
-    typedef typename Size<TAlign>::Type TSize;
-
-    typedef typename Row<TAlign>::Type TRow;
-    typedef typename Row<TInfixAlign const>::Type TInfixRow;
-
-    // Iterators on align and infixAlign.
-    typename Iterator<TRow>::Type it;
-    typedef typename Iterator<TInfixRow, Standard>::Type TInfixRowIt;
-
-
+    //TODO assert numrows(infix>= orig)
+    typedef typename Size<Align<TSource1, TSpec1> >::Type TSize;
+    //NOTE(h-2): could be parallelized
     for (TSize i = 0; i < length(rows(align)); ++i)
-    {
-        TInfixRow const & infixRow = row(infixAlign, i);
-        // This assertion ensures that the number of sequence characters after viewPos[i] is greater than or equal to
-        // the number of source characters in the clipped infix row.
-        SEQAN_ASSERT_GEQ(endPosition(row(align, i)) - toSourcePosition(row(align, i), viewPos[i]),
-                endPosition(infixRow) - beginPosition(infixRow));
-
-        // init iterators
-        it = iter(row(align, i), value(viewPos, i));
-
-        // walk through Gaps containers and copy gaps
-        for (TInfixRowIt infixIt = begin(infixRow, Standard()); !atEnd(infixIt);)
-        {
-            TSize gapSize = countGaps(infixIt);
-            insertGaps(it, gapSize);
-            goFurther(it, gapSize+1);
-            goFurther(infixIt, gapSize+1);
-        }
-    }
+        integrateGaps(row(align, i), row(infixAlign, i), viewPos[i]);
 }
 
-template <typename TSource, typename TSpec1, typename TSpec2>
-void integrateAlign(Align<TSource, TSpec1> & align,
-                    Align<typename Infix<TSource>::Type, TSpec2> const & infixAlign)
+template <typename TSource1, typename TSpec1, typename TSource2, typename TSpec2>
+void integrateAlign(Align<TSource1, TSpec1> & align,
+                    Align<TSource2, TSpec2> const & infixAlign)
 {
-    typedef typename Size<TSource>::Type TSize;
-    typedef typename Position<typename Row<Align<TSource, TSpec1> >::Type>::Type TPos;
-
-    String<TPos> viewPos;
-    TPos pos;
-    for (TSize i = 0; i < length(rows(infixAlign)); ++i)
-    {
-        pos = beginPosition(source(row(infixAlign, i)))
-            - beginPosition(source(row(align, i)))
-            + beginPosition(row(infixAlign, i));
-        appendValue(viewPos, toViewPosition(row(align, i), pos));
-    }
-
-    integrateAlign(align, infixAlign, viewPos);
+    typedef typename Size<Align<TSource1, TSpec1> >::Type TSize;
+    //NOTE(h-2): could be parallelized
+    for (TSize i = 0; i < length(rows(align)); ++i)
+        integrateGaps(row(align, i), row(infixAlign, i));
 }
 
 }  // namespace seqan

--- a/include/seqan/align/alignment_operations.h
+++ b/include/seqan/align/alignment_operations.h
@@ -126,7 +126,7 @@ void integrateAlign(Align<TSource1, TSpec1> & align,
                     Align<TSource2, TSpec2> const & infixAlign,
                     String<TPos> const & viewPos)
 {
-    //TODO assert numrows(infix>= orig)
+    SEQAN_ASSERT_EQ_MSG(length(rows(infixAlign)), length(rows(align)), "Both align objects need same number of rows.");
     typedef typename Size<Align<TSource1, TSpec1> >::Type TSize;
     //NOTE(h-2): could be parallelized
     for (TSize i = 0; i < length(rows(align)); ++i)
@@ -137,6 +137,7 @@ template <typename TSource1, typename TSpec1, typename TSource2, typename TSpec2
 void integrateAlign(Align<TSource1, TSpec1> & align,
                     Align<TSource2, TSpec2> const & infixAlign)
 {
+    SEQAN_ASSERT_EQ_MSG(length(rows(infixAlign)), length(rows(align)), "Both align objects need same number of rows.");
     typedef typename Size<Align<TSource1, TSpec1> >::Type TSize;
     //NOTE(h-2): could be parallelized
     for (TSize i = 0; i < length(rows(align)); ++i)

--- a/include/seqan/align/alignment_operations.h
+++ b/include/seqan/align/alignment_operations.h
@@ -90,9 +90,10 @@ inline void
 integrateGaps(Gaps<TSource0, TGapSpec0> & targetRow,
               Gaps<TSource1, TGapSpec1> const & sourceRow)
 {
-    typename Position<TSource0>::Type viewPos = beginPosition(source(sourceRow))
-                                              - beginPosition(source(targetRow))
-                                              + beginPosition(sourceRow); // correct for infixes
+    typename Position<TSource0>::Type viewPos = beginPosition(source(sourceRow)) // correct for infixes
+                                              - beginPosition(source(targetRow)) // ...
+                                              + beginPosition(sourceRow);        // respect source clipping
+
     integrateGaps(targetRow, sourceRow, toViewPosition(targetRow, viewPos));
 }
 

--- a/include/seqan/align/alignment_operations.h
+++ b/include/seqan/align/alignment_operations.h
@@ -63,7 +63,7 @@ integrateGaps(Gaps<TSource0, TGapSpec0> & targetRow,
               Gaps<TSource1, TGapSpec1> const & sourceRow,
               TPos const viewPos)
 {
-    typedef typename Iterator<Gaps<TSource0, TGapSpec0>, Standard >::Type TTargetIt;
+    typedef typename Iterator<Gaps<TSource0, TGapSpec0>, Standard>::Type TTargetIt;
     typedef typename Iterator<Gaps<TSource1, TGapSpec1> const, Standard>::Type TSourceIt;
 
     // This assertion ensures that the number of sequence characters after viewPos is greater than or equal to

--- a/include/seqan/align/alignment_operations.h
+++ b/include/seqan/align/alignment_operations.h
@@ -63,7 +63,7 @@ integrateGaps(Gaps<TSource0, TGapSpec0> & targetRow,
               Gaps<TSource1, TGapSpec1> const & sourceRow,
               TPos const viewPos)
 {
-    typedef typename Iterator<Gaps<TSource0, TGapSpec0> >::Type TTargetIt;
+    typedef typename Iterator<Gaps<TSource0, TGapSpec0>, Standard >::Type TTargetIt;
     typedef typename Iterator<Gaps<TSource1, TGapSpec1> const, Standard>::Type TSourceIt;
 
     // This assertion ensures that the number of sequence characters after viewPos is greater than or equal to
@@ -75,12 +75,12 @@ integrateGaps(Gaps<TSource0, TGapSpec0> & targetRow,
     TTargetIt it = iter(targetRow, viewPos);
 
     // walk through Gaps containers and copy gaps
-    for (TSourceIt infixIt = begin(sourceRow, Standard()); !atEnd(infixIt);)
+    for (TSourceIt sIt = begin(sourceRow, Standard()), sItEnd = end(sourceRow, Standard()); sIt != sItEnd;)
     {
-        TPos gapSize = countGaps(infixIt);
+        TPos gapSize = countGaps(sIt);
         insertGaps(it, gapSize);
         goFurther(it, gapSize+1);
-        goFurther(infixIt, gapSize+1);
+        goFurther(sIt, gapSize+1);
     }
 }
 

--- a/include/seqan/align_extend/align_extend.h
+++ b/include/seqan/align_extend/align_extend.h
@@ -67,11 +67,10 @@ template <typename TGaps0, typename TGaps1, typename TDPContext>
 inline void
 clear(AliExtContext_<TGaps0, TGaps1, TDPContext> & prov)
 {
-    // the expected behaviour for the alignObjects is that they shouldn't
+    // the expected behaviour for the gaps objects is that they shouldn't
     // have to be cleared, since every row is always assignSource'd before it
     // is used. However this DOES NOT CLEAR the object and causes undefined
-    // behaviour
-    // instead we have to clear() the array_gaps:
+    // behaviour instead we have to clear() each gaps object explicitly:
 
     clear(prov.leftRow0);
     clear(prov.rightRow0);
@@ -220,7 +219,7 @@ template <typename TSource0, typename TSource1, typename TGapsSpec0, typename TG
           typename TString0, typename TString1, typename TPos, typename TScoreValue, typename TScoreSpec,
           typename TBoolBanded, typename TBoolXDrop, typename TAliExtContext_>
 inline TScoreValue
-_extendAlignmentImpl(Gaps<TSource0, TGapsSpec0> & row0, // TODO replace TSource with Infix<TString const>
+_extendAlignmentImpl(Gaps<TSource0, TGapsSpec0> & row0,
                      Gaps<TSource1, TGapsSpec1> & row1,
                      TScoreValue const & origScore,
                      TString0 const & hSeq,
@@ -348,7 +347,7 @@ _extendAlignmentImpl(Gaps<TSource0, TGapsSpec0> & row0, // TODO replace TSource 
     if (extendRight)
     {
         TInf0 inf0 = infix(hSeq, hEndPos, length(hSeq));
-        TInf0 inf1 = infix(vSeq, vEndPos, length(vSeq));
+        TInf1 inf1 = infix(vSeq, vEndPos, length(vSeq));
 
         clear(alignContext.traceSegment);
         rightScore = _setUpAndRunAlignImpl(alignContext, inf0, inf1, scoreScheme, lowerDiag, upperDiag, xDrop,
@@ -373,6 +372,7 @@ _extendAlignmentImpl(Gaps<TSource0, TGapsSpec0> & row0, // TODO replace TSource 
     return leftScore + centerScore + rightScore;
 }
 
+// get rows from align object
 template <typename TStringInfix, typename TAlignSpec, typename TString,
           typename TPos, typename TScoreValue, typename TScoreSpec,
           typename TBoolBanded, typename TBoolXDrop, typename TAliExtContext_>

--- a/include/seqan/align_extend/align_extend.h
+++ b/include/seqan/align_extend/align_extend.h
@@ -112,12 +112,12 @@ void _reversePartialTrace(String<TraceSegment_<TPosition,
 // Function _setUpAndRunAlignImpl()
 // ----------------------------------------------------------------------------
 
-template <typename TAliExtContext_, typename TString, typename TScoreValue,
+template <typename TAliExtContext_, typename TString0, typename TString1, typename TScoreValue,
           typename TScoreSpec, typename TTracebackConfig>
 inline TScoreValue
 _setUpAndRunAlignImpl(TAliExtContext_ & alignContext,
-                      TString const & str0,
-                      TString const & str1,
+                      TString0 const & str0,
+                      TString1 const & str1,
                       Score<TScoreValue, TScoreSpec> const & scoreScheme,
                       int const /*lowerDiag*/,
                       int const /*upperDiag*/,
@@ -135,19 +135,19 @@ _setUpAndRunAlignImpl(TAliExtContext_ & alignContext,
                                  TAlignConfig());
 }
 
-template <typename TAliExtContext_, typename TString, typename TScoreValue,
+template <typename TAliExtContext_, typename TString0, typename TString1, typename TScoreValue,
           typename TScoreSpec, typename TTracebackConfig>
 inline TScoreValue
-_setUpAndRunAlignImpl( TAliExtContext_ & alignContext,
-                       TString const & str0,
-                       TString const & str1,
-                       Score<TScoreValue, TScoreSpec> const & scoreScheme,
-                       int const lowerDiag,
-                       int const upperDiag,
-                       TScoreValue const /*xDrop*/,
-                       TTracebackConfig const & /*gapOrientation*/,
-                       True const & /*TBoolBanded*/,
-                       False const & /*TBoolXDrop*/)
+_setUpAndRunAlignImpl(TAliExtContext_ & alignContext,
+                      TString0 const & str0,
+                      TString1 const & str1,
+                      Score<TScoreValue, TScoreSpec> const & scoreScheme,
+                      int const lowerDiag,
+                      int const upperDiag,
+                      TScoreValue const /*xDrop*/,
+                      TTracebackConfig const & /*gapOrientation*/,
+                      True const & /*TBoolBanded*/,
+                      False const & /*TBoolXDrop*/)
 {
     typedef FreeEndGaps_<False, False, True, True> TFreeEndGaps;
     typedef AlignConfig2<AlignExtend_<>, DPBandConfig<BandOn>, TFreeEndGaps,
@@ -158,12 +158,12 @@ _setUpAndRunAlignImpl( TAliExtContext_ & alignContext,
                                  TAlignConfig(lowerDiag, upperDiag));
 }
 
-template <typename TAliExtContext_, typename TString, typename TScoreValue,
+template <typename TAliExtContext_, typename TString0, typename TString1, typename TScoreValue,
           typename TScoreSpec, typename TTracebackConfig>
 inline TScoreValue
 _setUpAndRunAlignImpl(TAliExtContext_ & alignContext,
-                      TString const & str0,
-                      TString const & str1,
+                      TString0 const & str0,
+                      TString1 const & str1,
                       Score<TScoreValue, TScoreSpec> const & scoreScheme,
                       int const /*lowerDiag*/,
                       int const /*upperDiag*/,
@@ -181,12 +181,12 @@ _setUpAndRunAlignImpl(TAliExtContext_ & alignContext,
                                  TAlignConfig());
 }
 
-template <typename TAliExtContext_, typename TString, typename TScoreValue,
+template <typename TAliExtContext_, typename TString0, typename TString1, typename TScoreValue,
           typename TScoreSpec, typename TTracebackConfig>
 inline TScoreValue
 _setUpAndRunAlignImpl(TAliExtContext_ & alignContext,
-                      TString const & str0,
-                      TString const & str1,
+                      TString0 const & str0,
+                      TString1 const & str1,
                       Score<TScoreValue, TScoreSpec> const & scoreScheme,
                       int const lowerDiag,
                       int const upperDiag,

--- a/include/seqan/align_extend/align_extend.h
+++ b/include/seqan/align_extend/align_extend.h
@@ -49,41 +49,34 @@ namespace seqan {
 
 // Context with memory holding objects for alignment extension
 // This can be reused to prevent repeated memory allocations
-template <typename TAlign, typename TDPContext>
+template <typename TGaps0, typename TGaps1, typename TDPContext>
 struct AliExtContext_
 {
-    typedef typename Size<TAlign>::Type TSize;
-    typedef typename Position<TAlign>::Type TPosition;
+    typedef typename Size<TGaps0>::Type TSize;
+    typedef typename Position<TGaps0>::Type TPosition;
 
-    TAlign leftAlign;
-    TAlign centerAlign;
-    TAlign rightAlign;
+    TGaps0 leftRow0, centerRow0, rightRow0;
+    TGaps1 leftRow1, centerRow1, rightRow1;
 
     TDPContext dpContext;
 
     String<TraceSegment_<TPosition, TSize> > traceSegment;
 };
 
-template <typename TAlign, typename TDPContext>
+template <typename TGaps0, typename TGaps1, typename TDPContext>
 inline void
-clear(AliExtContext_<TAlign, TDPContext> & prov)
+clear(AliExtContext_<TGaps0, TGaps1, TDPContext> & prov)
 {
-    // centerAlign nead not be cleared, because it is always reassigned
-    if (length(rows(prov.leftAlign)) != 2)
-        resize(rows(prov.leftAlign), 2);
-    if (length(rows(prov.rightAlign)) != 2)
-        resize(rows(prov.rightAlign), 2);
-
     // the expected behaviour for the alignObjects is that they shouldn't
     // have to be cleared, since every row is always assignSource'd before it
     // is used. However this DOES NOT CLEAR the object and causes undefined
     // behaviour
     // instead we have to clear() the array_gaps:
 
-    clear(row(prov.leftAlign,0));
-    clear(row(prov.leftAlign,1));
-    clear(row(prov.rightAlign,0));
-    clear(row(prov.rightAlign,1));
+    clear(prov.leftRow0);
+    clear(prov.rightRow0);
+    clear(prov.leftRow1);
+    clear(prov.rightRow1);
 
     // trace segment always needs to be cleared
     clear(prov.traceSegment);
@@ -223,6 +216,163 @@ _setUpAndRunAlignImpl(TAliExtContext_ & alignContext,
 // Function _extendAlignmentImpl()
 // ----------------------------------------------------------------------------
 
+template <typename TSource0, typename TSource1, typename TGapsSpec0, typename TGapsSpec1,
+          typename TString0, typename TString1, typename TPos, typename TScoreValue, typename TScoreSpec,
+          typename TBoolBanded, typename TBoolXDrop, typename TAliExtContext_>
+inline TScoreValue
+_extendAlignmentImpl(Gaps<TSource0, TGapsSpec0> & row0, // TODO replace TSource with Infix<TString const>
+                     Gaps<TSource1, TGapsSpec1> & row1,
+                     TScoreValue const & origScore,
+                     TString0 const & hSeq,
+                     TString1 const & vSeq,
+                     Tuple<TPos, 4> const & positions,
+                     ExtensionDirection const & direction,
+                     int const lowerDiag,
+                     int const upperDiag,
+                     TScoreValue const & xDrop,
+                     Score<TScoreValue, TScoreSpec> const & scoreScheme,
+                     TBoolBanded const & /**/,
+                     TBoolXDrop const & /**/,
+                     TAliExtContext_ & alignContext)
+{
+    typedef typename Infix<TSource0 const>::Type TInf0;
+    typedef typename Infix<TSource1 const>::Type TInf1;
+
+    TPos const hBeginPos    = positions[0];
+    TPos const vBeginPos    = positions[1];
+    TPos const hEndPos      = positions[2];
+    TPos const vEndPos      = positions[3];
+
+    SEQAN_ASSERT_EQ(infix(source(row0), beginPosition(row0), endPosition(row0)),
+                    infix(hSeq, hBeginPos, hEndPos));
+    SEQAN_ASSERT_EQ(infix(source(row1), beginPosition(row1), endPosition(row1)),
+                    infix(vSeq, vBeginPos, vEndPos));
+
+    bool extendLeft = ((direction & EXTEND_LEFT) && (hBeginPos > 0u) && (vBeginPos > 0u));
+    bool extendRight = ((direction & EXTEND_RIGHT) && (hEndPos < length(hSeq)) && (vEndPos < length(vSeq)));
+
+    clear(alignContext);
+    alignContext.centerRow0 = row0;
+    alignContext.centerRow1 = row1;
+
+    TScoreValue leftScore   = 0;
+    TScoreValue centerScore = origScore;
+    TScoreValue rightScore  = 0;
+
+    if (centerScore == minValue<TScoreValue>())
+    {
+        centerScore = 0;
+
+        for (TPos i = 0; i < length(row0); ++i)
+        {
+            if ( ( isGap(row0, i)) || ( isGap(row1, i)) )
+            {
+                if (( i==0 ) ||
+                    (isGap(row0, i-1) != isGap(row0, i)) ||
+                    (isGap(row1, i-1) != isGap(row1, i)) )
+                {
+                    centerScore += scoreGapOpen(scoreScheme);
+                }
+                else
+                {
+                    centerScore += scoreGapExtend(scoreScheme);
+                }
+            }
+            else
+            {
+                centerScore += score(scoreScheme, row0[i], row1[i]);
+            }
+        }
+    }
+
+    // "reset" original alignment to full length on sequences and no gaps
+    assignSource(row0, infix(hSeq, 0, length(hSeq)));
+    assignSource(row1, infix(vSeq, 0, length(vSeq)));
+
+    // left
+    if (extendLeft)
+    {
+        TInf0 inf0 = infix(hSeq, 0, hBeginPos);
+        TInf1 inf1 = infix(vSeq, 0, vBeginPos);
+
+        // reverse input
+        ModifiedString<TInf0, ModReverse> const r_inf0(inf0);
+        ModifiedString<TInf1, ModReverse> const r_inf1(inf1);
+
+        leftScore = _setUpAndRunAlignImpl(alignContext, r_inf0, r_inf1, scoreScheme, lowerDiag, upperDiag, xDrop,
+                                          TracebackConfig_<CompleteTrace, GapsRight>(), TBoolBanded(), TBoolXDrop());
+        // un-reverve
+        _reversePartialTrace(alignContext.traceSegment, length(inf0), length(inf1));
+
+        assignSource(alignContext.leftRow0, inf0);
+        assignSource(alignContext.leftRow1, inf1);
+
+        _adaptTraceSegmentsTo(alignContext.leftRow0, alignContext.leftRow1, alignContext.traceSegment);
+
+        if (length(alignContext.leftRow0) > 0)
+        {
+            integrateGaps(row0, alignContext.leftRow0);
+            integrateGaps(row1, alignContext.leftRow1);
+            setClippedBeginPosition(row0, clippedBeginPosition(alignContext.leftRow0));
+            setClippedBeginPosition(row1, clippedBeginPosition(alignContext.leftRow1));
+        }
+        else
+        {
+            extendLeft = false;
+        }
+    }
+
+    // center
+    if (extendLeft)
+    {
+        integrateGaps(row0, alignContext.centerRow0, length(alignContext.leftRow0));
+        integrateGaps(row1, alignContext.centerRow1, length(alignContext.leftRow1));
+    }
+    else
+    {
+        integrateGaps(row0, alignContext.centerRow0, hBeginPos);
+        integrateGaps(row1, alignContext.centerRow1, vBeginPos);
+        TPos leadGaps0 = countGaps(begin(alignContext.centerRow0));
+        TPos leadGaps1 = countGaps(begin(alignContext.centerRow1));
+
+        TPos sourceBeginPos0 = toSourcePosition(alignContext.centerRow0, leadGaps0) + hBeginPos -
+                               beginPosition(alignContext.centerRow0);
+        TPos sourceBeginPos1 = toSourcePosition(alignContext.centerRow1, leadGaps1) + vBeginPos -
+                               beginPosition(alignContext.centerRow1);
+
+        setClippedBeginPosition(row0, toViewPosition(row0, sourceBeginPos0) - leadGaps0);
+        setClippedBeginPosition(row1, toViewPosition(row1, sourceBeginPos1) - leadGaps1);
+    }
+
+    // right
+    if (extendRight)
+    {
+        TInf0 inf0 = infix(hSeq, hEndPos, length(hSeq));
+        TInf0 inf1 = infix(vSeq, vEndPos, length(vSeq));
+
+        clear(alignContext.traceSegment);
+        rightScore = _setUpAndRunAlignImpl(alignContext, inf0, inf1, scoreScheme, lowerDiag, upperDiag, xDrop,
+                                           TracebackConfig_<CompleteTrace, GapsLeft>(), TBoolBanded(), TBoolXDrop());
+
+        assignSource(alignContext.rightRow0, inf0);
+        assignSource(alignContext.rightRow1, inf1);
+        _adaptTraceSegmentsTo(alignContext.rightRow0, alignContext.rightRow1, alignContext.traceSegment);
+
+        if (length(alignContext.rightRow0) > 0)
+        {
+            integrateGaps(row0, alignContext.rightRow0);
+            integrateGaps(row1, alignContext.rightRow1);
+        }
+    }
+
+    setClippedEndPosition(row0, clippedBeginPosition(row0) + length(alignContext.leftRow0) +
+                          length(alignContext.centerRow0) + length(alignContext.rightRow0));
+    setClippedEndPosition(row1, clippedBeginPosition(row1) + length(alignContext.leftRow1) +
+                          length(alignContext.centerRow1) + length(alignContext.rightRow1));
+
+    return leftScore + centerScore + rightScore;
+}
+
 template <typename TStringInfix, typename TAlignSpec, typename TString,
           typename TPos, typename TScoreValue, typename TScoreSpec,
           typename TBoolBanded, typename TBoolXDrop, typename TAliExtContext_>
@@ -241,138 +391,11 @@ _extendAlignmentImpl(Align<TStringInfix, TAlignSpec> & align,
                      TBoolXDrop const & /**/,
                      TAliExtContext_ & alignContext)
 {
-    typedef typename Infix<TString const>::Type TInf;
-    typedef Align<TStringInfix, TAlignSpec>     TAlign;
-    typedef typename Size<TAlign>::Type         TSize SEQAN_TYPEDEF_FOR_DEBUG;
+    SEQAN_ASSERT_EQ_MSG(length(rows(align)), 2u, "Only works with pairwise alignments.");
+    SEQAN_ASSERT_EQ_MSG(length(row(align, 0)), length(row(align, 1)), "Invalid alignment!");
 
-    TPos const hBeginPos    = positions[0];
-    TPos const vBeginPos    = positions[1];
-    TPos const hEndPos      = positions[2];
-    TPos const vEndPos      = positions[3];
-
-    SEQAN_ASSERT_EQ(length(rows(align)), static_cast<TSize>(2));
-    SEQAN_ASSERT_EQ(infix(source(row(align, 0)), beginPosition(row(align, 0)), endPosition(row(align, 0))),
-                    infix(hSeq, hBeginPos, hEndPos));
-    SEQAN_ASSERT_EQ(infix(source(row(align, 1)), beginPosition(row(align, 1)), endPosition(row(align, 1))),
-                    infix(vSeq, vBeginPos, vEndPos));
-
-    bool extendLeft = ((direction & EXTEND_LEFT) && (hBeginPos > 0u) && (vBeginPos > 0u));
-    bool extendRight = ((direction & EXTEND_RIGHT) && (hEndPos < length(hSeq)) && (vEndPos < length(vSeq)));
-
-    clear(alignContext);
-    alignContext.centerAlign = align;
-
-    TScoreValue leftScore   = 0;
-    TScoreValue centerScore = origScore;
-    TScoreValue rightScore  = 0;
-
-    if (centerScore == minValue<TScoreValue>())
-    {
-        centerScore = 0;
-        typename Row<TAlign>::Type const & row0 = row(align, 0);
-        typename Row<TAlign>::Type const & row1 = row(align, 1);
-
-        for (TPos i = 0; i < length(row(align, 0)); ++i)
-        {
-            if ( ( isGap(row0, i)) || ( isGap(row1, i)) )
-            {
-                if (( i==0 ) ||
-                    (isGap(row0, i-1) != isGap(row0, i)) ||
-                    (isGap(row1, i-1) != isGap(row1, i)) )
-                {
-                    centerScore += scoreGapOpen(scoreScheme);
-                }
-                else
-                {
-                    centerScore += scoreGapExtend(scoreScheme);
-                }
-            }
-            else
-            {
-                centerScore += score(scoreScheme, value(row0, i),
-                                     value(row1, i));
-            }
-        }
-    }
-
-    // "reset" original alignment to full length on sequences and no gaps
-    assignSource(row(align, 0), infix(hSeq, 0, length(hSeq)));
-    assignSource(row(align, 1), infix(vSeq, 0, length(vSeq)));
-
-    // left
-    if (extendLeft)
-    {
-        TInf inf0 = infix(hSeq, 0, hBeginPos);
-        TInf inf1 = infix(vSeq, 0, vBeginPos);
-
-        // reverse input
-        ModifiedString<TInf, ModReverse> const r_inf0(inf0);
-        ModifiedString<TInf, ModReverse> const r_inf1(inf1);
-
-        leftScore = _setUpAndRunAlignImpl(alignContext, r_inf0, r_inf1, scoreScheme, lowerDiag, upperDiag, xDrop,
-                                          TracebackConfig_<CompleteTrace, GapsRight>(), TBoolBanded(), TBoolXDrop());
-        // un-reverve
-        _reversePartialTrace(alignContext.traceSegment, length(inf0), length(inf1));
-
-        assignSource(row(alignContext.leftAlign, 0), inf0);
-        assignSource(row(alignContext.leftAlign, 1), inf1);
-
-        _adaptTraceSegmentsTo(row(alignContext.leftAlign, 0), row(alignContext.leftAlign, 1),
-                              alignContext.traceSegment);
-
-        if (length(row(alignContext.leftAlign, 0)) > 0)
-        {
-            integrateAlign(align, alignContext.leftAlign);
-            setClippedBeginPosition(row(align, 0), clippedBeginPosition(row(alignContext.leftAlign, 0)));
-            setClippedBeginPosition(row(align, 1), clippedBeginPosition(row(alignContext.leftAlign, 1)));
-        }
-        else
-        {
-            extendLeft = false;
-        }
-    }
-
-    // center
-    integrateAlign(align, alignContext.centerAlign);
-    if (!extendLeft)
-    {
-        TPos leadGaps0 = countGaps(begin(row(alignContext.centerAlign, 0)));
-        TPos leadGaps1 = countGaps(begin(row(alignContext.centerAlign, 1)));
-
-        TPos sourceBeginPos0 = toSourcePosition(row(alignContext.centerAlign, 0), leadGaps0) + hBeginPos -
-                               beginPosition(row(alignContext.centerAlign, 0));
-        TPos sourceBeginPos1 = toSourcePosition(row(alignContext.centerAlign, 1), leadGaps1) + vBeginPos -
-                               beginPosition(row(alignContext.centerAlign, 1));
-
-        setClippedBeginPosition(row(align, 0), toViewPosition(row(align, 0), sourceBeginPos0) - leadGaps0);
-        setClippedBeginPosition(row(align, 1), toViewPosition(row(align, 1), sourceBeginPos1) - leadGaps1);
-    }
-
-    // right
-    if (extendRight)
-    {
-        TInf inf0 = infix(hSeq, hEndPos, length(hSeq));
-        TInf inf1 = infix(vSeq, vEndPos, length(vSeq));
-
-        clear(alignContext.traceSegment);
-        rightScore = _setUpAndRunAlignImpl(alignContext, inf0, inf1, scoreScheme, lowerDiag, upperDiag, xDrop,
-                                           TracebackConfig_<CompleteTrace, GapsLeft>(), TBoolBanded(), TBoolXDrop());
-
-        assignSource(row(alignContext.rightAlign, 0), inf0);
-        assignSource(row(alignContext.rightAlign, 1), inf1);
-        _adaptTraceSegmentsTo(row(alignContext.rightAlign, 0), row(alignContext.rightAlign, 1),
-                              alignContext.traceSegment);
-
-        if (length(row(alignContext.rightAlign, 0)) > 0)
-            integrateAlign(align, alignContext.rightAlign);
-    }
-
-    setClippedEndPosition(row(align, 0), clippedBeginPosition(row(align, 0)) + length(row(alignContext.leftAlign, 0)) +
-                          length(row(alignContext.centerAlign, 0)) + length(row(alignContext.rightAlign, 0)));
-    setClippedEndPosition(row(align, 1), clippedBeginPosition(row(align, 1)) + length(row(alignContext.leftAlign, 1)) +
-                          length(row(alignContext.centerAlign, 1)) + length(row(alignContext.rightAlign, 1)));
-
-    return leftScore + centerScore + rightScore;
+    return _extendAlignmentImpl(row(align, 0), row(align, 1), origScore, hSeq, vSeq, positions, direction, lowerDiag,
+                                upperDiag, xDrop, scoreScheme, TBoolBanded(), TBoolXDrop(), alignContext);
 }
 
 // create AlignContext
@@ -396,7 +419,9 @@ _extendAlignmentImpl(Align<TStringInfix, TAlignSpec> & align,
     if (scoreGapOpen(scoreScheme) == scoreGapExtend(scoreScheme))
     {
         typedef DPContext<TScoreValue, LinearGaps> TDPContext;
-        typedef AliExtContext_<Align<TStringInfix, TAlignSpec>, TDPContext> TAliExtContext_;
+        typedef AliExtContext_<Gaps<TStringInfix, TAlignSpec>,
+                               Gaps<TStringInfix, TAlignSpec>,
+                               TDPContext> TAliExtContext_;
         TAliExtContext_ alignContext;
         return _extendAlignmentImpl(align, origScore, hSeq, vSeq, positions, direction, lowerDiag, upperDiag, xDrop,
                                     scoreScheme, TBoolBanded(), TBoolXDrop(), alignContext);
@@ -404,7 +429,9 @@ _extendAlignmentImpl(Align<TStringInfix, TAlignSpec> & align,
     else
     {
         typedef DPContext<TScoreValue, AffineGaps> TDPContext;
-        typedef AliExtContext_<Align<TStringInfix, TAlignSpec>, TDPContext> TAliExtContext_;
+        typedef AliExtContext_<Gaps<TStringInfix, TAlignSpec>,
+                               Gaps<TStringInfix, TAlignSpec>,
+                               TDPContext> TAliExtContext_;
         TAliExtContext_ alignContext;
         return _extendAlignmentImpl(align, origScore, hSeq, vSeq, positions, direction, lowerDiag, upperDiag, xDrop,
                                     scoreScheme, TBoolBanded(), TBoolXDrop(), alignContext);


### PR DESCRIPTION
This also fixes some things in alignExtend where it depended on broken behaviour and did unnecessary clears.