### PR TITLE
[FIX] segfault for iupac assignment in dna5 stringset

### DIFF
--- a/apps/gustaf/stellar_routines.h
+++ b/apps/gustaf/stellar_routines.h
@@ -625,7 +625,7 @@ _importSequences(CharString const & fileName,
         return false;
     }
 
-    TSequence seq;
+    String<Iupac> seq;
     TId id;
     TId sId;
     unsigned seqCount = 0;


### PR DESCRIPTION
Fixes segmentation fault when reading a Iupac sequence into a Dna5 StringSet.