### PR TITLE
TravisCI: consider warnings as errors

### DIFF
--- a/util/travis/linux-cibuild.cmake
+++ b/util/travis/linux-cibuild.cmake
@@ -20,12 +20,8 @@ file(WRITE "${CTEST_BINARY_DIRECTORY}/CMakeCache.txt" ${INITIAL_CACHE})
 set(CTEST_CUSTOM_MAXIMUM_NUMBER_OF_ERRORS 1000)
 set(CTEST_CUSTOM_MAXIMUM_NUMBER_OF_WARNINGS 1000)
 
-# try to speed up the builds so we don't get killed
-if ("$ENV{CXX}" MATCHES ".*(clang\\+\\+-?.*)")
-  set(CTEST_BUILD_FLAGS -j6)
-else ("$ENV{CXX}" MATCHES ".*(clang\\+\\+-?.*)")
-  set(CTEST_BUILD_FLAGS -j4)
-endif ("$ENV{CXX}" MATCHES ".*(clang\\+\\+-?.*)")
+# Use 4 build threads
+set(CTEST_BUILD_FLAGS -j4)
 
 # we want makefiles
 set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
@@ -40,13 +36,13 @@ CONFIGURE_FILE (${CTEST_SOURCE_DIRECTORY}/util/cmake/CTestConfig.cmake
 # run the classical ctest suite without update
 # travis-ci handles this for us
 ctest_start     (Continuous)
-
 ctest_configure (BUILD "${CTEST_BINARY_DIRECTORY}" RETURN_VALUE _configure_ret)
-ctest_build     (BUILD "${CTEST_BINARY_DIRECTORY}" NUMBER_ERRORS _build_errors)
-ctest_test      (BUILD "${CTEST_BINARY_DIRECTORY}" PARALLEL_LEVEL 8)
+ctest_build     (BUILD "${CTEST_BINARY_DIRECTORY}" NUMBER_ERRORS _build_errors
+                                                   NUMBER_WARNINGS _build_warnings)
+ctest_test      (BUILD "${CTEST_BINARY_DIRECTORY}" PARALLEL_LEVEL 4)
 ctest_submit()
 
 # indicate errors
-if(${_build_errors} GREATER 0 OR NOT ${_configure_ret} EQUAL 0)
+if (${_build_errors} GREATER 0 OR ${_build_warnings} GREATER 0 OR NOT ${_configure_ret} EQUAL 0)
   file(WRITE "$ENV{SOURCE_DIRECTORY}/failed" "build_failed")
-endif()
+endif ()


### PR DESCRIPTION
And always use 4 build/test threads.