### PR TITLE
[FIX] fixes wrong file extensions eg .fasta.bam 

### DIFF
--- a/include/seqan/bam_io/read_bam.h
+++ b/include/seqan/bam_io/read_bam.h
@@ -97,6 +97,7 @@ readHeader(BamHeader & header,
            Bam const & /*tag*/)
 {
     clear(header);
+    FileExtensions<BgzfFile>::VALUE[0] = ".bam";
     // Read BAM magic string.
     String<char, Array<4> > magic;
     read(magic, iter, 4);

--- a/include/seqan/stream/formatted_file.h
+++ b/include/seqan/stream/formatted_file.h
@@ -354,7 +354,7 @@ struct FormattedFile
 
         _getCompressionExtensions(extensions,
                                   TFileFormats(),
-                                  CompressedFileTypesWithoutBgzf_(),
+                                  CompressedFileTypes(),
                                   false);
         return extensions;
     }

--- a/include/seqan/stream/formatted_file.h
+++ b/include/seqan/stream/formatted_file.h
@@ -840,7 +840,7 @@ _getCompressionExtensions(
     typedef Tag<TFormat_> TFormat;
 
     std::vector<std::string> compressionExtensions;
-    _getFileExtensions(compressionExtensions, compress, primaryExtensionOnly);
+    _getFileExtensions(compressionExtensions, compress, true);
 
     unsigned len = (primaryExtensionOnly)? 1 : sizeof(FileExtensions<TFormat>::VALUE) / sizeof(char*);
     for (unsigned i = 0; i < len; ++i)

--- a/include/seqan/stream/stream_base.h
+++ b/include/seqan/stream/stream_base.h
@@ -134,15 +134,13 @@ char const * FileExtensions<GZFile, T>::VALUE[1] =
 template <typename T>
 struct FileExtensions<BgzfFile, T>
 {
-    static char const * VALUE[2];
+    static char const * VALUE[1];
 };
 
 template <typename T>
-char const * FileExtensions<BgzfFile, T>::VALUE[2] =
+char const * FileExtensions<BgzfFile, T>::VALUE[1] =
 {
-    ".bgzf",      // default output extension
-    ".bam"        // BAM files are bgzf compressed
-
+    ".bgzf",      // default output extension will be changed to ".bam" in case of BAM files
     // if you add extensions here, extend getBasename() below
 };
 

--- a/include/seqan/stream/stream_base.h
+++ b/include/seqan/stream/stream_base.h
@@ -134,13 +134,15 @@ char const * FileExtensions<GZFile, T>::VALUE[1] =
 template <typename T>
 struct FileExtensions<BgzfFile, T>
 {
-    static char const * VALUE[1];
+    static char const * VALUE[2];
 };
 
 template <typename T>
-char const * FileExtensions<BgzfFile, T>::VALUE[1] =
+char const * FileExtensions<BgzfFile, T>::VALUE[2] =
 {
-    ".bgzf",      // default output extension will be changed to ".bam" in case of BAM files
+    ".bgzf",      // default output extension
+    ".bam"        // BAM files are bgzf compressed
+
     // if you add extensions here, extend getBasename() below
 };
 

--- a/include/seqan/stream/virtual_stream.h
+++ b/include/seqan/stream/virtual_stream.h
@@ -75,28 +75,6 @@ typedef
 #endif
     CompressedFileTypes;  // if TagSelector is set to -1, the file format is auto-detected
 
-// --------------------------------------------------------------------------
-// TagList CompressedFileTypes
-// --------------------------------------------------------------------------
-// NOTE(h-2): this currently lacks BGZF, so that we don't get .fasta.bam, .m8.bam ...
-// in the long term bgzf should just not contain .bam but that would require more changes
-
-typedef
-#if SEQAN_HAS_ZLIB
-    TagList<GZFile,
-#endif
-#if SEQAN_HAS_BZIP2
-    TagList<BZ2File,
-#endif
-    TagList<Nothing>
-#if SEQAN_HAS_BZIP2
-    >
-#endif
-#if SEQAN_HAS_ZLIB
-    >
-#endif
-    CompressedFileTypesWithoutBgzf_;
-
 // ============================================================================
 // Metafunctions
 // ============================================================================


### PR DESCRIPTION
- Removed wrong extensions like .fasta.bam
- Added bgzf compression for all file types.
- Done by reusing the .bgzf extension for BAM files

This fixes issue #1037 
