### PR TITLE
Hotfix/win build warnings develop

### DIFF
--- a/util/cmake/FindSeqAn.cmake
+++ b/util/cmake/FindSeqAn.cmake
@@ -201,7 +201,7 @@ endif ()
 if (WIN32)
   # Always set NOMINMAX such that <Windows.h> does not define min/max as
   # macros.
-  add_definitions (-DNOMINMAX)
+  set (SEQAN_CXX_FLAGS "${SEQAN_CXX_FLAGS} -DNOMINMAX")
 endif (WIN32)
 
 # Visual Studio Setup
@@ -214,11 +214,17 @@ if (MSVC)
   # TODO(holtgrew): This rather belongs into the SeqAn build system and notso much into FindSeqAn.cmake.
 
   # Force to always compile with W2.
-  # add_definitions (/W2)
-  set (SEQAN_CXX_FLAGS "${SEQAN_CXX_FLAGS} /W2")
+  # Use the /W2 warning level for visual studio.
+  SET(CMAKE_CXX_WARNING_LEVEL 2)
+  if (CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
+    STRING (REGEX REPLACE "/W[0-4]"
+            "/W2" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+  else (CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
+    set (SEQAN_CXX_FLAGS "${SEQAN_CXX_FLAGS} /W2")
+  endif (CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
 
   # Disable warnings about unsecure (although standard) functions.
-  add_definitions (-D_SCL_SECURE_NO_WARNINGS)
+  set (SEQAN_CXX_FLAGS "${SEQAN_CXX_FLAGS} /D_SCL_SECURE_NO_WARNINGS")
 endif (MSVC)
 
 # ----------------------------------------------------------------------------

--- a/util/cmake/SeqAnBuildSystem.cmake
+++ b/util/cmake/SeqAnBuildSystem.cmake
@@ -572,11 +572,11 @@ endmacro (_seqan_setup_demo_test CPP_FILE)
 
 # Install all demo source files.
 macro (seqan_install_demos_release)
-    # Set flags for SeqAn.
-    set (SEQAN_FIND_ENABLE_TESTING 0)
-    set (CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -DSEQAN_ENABLE_DEBUG=0")
-    set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DSEQAN_ENABLE_DEBUG=0")
-    set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DSEQAN_ENABLE_DEBUG=1")
+    # Set flags for SeqAn. Use PARENT_SCOPE since it is called from within a function.
+    set (SEQAN_FIND_ENABLE_TESTING 0 PARENT_SCOPE)
+    set (CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -DSEQAN_ENABLE_DEBUG=0" PARENT_SCOPE)
+    set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DSEQAN_ENABLE_DEBUG=0" PARENT_SCOPE)
+    set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DSEQAN_ENABLE_DEBUG=1" PARENT_SCOPE)
 
     # Get a list of all .cpp and .cu files in the current directory.
     file (GLOB_RECURSE ENTRIES
@@ -622,9 +622,8 @@ macro (seqan_build_demos_develop PREFIX)
     seqan_setup_cuda_vars(ARCH sm_20 DEBUG_DEVICE DISABLE_WARNINGS)
 
     # Add SeqAn flags to CXX and NVCC flags.
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SEQAN_CXX_FLAGS} ${CXX11_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-    #NOTE(h-2): it is not clear, why the flags have to be added to the defs, but they are not included otherwise
-    add_definitions(${CMAKE_CXX_FLAGS})
+    # Set to PARENT_SCOPE since this macro is executed from within a function which declares it's own scope.
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SEQAN_CXX_FLAGS} ${CXX11_CXX_FLAGS} ${OpenMP_CXX_FLAGS}" PARENT_SCOPE)
 
     # Add all demos with found flags in SeqAn.
     foreach (ENTRY ${ENTRIES})


### PR DESCRIPTION
Replaces #1216 which could not be merged since there were some changes in develop not made for master, causing this merge conflict.
I know branched off of develop and merged the changes from #1214 into it.
So the state of master and develop after merging both should be the same again.