### PR TITLE
[FIXED-#159] Allows BamTagsDict to take const CharString as argument.

### DIFF
--- a/include/seqan/bam_io/bam_tags_dict.h
+++ b/include/seqan/bam_io/bam_tags_dict.h
@@ -122,7 +122,7 @@ class BamTagsDict
 {
 public:
     typedef Host<BamTagsDict>::Type TBamTagsSequence;
-    typedef typename RemoveConst<TBamTagsSequence>::Type TBamTagsSeqNonConst;
+    typedef RemoveConst<TBamTagsSequence>::Type TBamTagsSeqNonConst;
     typedef Position<TBamTagsSequence>::Type TPos;
 
     Holder<TBamTagsSequence> _host;

--- a/include/seqan/bam_io/bam_tags_dict.h
+++ b/include/seqan/bam_io/bam_tags_dict.h
@@ -881,7 +881,7 @@ eraseTag(BamTagsDict & tags, TId const & id)
 
 /*!
  * @fn BamTagsDict#tagsToBamRecord
- * @brief Writes the .
+ * @brief Writes bam tags to the <tt>tags</tt> field of the given @link BamAlignmentRecord @endlink.
  *
  * @signature void tagsToBamRecord(record, tagsDict)
  *

--- a/include/seqan/bam_io/bam_tags_dict.h
+++ b/include/seqan/bam_io/bam_tags_dict.h
@@ -122,6 +122,7 @@ class BamTagsDict
 {
 public:
     typedef Host<BamTagsDict>::Type TBamTagsSequence;
+    typedef typename RemoveConst<TBamTagsSequence>::Type TBamTagsSeqNonConst;
     typedef Position<TBamTagsSequence>::Type TPos;
 
     Holder<TBamTagsSequence> _host;
@@ -130,7 +131,10 @@ public:
     BamTagsDict() {}
 
     explicit
-    BamTagsDict(TBamTagsSequence & tags) : _host(tags) {}
+    BamTagsDict(TBamTagsSeqNonConst & tags) : _host(tags) {}
+
+    explicit
+    BamTagsDict(TBamTagsSeqNonConst const & tags) : _host(tags) {}
 
     template <typename TPos>
     inline Infix<Host<BamTagsDict const>::Type>::Type

--- a/tests/bam_io/test_bam_io.cpp
+++ b/tests/bam_io/test_bam_io.cpp
@@ -143,6 +143,7 @@ SEQAN_BEGIN_TESTSUITE(test_bam_io)
     SEQAN_CALL_TEST(test_bam_tags_dict_erase_tag);
     SEQAN_CALL_TEST(test_bam_tags_dict_set_tag_value);
     SEQAN_CALL_TEST(test_bam_tags_dict_append_tag_value);
+    SEQAN_CALL_TEST(test_bam_tags_dict_const_bam_tags_sequence);
     
     // Test SAM I/O.
     SEQAN_CALL_TEST(test_bam_io_sam_read_header);

--- a/tests/bam_io/test_bam_tags_dict.h
+++ b/tests/bam_io/test_bam_tags_dict.h
@@ -573,4 +573,32 @@ SEQAN_DEFINE_TEST(test_bam_tags_dict_erase_tag)
     }
 }
 
+SEQAN_DEFINE_TEST(test_bam_tags_dict_const_bam_tags_sequence)
+{
+    using namespace seqan;
+    CharString bamStr, samStr = "AA:Z:value1\tAB:Z:value2\tAC:i:30";
+    assignTagsSamToBam(bamStr, samStr);
+
+    CharString const bamStrConst = bamStr;
+
+    BamTagsDict tagsNonConst(bamStr);
+    BamTagsDict tagsConst(bamStrConst);
+
+    buildIndex(tagsNonConst);
+    buildIndex(tagsConst);
+
+    SEQAN_ASSERT(host(tagsConst) == host(tagsNonConst));
+    appendTagValue(tagsConst, "AS", 10, 'i');
+    SEQAN_ASSERT(bamStr != host(tagsConst));
+
+    appendTagValue(tagsNonConst, "AS", 10, 'i');
+    SEQAN_ASSERT(bamStr == host(tagsConst));
+
+    unsigned tagId;
+    SEQAN_ASSERT(findTagKey(tagId, tagsConst, "AS"));
+    SEQAN_ASSERT(tagId == 3u);
+    SEQAN_ASSERT(findTagKey(tagId, tagsNonConst, "AS"));
+    SEQAN_ASSERT(tagId == 3u);
+}
+
 #endif  // TESTS_BAM_IO_TEST_BAM_TAGS_DICT_DICT_H_


### PR DESCRIPTION
# Fixes #159

*  Adds constructor which takes const argument.
*  Fixes incomplete dox entry.