### PR TITLE
[FIX] Addition to StringSet: add insertValue, insert, replace #1297

### DIFF
--- a/tests/sequence/test_string_set.h
+++ b/tests/sequence/test_string_set.h
@@ -1614,10 +1614,6 @@ SEQAN_TYPED_TEST(StringSetTestCommon, Insert)
 }
 
 // Test of insertValue().
-// this should work, but doesnt
-template <typename TSpec>
-void testStringSetInsertValue(StringSet<String<short, Packed<TSpec> >, Owner<ConcatDirect<> > > & /*Tag*/) {}
-
 template <typename TStringSet>
 void testStringSetInsertValue(TStringSet & /*Tag*/)
 {
@@ -1630,7 +1626,7 @@ void testStringSetInsertValue(TStringSet & /*Tag*/)
     resize(stringSet, 1u);
     insertValue(stringSet, 0, "ACGT");
     SEQAN_ASSERT_EQ(length(stringSet), 2u);
-    SEQAN_ASSERT_EQ(TString(stringSet[0]), TString("ACGT"));
+    SEQAN_ASSERT_EQ(stringSet[0], TString("ACGT"));
     SEQAN_ASSERT_EQ(stringSet[1], TString());
 }
 


### PR DESCRIPTION
readded test of String<short, Packed<> > on a ConcatDirect-Stringset. Test does not fail anymore because the double conversion to TString was removed.