### PR TITLE
Add version selector in API doc. #1321

### DIFF
--- a/util/py_lib/seqan/dox/tpl/css/common.less.css
+++ b/util/py_lib/seqan/dox/tpl/css/common.less.css
@@ -1858,7 +1858,7 @@ html.list body {
 html.list:after {
   content: "";
   background-image: url(../img/list.png);
-  background-position: right bottom;
+  background-position: right 94%;
   background-repeat: no-repeat;
   background-size: 362px;
   background-color: #dad9dc;

--- a/util/py_lib/seqan/dox/tpl/js/version.js
+++ b/util/py_lib/seqan/dox/tpl/js/version.js
@@ -15,12 +15,11 @@ function addVersionSelection(arr)
     var version_div = document.createElement("div");
 
     version_select.setAttribute("id","version_select");
-    version_div.setAttribute("align","center");
-    version_div.appendChild(document.createElement("br"));
+    version_div.setAttribute("style","background:#dad9dc; vertical-align:middle; transparent:false; line-hieght:150px; width:100%; text-align:right; position:fixed; padding:10px; padding-right:20px; bottom:0px;");
     version_div.appendChild(document.createTextNode("Version: "));
     version_div.appendChild(version_select);
     document.body.appendChild(version_div);
-            
+           
     version_select.addEventListener("change", function(){changeVersion(this.id);}, false);
 
     // current selection is.. 

--- a/util/py_lib/seqan/dox/tpl/js/version.js
+++ b/util/py_lib/seqan/dox/tpl/js/version.js
@@ -25,7 +25,6 @@ function addVersionSelection(arr)
 
     // current selection is.. 
     cur_sel = window.location.pathname.split("/")[2];
-    cur_sel = "master"; // should be deleted
 
     for(i=0; i < arr.length; ++i)
     {

--- a/util/py_lib/seqan/dox/tpl/js/version.js
+++ b/util/py_lib/seqan/dox/tpl/js/version.js
@@ -1,0 +1,52 @@
+/* Jongkyu Kim (j.kim@fu-berlin.de), 2016.01.12 */
+DOCUMENT_URL = "http://docs.seqan.de/seqan/";
+VERSION_JSON_URL = "http://docs.seqan.de/version.php";
+
+function changeVersion(formid)
+{
+    var frm = document.getElementById(formid);
+    window.top.location.href = DOCUMENT_URL + frm.options[frm.selectedIndex].value;
+}    
+
+function addVersionSelection(arr)
+{
+    // add HTMLs 
+    var version_select = document.createElement("select");
+    var version_div = document.createElement("div");
+
+    version_select.setAttribute("id","version_select");
+    version_div.setAttribute("align","center");
+    version_div.appendChild(document.createElement("br"));
+    version_div.appendChild(document.createTextNode("Version: "));
+    version_div.appendChild(version_select);
+    document.body.appendChild(version_div);
+            
+    version_select.addEventListener("change", function(){changeVersion(this.id);}, false);
+
+    // current selection is.. 
+    cur_sel = window.location.pathname.split("/")[2];
+    cur_sel = "master"; // should be deleted
+
+    for(i=0; i < arr.length; ++i)
+    {
+        var op = document.createElement("option");
+        op.value = arr[i];
+        op.text = arr[i];
+        op.selected = ( arr[i] == cur_sel ) ? true : false;
+        version_select.add(op);
+    }
+}
+
+// get JSON data & add selection form
+var req = new XMLHttpRequest();
+req.open("GET", VERSION_JSON_URL, true);
+req.setRequestHeader("Content-type", "application/json");
+req.onreadystatechange = function()
+{
+    if( req.readyState == 4 && req.status == 200 )
+    {
+       var response = JSON.parse(req.responseText);
+        addVersionSelection(response); // add selection form
+    }
+}
+req.send();

--- a/util/py_lib/seqan/dox/tpl/list.html
+++ b/util/py_lib/seqan/dox/tpl/list.html
@@ -121,5 +121,15 @@
           </ol>
         </div>
     </div>
+
+    <!-- version selection -->
+    {% if development %}
+    <script type="text/javascript" charset="utf-8" src="../../util/py_lib/seqan/dox/tpl/js/version.js"></script>
+    {% endif %}
+
+    {% if not development %}
+    <script type="text/javascript" charset="utf-8" src="/js/version.js"></script>
+    {% endif %}
+ 
   </body>
 </html>

--- a/util/py_lib/seqan/dox/tpl/list.html
+++ b/util/py_lib/seqan/dox/tpl/list.html
@@ -121,15 +121,12 @@
           </ol>
         </div>
     </div>
-
     <!-- version selection -->
     {% if development %}
     <script type="text/javascript" charset="utf-8" src="../../util/py_lib/seqan/dox/tpl/js/version.js"></script>
     {% endif %}
-
     {% if not development %}
-    <script type="text/javascript" charset="utf-8" src="/js/version.js"></script>
+    <script type="text/javascript" charset="utf-8" src="js/version.js"></script>
     {% endif %}
- 
   </body>
 </html>


### PR DESCRIPTION
You can add a version selector in API doc. by simply adding 
<script type="text/javascript" charset="utf-8" src="js/version.js"></script>
Check http://docs.seqan.de/seqan/master_version_test/ as an example.

To do that, I made a .php script in the documenation server.

version.php : This will generate available versions in JSON format based on local directories. Check http://docs.seqan.de/version.php
