### PR TITLE
[FIX] Fixes MSVS build warnings for stringset v2 test.

### DIFF
--- a/tests/sequence/test_string_set.h
+++ b/tests/sequence/test_string_set.h
@@ -1626,8 +1626,8 @@ void testStringSetInsertValue(TStringSet & /*Tag*/)
     resize(stringSet, 1u);
     insertValue(stringSet, 0, "ACGT");
     SEQAN_ASSERT_EQ(length(stringSet), 2u);
-    SEQAN_ASSERT_EQ(stringSet[0], TString("ACGT"));
-    SEQAN_ASSERT_EQ(stringSet[1], TString());
+    SEQAN_ASSERT(stringSet[0] == TString("ACGT"));
+    SEQAN_ASSERT(stringSet[1] == TString());
 }
 
 SEQAN_TYPED_TEST(StringSetTestCommon, InsertValue)


### PR DESCRIPTION
Replaces SEQAN_ASSERT_EQ with SEQAN_ASSERT to remove compiler warnings under MSVS.