### PR TITLE
[FIX] Replace spaces with underscores (ICC related)

### DIFF
--- a/util/cmake/ctd/configure_profile_properties.cmake
+++ b/util/cmake/ctd/configure_profile_properties.cmake
@@ -2,7 +2,7 @@
 message(STATUS "SEQAN_SOURCE_DIR ${SEQAN_SOURCE_DIR}")
 message(STATUS "SEQAN_DATE ${SEQAN_DATE}")
 if (SEQAN_DATE)
-	string(REGEX REPLACE "^([0-9]+)-([0-9]+)-([0-9]+) ([0-9]+):([0-9]+).*"
+	string(REGEX REPLACE "^([0-9]+)-([0-9]+)-([0-9]+)_([0-9]+):([0-9]+).*"
     "\\1\\2\\3\\4\\5" SEQAN_LAST_CHANGED_DATE "${SEQAN_DATE}")
   set (CF_SEQAN_VERSION ${SEQAN_VERSION_STRING}.${SEQAN_LAST_CHANGED_DATE})
 else ()


### PR DESCRIPTION
This accounts for the changes made by #1296. 
Teh new ${SEQAN_DATE} is delimited by underscore instead of space. The change is made to accommodate this.