### PR TITLE
BAM index file (.bai) can be saved

### DIFF
--- a/include/seqan/bam_io/bam_index_bai.h
+++ b/include/seqan/bam_io/bam_index_bai.h
@@ -138,11 +138,6 @@ public:
     typedef std::map<__uint32, BaiBamIndexBinData_> TBinIndex_;
     typedef String<__uint64> TLinearIndex_;
 
-    // The name of the BAM file.
-    CharString bamFilename;
-    // The name of the BAI file.
-    CharString baiFilename;
-
     __uint64 _unalignedCount;
 
     // 1<<14 is the size of the minimum bin.
@@ -536,13 +531,10 @@ open(BamIndex<Bai> & index, char * filename)
  * @fn BaiIndex#save
  * @brief Save a BaiIndex object.
  *
- * @signature bool save(baiIndex[, baiFileName]);
+ * @signature bool save(baiIndex, baiFileName);
  *
  * @param[in] baiIndex    The BaiIndex to write out.
- * @param[in] baiFileName The name of the BAI file to write to.  This parameter is optional only if the BAI index knows
- *                        the BAI file name from a previous @link BaiIndex#build @endlink call.  By default, the BAI
- *                        file name from the previous call to @link BaiIndex#build @endlink is used.  Type: <tt>char
- *                        const *</tt>.
+ * @param[in] baiFileName The name of the BAI file to write to.
  *
  * @return bool <tt>true</tt> on success, <tt>false</tt> otherwise.
  */
@@ -604,12 +596,6 @@ inline bool save(BamIndex<Bai> const & index, char const * baiFilename)
     return out.good();  // false on error, true on success.
 }
 
-inline bool save(BamIndex<Bai> const & index)
-{
-    if (empty(index.baiFilename))
-        return false;  // Cannot write out if baiFilename member is empty.
-    return save(index, toCString(index.baiFilename));
-}
 
 inline void _baiAddAlignmentChunkToBin(BamIndex<Bai> & index,
                                        __uint32 currBin,
@@ -642,21 +628,16 @@ inline void _baiAddAlignmentChunkToBin(BamIndex<Bai> & index,
  * @fn BaiIndex#build
  * @brief Create a BaiIndex from BAM file.
  *
- * @signature bool build(baiIndex, bamFileName[, baiFileName]);
+ * @signature bool build(baiIndex, bamFileName);
  *
  * @param[out] baiIndex    The BaiIndex to build into.
  * @param[in]  bamFileName Path to the BAM file to build an index for.  Type: <tt>char const *</tt>.
- * @param[in]  baiFileName Path to the BAI file to use as the index file.  Type: <tt>char const *</tt>.
- *                         Default: <tt>"${bamFileName}.bai"</tt>.
  *
  * @return bool <tt>true</tt> on success, <tt>false</tt> otherwise.
  */
-inline bool build(BamIndex<Bai> & index, char const * bamFilename, char const * baiFilename)
+inline bool build(BamIndex<Bai> & index, char const * bamFilename)
 {
     // SEQAN_FAIL("This does not work yet!");
-
-    index.bamFilename = bamFilename;
-    index.baiFilename = baiFilename;
 
     index._unalignedCount = 0;
     clear(index._binIndices);
@@ -805,13 +786,6 @@ inline bool build(BamIndex<Bai> & index, char const * bamFilename, char const * 
     // Merge small bins if possible.
     // SEQAN_FAIL("TODO: Merge bins!");
     return true;
-}
-
-inline bool build(BamIndex<Bai> & index, char const * bamFilename)
-{
-    CharString baiFilename(bamFilename);
-    append(baiFilename, ".bai");
-    return build(index, bamFilename, toCString(baiFilename));
 }
 
 

--- a/include/seqan/bam_io/bam_index_bai.h
+++ b/include/seqan/bam_io/bam_index_bai.h
@@ -529,7 +529,7 @@ open(BamIndex<Bai> & index, char * filename)
 
 inline bool _saveIndex(BamIndex<Bai> const & index, char const * filename)
 {
-    std::cerr << "WRITE INDEX TO " << filename << std::endl;
+    //std::cerr << "WRITE INDEX TO " << filename << std::endl;
     // Open output file.
     std::ofstream out(filename, std::ios::binary | std::ios::out);
 
@@ -570,7 +570,7 @@ inline bool _saveIndex(BamIndex<Bai> const & index, char const * filename)
         }
 
         // Write out linear index.
-        __int32 numIntervals = length(index._linearIndices);
+        __int32 numIntervals = length(linearIndex);
         out.write(reinterpret_cast<char *>(&numIntervals), 4);
         typedef Iterator<String<__uint64> const, Rooted>::Type TLinearIndexIter;
         for (TLinearIndexIter it = begin(linearIndex, Rooted()); !atEnd(it); goNext(it))
@@ -578,7 +578,7 @@ inline bool _saveIndex(BamIndex<Bai> const & index, char const * filename)
     }
 
     // Write the number of unaligned reads if set.
-    std::cerr << "UNALIGNED\t" << index._unalignedCount << std::endl;
+    //std::cerr << "UNALIGNED\t" << index._unalignedCount << std::endl;
     if (index._unalignedCount != maxValue<__uint64>())
         out.write(reinterpret_cast<char const *>(&index._unalignedCount), 8);
 

--- a/include/seqan/bam_io/bam_index_bai.h
+++ b/include/seqan/bam_io/bam_index_bai.h
@@ -528,12 +528,12 @@ open(BamIndex<Bai> & index, char * filename)
 // ---------------------------------------------------------------------------
 
 /*!
- * @fn BaiIndex#save
- * @brief Save a BaiIndex object.
+ * @fn BamIndex#save
+ * @brief Save a BamIndex object.
  *
  * @signature bool save(baiIndex, baiFileName);
  *
- * @param[in] baiIndex    The BaiIndex to write out.
+ * @param[in] baiIndex    The BamIndex to write out.
  * @param[in] baiFileName The name of the BAI file to write to.
  *
  * @return bool <tt>true</tt> on success, <tt>false</tt> otherwise.
@@ -625,12 +625,12 @@ inline void _baiAddAlignmentChunkToBin(BamIndex<Bai> & index,
 // ---------------------------------------------------------------------------
 // TODO(dadi): uncomment when BamIndex.build index is fixed. DOX commented out
 /*
- * @fn BaiIndex#build
- * @brief Create a BaiIndex from BAM file.
+ * @fn BamIndex#build
+ * @brief Create a BamIndex from BAM file.
  *
  * @signature bool build(baiIndex, bamFileName);
  *
- * @param[out] baiIndex    The BaiIndex to build into.
+ * @param[out] baiIndex    The BamIndex to build into.
  * @param[in]  bamFileName Path to the BAM file to build an index for.  Type: <tt>char const *</tt>.
  *
  * @return bool <tt>true</tt> on success, <tt>false</tt> otherwise.

--- a/tests/bam_io/CMakeLists.txt
+++ b/tests/bam_io/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable (test_bam_io
                test_bam_io.cpp
                test_bam_alignment_record.h
                test_bam_header_record.h
+               test_bam_index.h
                test_bam_io_context.h
                test_bam_sam_conversion.h
                test_bam_tags_dict.h

--- a/tests/bam_io/test_bam_index.h
+++ b/tests/bam_io/test_bam_index.h
@@ -54,8 +54,8 @@ SEQAN_DEFINE_TEST(test_bam_io_bam_index_build)
     append(tmpOutPath, ".bai");
 
     BamIndex<Bai> baiIndex;
-    SEQAN_ASSERT(build(baiIndex, toCString(bamFilename), toCString(tmpOutPath)));
-    SEQAN_ASSERT(save(baiIndex));
+    SEQAN_ASSERT(build(baiIndex, toCString(bamFilename)));
+    SEQAN_ASSERT(save(baiIndex, toCString(tmpOutPath)));
 
     SEQAN_ASSERT(_compareBinaryFiles(toCString(tmpOutPath), toCString(expectedBaiFilename)));
 }

--- a/tests/bam_io/test_bam_index.h
+++ b/tests/bam_io/test_bam_index.h
@@ -80,4 +80,21 @@ SEQAN_DEFINE_TEST(test_bam_io_bam_index_bai)
     SEQAN_ASSERT_NOT(found);
 }
 
+SEQAN_DEFINE_TEST(test_bam_io_bam_index_write_bai)
+{
+    using namespace seqan;
+
+    CharString baiFilename;
+    append(baiFilename, SEQAN_PATH_TO_ROOT());
+    append(baiFilename, "/tests/bam_io/small.bam.bai");
+    BamIndex<Bai> baiIndex;
+    SEQAN_ASSERT(open(baiIndex, toCString(baiFilename)));
+
+    CharString outPath = SEQAN_TEMP_FILENAME();
+    append(outPath, ".bai");
+    _saveIndex(baiIndex, toCString(outPath));
+
+    SEQAN_ASSERT(_compareBinaryFiles(toCString(outPath), toCString(baiFilename)));
+}
+
 #endif  // TESTS_BAM_IO_TEST_BAM_INDEX_H_

--- a/tests/bam_io/test_bam_index.h
+++ b/tests/bam_io/test_bam_index.h
@@ -40,12 +40,30 @@
 
 #include <seqan/bam_io.h>
 
-SEQAN_DEFINE_TEST(test_bam_io_bam_index_bai)
-{
-    using namespace seqan;
+using namespace seqan;
 
-    CharString baiFilename;
-    append(baiFilename, SEQAN_PATH_TO_ROOT());
+SEQAN_DEFINE_TEST(test_bam_io_bam_index_build)
+{
+    CharString expectedBaiFilename = SEQAN_PATH_TO_ROOT();
+    append(expectedBaiFilename, "/tests/bam_io/small.bam.bai");
+
+    CharString bamFilename = SEQAN_PATH_TO_ROOT();
+    append(bamFilename, "/tests/bam_io/small.bam");
+
+    CharString tmpOutPath = SEQAN_TEMP_FILENAME();
+    append(tmpOutPath, ".bai");
+
+    BamIndex<Bai> baiIndex;
+    SEQAN_ASSERT(build(baiIndex, toCString(bamFilename), toCString(tmpOutPath)));
+    SEQAN_ASSERT(save(baiIndex));
+
+    SEQAN_ASSERT(_compareBinaryFiles(toCString(tmpOutPath), toCString(expectedBaiFilename)));
+}
+
+
+SEQAN_DEFINE_TEST(test_bam_io_bam_index_open)
+{
+    CharString baiFilename = SEQAN_PATH_TO_ROOT();
     append(baiFilename, "/tests/bam_io/small.bam.bai");
 
     BamIndex<Bai> baiIndex;
@@ -62,8 +80,7 @@ SEQAN_DEFINE_TEST(test_bam_io_bam_index_bai)
     SEQAN_ASSERT_EQ(getUnalignedCount(baiIndex), 0u);
 
     // File has same contents as in the SAM test.
-    CharString bamFilename;
-    append(bamFilename, SEQAN_PATH_TO_ROOT());
+    CharString bamFilename = SEQAN_PATH_TO_ROOT();
     append(bamFilename, "/tests/bam_io/small.bam");
 
     BamFileIn bamFile(toCString(bamFilename));
@@ -80,21 +97,20 @@ SEQAN_DEFINE_TEST(test_bam_io_bam_index_bai)
     SEQAN_ASSERT_NOT(found);
 }
 
-SEQAN_DEFINE_TEST(test_bam_io_bam_index_write_bai)
+SEQAN_DEFINE_TEST(test_bam_io_bam_index_save)
 {
-    using namespace seqan;
-
-    CharString baiFilename;
-    append(baiFilename, SEQAN_PATH_TO_ROOT());
+    CharString baiFilename = SEQAN_PATH_TO_ROOT();
     append(baiFilename, "/tests/bam_io/small.bam.bai");
+    
+    CharString tmpOutPath = SEQAN_TEMP_FILENAME();
+    append(tmpOutPath, ".bai");
+    
     BamIndex<Bai> baiIndex;
     SEQAN_ASSERT(open(baiIndex, toCString(baiFilename)));
-
-    CharString outPath = SEQAN_TEMP_FILENAME();
-    append(outPath, ".bai");
-    _saveIndex(baiIndex, toCString(outPath));
-
-    SEQAN_ASSERT(_compareBinaryFiles(toCString(outPath), toCString(baiFilename)));
+    SEQAN_ASSERT(save(baiIndex, toCString(tmpOutPath)));
+    
+    SEQAN_ASSERT(_compareBinaryFiles(toCString(tmpOutPath), toCString(baiFilename)));
 }
+
 
 #endif  // TESTS_BAM_IO_TEST_BAM_INDEX_H_

--- a/tests/bam_io/test_bam_io.cpp
+++ b/tests/bam_io/test_bam_io.cpp
@@ -177,6 +177,7 @@ SEQAN_BEGIN_TESTSUITE(test_bam_io)
 
     // Test BAM indices.
     SEQAN_CALL_TEST(test_bam_io_bam_index_bai);
+    SEQAN_CALL_TEST(test_bam_io_bam_index_write_bai);
 #endif
 }
 SEQAN_END_TESTSUITE

--- a/tests/bam_io/test_bam_io.cpp
+++ b/tests/bam_io/test_bam_io.cpp
@@ -176,8 +176,10 @@ SEQAN_BEGIN_TESTSUITE(test_bam_io)
     SEQAN_CALL_TEST(test_bam_io_sam_file_issue_489);
 
     // Test BAM indices.
-    SEQAN_CALL_TEST(test_bam_io_bam_index_bai);
-    SEQAN_CALL_TEST(test_bam_io_bam_index_write_bai);
+    SEQAN_CALL_TEST(test_bam_io_bam_index_save);
+//  TODO(dadi): uncomment when BamIndex.build index is fixed
+//    SEQAN_CALL_TEST(test_bam_io_bam_index_build);
+    SEQAN_CALL_TEST(test_bam_io_bam_index_open);
 #endif
 }
 SEQAN_END_TESTSUITE


### PR DESCRIPTION
This Fixes #1081
Tests added for BamIndex, _saveIndex() changed to save() and BuildIndex() changed to build()