### PR TITLE
[FIX] fixes wrong file extensions eg .fasta.bam …

### DIFF
--- a/include/seqan/bam_io/bam_file.h
+++ b/include/seqan/bam_io/bam_file.h
@@ -359,24 +359,6 @@ writeRecords(FormattedFile<Bam, Output, TSpec> & file, TRecords const & records)
         write(file.iter, buffers[i]);
 }
 
-// ----------------------------------------------------------------------------
-// Function getFileExtensions()
-// ----------------------------------------------------------------------------
-// NOTE(h-2): this is overloaded so we get Bgzf in addition to other
-// compressions which is crucial for Bam
-
-template <typename TDirection, typename TSpec>
-static std::vector<std::string>
-getFileExtensions(FormattedFile<Bam, TDirection, TSpec> const &)
-{
-    std::vector<std::string> extensions;
-    _getCompressionExtensions(extensions,
-                              typename FormattedFile<Bam, TDirection, TSpec>::TFileFormats(),
-                              CompressedFileTypes(),
-                              false);
-    return extensions;
-}
-
 }  // namespace seqan
 
 #endif // SEQAN_BAM_IO_BAM_FILE_H_

--- a/include/seqan/stream/formatted_file.h
+++ b/include/seqan/stream/formatted_file.h
@@ -354,7 +354,7 @@ struct FormattedFile
 
         _getCompressionExtensions(extensions,
                                   TFileFormats(),
-                                  CompressedFileTypesWithoutBgzf_(),
+                                  CompressedFileTypes(),
                                   false);
         return extensions;
     }
@@ -840,7 +840,7 @@ _getCompressionExtensions(
     typedef Tag<TFormat_> TFormat;
 
     std::vector<std::string> compressionExtensions;
-    _getFileExtensions(compressionExtensions, compress, primaryExtensionOnly);
+    _getFileExtensions(compressionExtensions, compress, true);
 
     unsigned len = (primaryExtensionOnly)? 1 : sizeof(FileExtensions<TFormat>::VALUE) / sizeof(char*);
     for (unsigned i = 0; i < len; ++i)

--- a/include/seqan/stream/virtual_stream.h
+++ b/include/seqan/stream/virtual_stream.h
@@ -75,28 +75,6 @@ typedef
 #endif
     CompressedFileTypes;  // if TagSelector is set to -1, the file format is auto-detected
 
-// --------------------------------------------------------------------------
-// TagList CompressedFileTypes
-// --------------------------------------------------------------------------
-// NOTE(h-2): this currently lacks BGZF, so that we don't get .fasta.bam, .m8.bam ...
-// in the long term bgzf should just not contain .bam but that would require more changes
-
-typedef
-#if SEQAN_HAS_ZLIB
-    TagList<GZFile,
-#endif
-#if SEQAN_HAS_BZIP2
-    TagList<BZ2File,
-#endif
-    TagList<Nothing>
-#if SEQAN_HAS_BZIP2
-    >
-#endif
-#if SEQAN_HAS_ZLIB
-    >
-#endif
-    CompressedFileTypesWithoutBgzf_;
-
 // ============================================================================
 // Metafunctions
 // ============================================================================


### PR DESCRIPTION
 - Removed wrong extensions like .fasta.bam
 - Added bgzf compression for all file types.
 - Done by setting primaryExtensionOnly to true when looking for compression extensions
 - This fixes issue #1037