### PR TITLE
Fix some typos in the manual

### DIFF
--- a/include/seqan/bam_io/read_bam.h
+++ b/include/seqan/bam_io/read_bam.h
@@ -96,6 +96,7 @@ readHeader(BamHeader & header,
            TForwardIter & iter,
            Bam const & /*tag*/)
 {
+    clear(header);
     // Read BAM magic string.
     String<char, Array<4> > magic;
     read(magic, iter, 4);

--- a/include/seqan/modifier/modifier_string.h
+++ b/include/seqan/modifier/modifier_string.h
@@ -851,14 +851,14 @@ open(StringSet<ModifiedString<THost, TSpec>, Owner<ConcatDirect<TSpec2> > > &,
 
 template <typename THost, typename TSpec >
 inline bool
-save(ModifiedString<THost, TSpec> &, const char *, int)
+save(ModifiedString<THost, TSpec> const &, const char *, int)
 {
     return true; // NOOP; this has to be done manually right now
 }
 
 template <typename THost, typename TSpec, typename TSpec2>
 inline bool
-save(StringSet<ModifiedString<THost, TSpec>, Owner<ConcatDirect<TSpec2> > > &,
+save(StringSet<ModifiedString<THost, TSpec>, Owner<ConcatDirect<TSpec2> > > const &,
      const char *,
      int)
 {

--- a/manual/source/Tutorial/Iterators.rst
+++ b/manual/source/Tutorial/Iterators.rst
@@ -300,7 +300,7 @@ Workshop Assignment 4
      Review
 
    Objective
-     Now, use rooted iterators in the example from Workshop ASsignment 3.
+     Now, use rooted iterators in the example from Workshop Assignment 3.
 
    Solution
      Click **more...** to see the solution.

--- a/manual/source/Tutorial/Sequences.rst
+++ b/manual/source/Tutorial/Sequences.rst
@@ -69,8 +69,8 @@ You can find detailed information in the tutorial :ref:`tutorial-alphabets`.
 
 .. code-block:: cpp
 
-   String<Dna>        myGenome;   // A string of nucleotides.
-   String<AminAcid>   myProtein;  // A string of amino acids.
+   String<Dna>         myGenome;   // A string of nucleotides.
+   String<AminoAcid>   myProtein;  // A string of amino acids.
 
 For commonly used string parameterizations, SeqAn has a range of shortcuts implemented, e.g. :dox:`DnaString`, :dox:`RnaString` and :dox:`Peptide`.
 

--- a/manual/source/Tutorial/SequencesInDepth.rst
+++ b/manual/source/Tutorial/SequencesInDepth.rst
@@ -104,7 +104,7 @@ Each sequence object has a capacity, i.e. the reserved space for this object.
 The capacity can be set explicitly by functions such as :dox:`String#reserve` or :dox:`StringConcept#resize`.
 It can also bet set implicitly by functions like :dox:`ContainerConcept#append`, :dox:`AssignableConcept#assign`, :dox:`StringConcept#insert` or :dox:`StringConcept#replace`, if the operation's result exceeds the length of the target sequence.
 
-If the current capacity of a sequence is exceeded by chaning the length, we say that the sequence overflows.
+If the current capacity of a sequence is exceeded by chaining the length, we say that the sequence overflows.
 There are several overflow strategies that determine what actually happens when a string should be expanded beyond its capacity.
 The user can specify this for a function call by additionally handing over a tag.
 If no overflow strategy is specified, a default overflow strategy is selected depending on the type of the sequence.

--- a/manual/source/conf.py
+++ b/manual/source/conf.py
@@ -266,11 +266,11 @@ texinfo_documents = [
 
 # -- Options for the Disqus integration -------------------------------------
 
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if on_rtd:
-    html_context = {
-      'disqus_shortname': 'seqan-manual',
-    }
+#on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+#if on_rtd:
+#    html_context = {
+#      'disqus_shortname': 'seqan-manual',
+#    }
 
 # -- Options for SeqAn plugins ----------------------------------------------
 


### PR DESCRIPTION
Fixed three typos in tutorial, see #1186 