### PR TITLE
[INTERNAL] for compatibility with bam io we need numerical IDs

### DIFF
--- a/include/seqan/blast/blast_record.h
+++ b/include/seqan/blast/blast_record.h
@@ -80,6 +80,10 @@ struct BlastMatch
     typedef TQId_ TQId;
     typedef TSId_ TSId;
 
+    // internal use numerical ids
+    __uint32 _n_qId;
+    __uint32 _n_sId;
+
     /*!
      * @var TQId BlastMatch::qId;
      * @brief The verbose Id of the query.


### PR DESCRIPTION
these are now required for Lambda, so that Lambda can work with bam io.