### PR TITLE
[FIX] detect c++11 for demos on master, too

### DIFF
--- a/util/cmake/SeqAnBuildSystem.cmake
+++ b/util/cmake/SeqAnBuildSystem.cmake
@@ -604,6 +604,7 @@ macro (seqan_build_demos_develop PREFIX)
     # Find SeqAn with all dependencies.
     set (SEQAN_FIND_DEPENDENCIES ALL)
     find_package (SeqAn REQUIRED)
+    find_package (CXX11)
 
     # Setup include directories and definitions for SeqAn; flags follow below.
     include_directories (${SEQAN_INCLUDE_DIRS})


### PR DESCRIPTION
we only had this in develop. It could cause a situation where some demos failed on gcc-5, where the compilers default defines lead to SEQAN_CXX11_STANDARD being defined, but our custom CXX11_CXX_FLAGS where not set in time, so some demos *thought* they had c++11, while they did not.
I am not sure why we did not see this on cdash, maybe due to differences in the build config, or because something changed between gcc-5.2 and gcc-5.3