### PR TITLE
[FIX] adapter iterator for const strings

### DIFF
--- a/include/seqan/basic/iterator_adapt_std.h
+++ b/include/seqan/basic/iterator_adapt_std.h
@@ -158,13 +158,13 @@ public:
     // Pointer Operators;  Have to be defined within class.
     // ------------------------------------------------------------------------
 
-    typename Value<Iter>::Type *
+    typename std::iterator_traits<TIterator>::pointer
     operator->()
     {
         return &*data_iterator;
     }
 
-    typename Value<Iter>::Type const *
+    typename std::iterator_traits<TIterator>::pointer const
     operator->() const
     {
         return &*data_iterator;


### PR DESCRIPTION
previously the functions below returned Value* even if the container was const. The change directly makes dereferenciation go over the type that was defined for it instead of trying to use Value<>.