### PR TITLE
More VS fixes

### DIFF
--- a/demos/howto/using_zip_iterator.cpp
+++ b/demos/howto/using_zip_iterator.cpp
@@ -44,7 +44,7 @@ int main()
 {
     std::vector<int> vec = {10, 12, 14};
     DnaString str = "AGT";
-    std::array<float, 3> arr = { {3.14, 2.71, 1.41} };
+    std::array<double, 3> arr = { {3.14, 2.71, 1.41} };
 
     auto zipCont = makeZipView(vec, str, infix(str, 0, 3), arr, reverseString(str));
 

--- a/include/seqan/sequence/container_view_zip.h
+++ b/include/seqan/sequence/container_view_zip.h
@@ -277,13 +277,6 @@ struct Iterator<ContainerView<std::tuple<TContTypes...>, ZipContainer<TSpec> > c
  */
 
 // Helper function to create zipped view from container pack.
-template <typename... TContTypes, typename TSpec>
-inline ContainerView<std::tuple<typename std::remove_reference<TContTypes>::type...>, ZipContainer<TSpec> >
-makeZipView(TContTypes && ...contArgs,
-            TSpec const)
-{
-    return ContainerView<std::tuple<typename std::remove_reference<TContTypes>::type...>, ZipContainer<TSpec> >(std::forward<TContTypes>(contArgs)...);
-}
 
 template <typename... TContTypes>
 inline ContainerView<std::tuple<typename std::remove_reference<TContTypes>::type...>, ZipContainer<> >

--- a/tests/basic/test_basic_iterator.h
+++ b/tests/basic/test_basic_iterator.h
@@ -159,6 +159,42 @@ void resetCDStructStatics()
 // Tests
 // ==========================================================================
 
+// Disable for windows vs as the two-phase template lookup is broken. See the
+// following link http://stackoverflow.com/questions/6273176/what-exactly-is-broken-with-microsoft-visual-cs-two-phase-template-instanti
+#if !defined(PLATFORM_WINDOWS_VS)
+// --------------------------------------------------------------------------
+// Pointer adaptions to test the positional iterator.
+// --------------------------------------------------------------------------
+
+template <typename TValue, typename TPos>
+inline TValue &
+value(TValue * me,
+      TPos pos)
+{
+    SEQAN_CHECKPOINT;
+    return me[pos];
+}
+
+template <typename TValue, typename TPos, typename TValue2>
+inline void
+assignValue(TValue * me,
+            TPos pos,
+            TValue2 const & _value)
+{
+    SEQAN_CHECKPOINT;
+    seqan::assign(value(me, pos), _value);
+}
+
+template <typename TValue, typename TValue2, typename TPos>
+inline void
+moveValue(TValue * me,
+          TPos pos,
+          TValue2 const & _value)
+{
+    SEQAN_CHECKPOINT;
+    move(value(me, pos), _value);
+}
+#endif  // !defined(PLATFORM_WINDOWS_VS) 
 // --------------------------------------------------------------------------
 // Tests for Pointer Adaption to Iterator Concept
 // --------------------------------------------------------------------------

--- a/tests/basic/test_basic_iterator.h
+++ b/tests/basic/test_basic_iterator.h
@@ -160,39 +160,6 @@ void resetCDStructStatics()
 // ==========================================================================
 
 // --------------------------------------------------------------------------
-// Pointer adaptions to test the positional iterator.
-// --------------------------------------------------------------------------
-
-template <typename TValue, typename TPos>
-inline TValue &
-value(TValue * me,
-      TPos pos)
-{
-    SEQAN_CHECKPOINT;
-    return me[pos];
-}
-
-template <typename TValue, typename TValue2, typename TPos>
-inline void
-assignValue(TValue * me,
-            TPos pos,
-            TValue2 const & _value)
-{
-    SEQAN_CHECKPOINT;
-    seqan::assign(value(me, pos), _value);
-}
-
-template <typename TValue, typename TValue2, typename TPos>
-inline void
-moveValue(TValue * me,
-          TPos pos,
-          TValue2 const & _value)
-{
-    SEQAN_CHECKPOINT;
-    move(value(me, pos), _value);
-}
-
-// --------------------------------------------------------------------------
 // Tests for Pointer Adaption to Iterator Concept
 // --------------------------------------------------------------------------
 
@@ -1029,6 +996,7 @@ SEQAN_DEFINE_TEST(test_basic_iterator_position_transport_value)
         resetCDStructStatics();
 
         TIterator it(&values[0], 0);
+        
         assignValue(it, values[2]);
 
         SEQAN_ASSERT_EQ(it->copiedFrom, -1);


### PR DESCRIPTION
* Fixes compiler error for ```makeZipView```
* Fixes compiler error for test_basic_iteraor.
* Fixes compiler warning in demos: using_zip_iterator