### PR TITLE
[FIX] many warnings on newer compilers

### DIFF
--- a/include/seqan/basic/basic_exception.h
+++ b/include/seqan/basic/basic_exception.h
@@ -368,14 +368,8 @@ inline static void globalExceptionHandler()
     }
 }
 
-#ifdef __GNUC__
-#define IGNORE_WARNING __attribute__ ((unused))
-#else
-#define IGNORE_WARNING
-#endif
-
 // Install global exception handler.
-static const std::terminate_handler IGNORE_WARNING _globalExceptionHandler = std::set_terminate(globalExceptionHandler);
+static const std::terminate_handler SEQAN_UNUSED _globalExceptionHandler = std::set_terminate(globalExceptionHandler);
 
 #endif  // #if defined(SEQAN_EXCEPTIONS) && defined(SEQAN_GLOBAL_EXCEPTION_HANDLER)
 

--- a/include/seqan/basic/basic_exception.h
+++ b/include/seqan/basic/basic_exception.h
@@ -352,11 +352,6 @@ struct AssertFunctor
 
 #if defined(SEQAN_EXCEPTIONS) && defined(SEQAN_GLOBAL_EXCEPTION_HANDLER)
 // Declare global exception handler.
-static void globalExceptionHandler();
-
-// Install global exception handler.
-static const std::terminate_handler _globalExceptionHandler = std::set_terminate(globalExceptionHandler);
-
 inline static void globalExceptionHandler()
 {
     SEQAN_TRY
@@ -372,6 +367,16 @@ inline static void globalExceptionHandler()
         SEQAN_FAIL("Uncaught exception of unknown type.\n");
     }
 }
+
+#ifdef __GNUC__
+#define IGNORE_WARNING __attribute__ ((unused))
+#else
+#define IGNORE_WARNING
+#endif
+
+// Install global exception handler.
+static const std::terminate_handler IGNORE_WARNING _globalExceptionHandler = std::set_terminate(globalExceptionHandler);
+
 #endif  // #if defined(SEQAN_EXCEPTIONS) && defined(SEQAN_GLOBAL_EXCEPTION_HANDLER)
 
 }  // namespace seqan

--- a/include/seqan/basic/concept_checking.h
+++ b/include/seqan/basic/concept_checking.h
@@ -73,15 +73,6 @@ namespace seqan {
 #  define SEQAN_STATIC_ASSERT_BOOL_CAST(x) (bool)(x)
 //#endif
 
-//
-// If the compiler warns about unused typedefs then enable this:
-//
-#if (defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)))) || defined(__clang__)
-#  define SEQAN_STATIC_ASSERT_UNUSED_ATTRIBUTE __attribute__((unused))
-#else
-#  define SEQAN_STATIC_ASSERT_UNUSED_ATTRIBUTE
-#endif
-
 #ifdef SEQAN_CXX11_STANDARD
 #  define SEQAN_STATIC_ASSERT( B ) static_assert(B, #B)
 #else
@@ -160,7 +151,7 @@ template<int x> struct static_assert_test{};
 #define SEQAN_STATIC_ASSERT( B ) \
    typedef static_assert_test<\
       sizeof(STATIC_ASSERTION_FAILURE< SEQAN_STATIC_ASSERT_BOOL_CAST( B ) >)>\
-         SEQAN_JOIN(seqan_static_assert_typedef_, __LINE__) SEQAN_STATIC_ASSERT_UNUSED_ATTRIBUTE
+         SEQAN_JOIN(seqan_static_assert_typedef_, __LINE__) SEQAN_UNUSED
 #endif
 /*
 #else
@@ -232,7 +223,7 @@ struct concept_check_<void(*)(Model)>
 #  define SEQAN_CONCEPT_ASSERT_FN( ModelFnPtr )             \
     typedef seqan::detail::instantiate<          \
     &seqan::requirement_<ModelFnPtr>::failed>    \
-      SEQAN_PP_CAT(seqan_concept_check,__LINE__) SEQAN_STATIC_ASSERT_UNUSED_ATTRIBUTE
+      SEQAN_PP_CAT(seqan_concept_check,__LINE__) SEQAN_UNUSED
 
 // ---------------------------------------------------------------------------
 // ==> boost/concept/assert.hpp <==
@@ -429,7 +420,7 @@ struct requirement_<void(*)(Model)>
 #  define SEQAN_CONCEPT_ASSERT_FN( ModelFnPtr )             \
     typedef seqan::detail::instantiate<          \
     &seqan::requirement_<ModelFnPtr>::failed>    \
-      SEQAN_PP_CAT(seqan_concept_check,__LINE__) SEQAN_STATIC_ASSERT_UNUSED_ATTRIBUTE
+      SEQAN_PP_CAT(seqan_concept_check,__LINE__) SEQAN_UNUSED
 
 // ---------------------------------------------------------------------------
 // ==> boost/concept_check/detail/requires.hpp <==

--- a/include/seqan/basic/concept_checking.h
+++ b/include/seqan/basic/concept_checking.h
@@ -76,7 +76,7 @@ namespace seqan {
 //
 // If the compiler warns about unused typedefs then enable this:
 //
-#if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)))
+#if (defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)))) || defined(__clang__)
 #  define SEQAN_STATIC_ASSERT_UNUSED_ATTRIBUTE __attribute__((unused))
 #else
 #  define SEQAN_STATIC_ASSERT_UNUSED_ATTRIBUTE

--- a/include/seqan/basic/debug_test_system.h
+++ b/include/seqan/basic/debug_test_system.h
@@ -346,6 +346,16 @@ inline const char * toCString(Demangler<T> const & me)
 #define SEQAN_ENABLE_CHECKPOINTS 0 // SEQAN_ENABLE_TESTING
 #endif  // #ifndef SEQAN_ENABLE_CHECKPOINTS
 
+#if (defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)))) || defined(__clang__)
+#  define SEQAN_UNUSED __attribute__((unused))
+#else
+#  define SEQAN_UNUSED
+#endif
+
+// backwards compatibility
+#define SEQAN_UNUSED_TYPEDEF SEQAN_UNUSED
+
+
 /*!
  * @macro TestSystemMacros#SEQAN_TYPEDEF_FOR_DEBUG
  * @headerfile <seqan/basic.h>
@@ -361,20 +371,9 @@ inline const char * toCString(Demangler<T> const & me)
  */
 
 #if !SEQAN_ENABLE_DEBUG
-#  if (defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)))) || defined(__clang__)
-#    define SEQAN_TYPEDEF_FOR_DEBUG __attribute__((unused))
-#  else
-#    define SEQAN_TYPEDEF_FOR_DEBUG
-#  endif
+#define SEQAN_TYPEDEF_FOR_DEBUG SEQAN_UNUSED
 #else
-#  define SEQAN_TYPEDEF_FOR_DEBUG
-#endif
-
-// TODO(holtgrew): This one is for profiling and in tests.
-#if (defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)))) || defined(__clang__)
-#  define SEQAN_UNUSED_TYPEDEF __attribute__((unused))
-#else
-#  define SEQAN_UNUSED_TYPEDEF
+#define SEQAN_TYPEDEF_FOR_DEBUG
 #endif
 
 namespace seqan {

--- a/include/seqan/basic/debug_test_system.h
+++ b/include/seqan/basic/debug_test_system.h
@@ -346,16 +346,6 @@ inline const char * toCString(Demangler<T> const & me)
 #define SEQAN_ENABLE_CHECKPOINTS 0 // SEQAN_ENABLE_TESTING
 #endif  // #ifndef SEQAN_ENABLE_CHECKPOINTS
 
-#if (defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)))) || defined(__clang__)
-#  define SEQAN_UNUSED __attribute__((unused))
-#else
-#  define SEQAN_UNUSED
-#endif
-
-// backwards compatibility
-#define SEQAN_UNUSED_TYPEDEF SEQAN_UNUSED
-
-
 /*!
  * @macro TestSystemMacros#SEQAN_TYPEDEF_FOR_DEBUG
  * @headerfile <seqan/basic.h>

--- a/include/seqan/basic/debug_test_system.h
+++ b/include/seqan/basic/debug_test_system.h
@@ -361,7 +361,7 @@ inline const char * toCString(Demangler<T> const & me)
  */
 
 #if !SEQAN_ENABLE_DEBUG
-#  if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)))
+#  if (defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)))) || defined(__clang__)
 #    define SEQAN_TYPEDEF_FOR_DEBUG __attribute__((unused))
 #  else
 #    define SEQAN_TYPEDEF_FOR_DEBUG
@@ -371,7 +371,7 @@ inline const char * toCString(Demangler<T> const & me)
 #endif
 
 // TODO(holtgrew): This one is for profiling and in tests.
-#if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)))
+#if (defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)))) || defined(__clang__)
 #  define SEQAN_UNUSED_TYPEDEF __attribute__((unused))
 #else
 #  define SEQAN_UNUSED_TYPEDEF

--- a/include/seqan/platform.h
+++ b/include/seqan/platform.h
@@ -97,4 +97,13 @@
 #define SEQAN_UNLIKELY(x) (x)
 #endif
 
+// A macro to eliminate warnings on GCC and Clang
+#if (defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)))) || defined(__clang__)
+#  define SEQAN_UNUSED __attribute__((unused))
+#else
+#  define SEQAN_UNUSED
+#endif
+// backwards compatibility
+#define SEQAN_UNUSED_TYPEDEF SEQAN_UNUSED
+
 #endif


### PR DESCRIPTION
fixes many warnings on newer gcc and clang. Note that I think it is kind of a mess that we have the same typedef for `__attribute__ ((unused))` defined so many times, but oh well.