### PR TITLE
Correction of CIGAR example

### DIFF
--- a/manual/source/Tutorial/PairwiseSequenceAlignment.rst
+++ b/manual/source/Tutorial/PairwiseSequenceAlignment.rst
@@ -593,7 +593,7 @@ Assignment 5
 
           ref: AC--GTCATTT
           r01: ACGTCTCA---
-          Cigar of r01: 2M2I1S3M3D
+          Cigar of r01: 2M2I1X3M3D
 
     Solution (Step 1)
       .. container:: foldable


### PR DESCRIPTION
According to the definition, S stands for "soft-clipping" and X stands for "mismatch".
So "S" in the CIGAR string in ParwiseSequenceAlignment should be changed to "X".

This will fix #1309 .


