### PR TITLE
More compiler error/warning fixes for VS.

### DIFF
--- a/apps/stellar/stellar_extension.h
+++ b/apps/stellar/stellar_extension.h
@@ -762,7 +762,7 @@ _bestExtension(TInfix const & infH,
 template <typename TSource, typename TSpec1, typename TSpec2>
 void
 integrateAlign(Align<TSource, TSpec1> & align,
-			   Align<Segment<typename Infix<TSource>::Type, InfixSegment>, TSpec2> const & infixAlign) {
+			   Align<Segment<Segment<TSource, InfixSegment>, InfixSegment>, TSpec2> const & infixAlign) {
 	typedef typename Size<TSource>::Type TSize;
 	typedef typename Position<typename Row<Align<TSource, TSpec1> >::Type>::Type TPos;
 

--- a/include/seqan/basic/basic_simd_vector.h
+++ b/include/seqan/basic/basic_simd_vector.h
@@ -37,11 +37,15 @@
 #ifndef SEQAN_INCLUDE_SEQAN_BASIC_SIMD_VECTOR_H_
 #define SEQAN_INCLUDE_SEQAN_BASIC_SIMD_VECTOR_H_
 
-#ifdef __SSE4_1__
+#if defined(__SSE4_1__) || defined(__AVX__)
  #include <immintrin.h>
 #else
 // SSE4.1 or greater required
+#ifdef _MSC_VER
+ #pragma message("SSE4.1 instruction set not enabled")
+#else
  #warning "SSE4.1 instruction set not enabled"
+#endif  // _MSC_VER
 #endif
 
 

--- a/include/seqan/file/file_mapping.h
+++ b/include/seqan/file/file_mapping.h
@@ -730,7 +730,7 @@ unmapFileSegment(FileMapping<TSpec> &, void *addr, TSize size)
 
 #endif
     if (!result)
-        SEQAN_FAIL("unmapFileSegment(%x,%i) failed: \"%s\"", (unsigned long)addr, size, strerror(errno));
+        SEQAN_FAIL("unmapFileSegment(%x,%i) failed: \"%s\"", (__uint64)addr, size, strerror(errno));
     return result;
 }
 

--- a/tests/basic/CMakeLists.txt
+++ b/tests/basic/CMakeLists.txt
@@ -129,7 +129,8 @@ add_executable (
 target_link_libraries (test_basic_simd_vector ${SEQAN_LIBRARIES})
 
 if (MSVC)
-  SET (_FLAGS "/arch:SSE4")
+  # Disable vectorization support on windows for now.
+  # SET (_FLAGS "/arch:AVX")
 else (MSVC)
   SET (_FLAGS "-march=native")
   if (CMAKE_COMPILER_IS_GNUCXX)
@@ -141,9 +142,9 @@ else (MSVC)
       #endif ()
     endif (APPLE)
   endif (CMAKE_COMPILER_IS_GNUCXX)
+  SET_TARGET_PROPERTIES(test_basic_simd_vector PROPERTIES COMPILE_FLAGS ${_FLAGS})
 endif (MSVC)
 
-SET_TARGET_PROPERTIES(test_basic_simd_vector PROPERTIES COMPILE_FLAGS ${_FLAGS})
 
 # Add CXX flags found by find_package (SeqAn).
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SEQAN_CXX_FLAGS}")

--- a/tests/parallel/test_parallel_atomic_primitives.h
+++ b/tests/parallel/test_parallel_atomic_primitives.h
@@ -42,6 +42,7 @@
 #include <seqan/parallel.h>
 #include <seqan/random.h>
 
+
 template <typename T>
 void atomicIncTestImpl(T const &)
 {
@@ -50,9 +51,10 @@ void atomicIncTestImpl(T const &)
     T const ITERATIONS = 4 * 1024;
 
     T volatile x = 0;
+    
     SEQAN_OMP_PRAGMA(parallel for schedule(static, 1))
     for (int i = 0; i < static_cast<int>(ITERATIONS); ++i)
-        atomicInc(x);
+        seqan::atomicInc(x);
 
     SEQAN_ASSERT_EQ(x, ITERATIONS);
 }
@@ -167,6 +169,7 @@ SEQAN_DEFINE_TEST(test_parallel_atomic_inc)
     // Compare-And-Swap, also 64 bit CAS is not available on 32 bit Intel.
     atomicIncTestImpl(long());
     atomicIncTestImpl(SEQAN_ulong());
+    
 #if SEQAN_IS_64_BIT
     atomicIncTestImpl(__int64());
     atomicIncTestImpl(__uint64());


### PR DESCRIPTION
Fixes:
* warning about integrateAlign
* diable simd_vector tests on windows platforms and fixed #warning issue
* Fixes conversion error in file_mapping.h
* Fixes test for atomic primitives.