### PR TITLE
[FIX] flexbar: Workaround for MSVC bug.

### DIFF
--- a/apps/seqan_flexbar/general_processing.h
+++ b/apps/seqan_flexbar/general_processing.h
@@ -132,18 +132,24 @@ void processN(TSeqs& seqs, TIds& ids, unsigned allowed, TSub substitute, General
     {                                   //integer necessary because unsigned would cause error after last iteration
         if (res[i] == -1)                //Placing all sequences/ids which shall be erased at the end of their container
         {
-            SEQAN_OMP_PRAGMA(parallel default(shared))
+            #if defined(_OPENMP)
+            #pragma omp parallel default(shared)
             {
-                SEQAN_OMP_PRAGMA(sections nowait)
+                #pragma omp sections nowait
                 {
-                    SEQAN_OMP_PRAGMA(section)     //distributing the swapping actions
+                    #pragma omp section     //distributing the swapping actions
                     swap(seqs[i], seqs[limit - ex - 1]);
-                    SEQAN_OMP_PRAGMA(section)
+                    #pragma omp section
                     swap(ids[i], ids[limit - ex - 1]);
-                    SEQAN_OMP_PRAGMA(section)
+                    #pragma omp section
                     ++ex;
                 }
             }
+            #else  // defined(_OPENMP)
+                swap(seqs[i], seqs[limit - ex - 1]);
+                swap(ids[i], ids[limit - ex - 1]);
+                ++ex;            
+            #endif  // defined(_OPENMP)
         }
         else
         {
@@ -152,18 +158,24 @@ void processN(TSeqs& seqs, TIds& ids, unsigned allowed, TSub substitute, General
     }
     if (ex != 0)
     {
-        SEQAN_OMP_PRAGMA(parallel default(shared))
+        #if defined(_OPENMP)
+        #pragma omp parallel default(shared)
         {
-            SEQAN_OMP_PRAGMA(sections nowait)
+            #pragma omp sections nowait
             {   //Resizing the containers to erase all unwanted sequences/ids at once
-                SEQAN_OMP_PRAGMA(section)
+                #pragma omp section
                 resize(seqs, limit - ex);
-                SEQAN_OMP_PRAGMA(section)
+                #pragma omp section
                 resize(ids, limit - ex);
-                SEQAN_OMP_PRAGMA(section)
+                #pragma omp section
                 stats.removedSeqs += ex;
             }
         }
+        #else  // defined(_OPENMP)
+            resize(seqs, limit - ex);
+            resize(ids, limit - ex);
+            stats.removedSeqs += ex;
+        #endif  // defined(_OPENMP)
     }
 }
 


### PR DESCRIPTION
There is a nasty bug in the Visual Studio c++ compiler, that causes the compiler to crash when using _pragma clause wrapped by macros in a nested way. 
This happens to be a problem with our ```SEQAN_OMP_PRAGMA``` statement.
This workaround, although not beautiful, fixes this. However, seqan_flexbar is deleted in develop, so we won't support it with 2.1 anyway. So merging this into develop is not necessary.