### PR TITLE
[FIX] Asserts wrong use of scoring scheme for Hirschberg algorithm.

### DIFF
--- a/include/seqan/align/global_alignment_specialized.h
+++ b/include/seqan/align/global_alignment_specialized.h
@@ -60,25 +60,27 @@ namespace seqan {
 // Function globalAlignment()                                      [Hirschberg]
 // ----------------------------------------------------------------------------
 
-template <typename TSequence, typename TAlignSpec,
-          typename TScoreValue, typename TScoreSpec>
-TScoreValue globalAlignment(Align<TSequence, TAlignSpec> & align,
-                            Score<TScoreValue, TScoreSpec> const & scoringScheme,
-                            Hirschberg const & algorithmTag)
-{
-    SEQAN_ASSERT_EQ(length(rows(align)), 2u);
-    return _globalAlignment(row(align, 0), row(align, 1), scoringScheme, algorithmTag);
-}
-
 template <typename TSequenceH, typename TGapsSpecH,
           typename TSequenceV, typename TGapsSpecV,
-          typename TScoreValue, typename TScoreSpec>
+          typename TScoreValue>
 TScoreValue globalAlignment(Gaps<TSequenceH, TGapsSpecH> & gapsH,
                             Gaps<TSequenceV, TGapsSpecV> & gapsV,
-                            Score<TScoreValue, TScoreSpec> const & scoringScheme,
-                            Hirschberg const & algorithmTag)
+                            Score<TScoreValue, Simple> const & scoringScheme,
+                            Hirschberg const & /*algorithmTag*/)
 {
-    return _globalAlignment(gapsH, gapsV, scoringScheme, algorithmTag);
+    SEQAN_ASSERT_EQ(scoreGapOpen(scoringScheme), scoreGapExtend(scoringScheme));
+    return _globalAlignment(gapsH, gapsV, scoringScheme, Hirschberg());
+}
+
+template <typename TSequence, typename TAlignSpec,
+typename TScoreValue>
+TScoreValue globalAlignment(Align<TSequence, TAlignSpec> & align,
+                            Score<TScoreValue, Simple> const & scoringScheme,
+                            Hirschberg const & /*algorithmTag*/)
+{
+    SEQAN_ASSERT_EQ(length(rows(align)), 2u);
+
+    return globalAlignment(row(align, 0), row(align, 1), scoringScheme, Hirschberg());
 }
 
 // ----------------------------------------------------------------------------
@@ -129,10 +131,10 @@ int globalAlignment(Gaps<TSequenceH, TGapsSpecH> & gapsH,
 
 template <typename TAlphabetH, typename TSpecH,
           typename TAlphabetV, typename TSpecV,
-          typename TScoreValue, typename TScoreSpec>
+          typename TScoreValue>
 TScoreValue globalAlignmentScore(String<TAlphabetH, TSpecH> const & seqH,
                                  String<TAlphabetV, TSpecV> const & seqV,
-                                 Score<TScoreValue, TScoreSpec> const & scoringScheme,
+                                 Score<TScoreValue, Simple> const & scoringScheme,
                                  Hirschberg const & algorithmTag)
 {
     Gaps<String<TAlphabetH, TSpecH> const, ArrayGaps> gapsH(seqH);


### PR DESCRIPTION
Requires scoring scheme Simple for Hirschberg algorithm and asserts if affine gap costs are used.