### PR TITLE
Fix VS bug: missing '>' before identifier 'int64_t'

### DIFF
--- a/include/seqan/misc/bit_twiddling.h
+++ b/include/seqan/misc/bit_twiddling.h
@@ -271,42 +271,13 @@ popCount(TWord word)
 // GCC, MINGW and CLANG provide the intrinsics __builtin_popcount, __builtin_popcountl, and __builtin_popcountll for
 // the types unsigned, unsigned long, and unsigned long long.  Starting with version 2008, Visual C++ provides the
 // intrinsics __popcnt16, __popcnt, and __popcnt64 for 16, 32, and 64 bit words.
-//
-// The functions below are implemented as follows.  _popCountImplGeneric() is used if there are no intrinsics provided
-// by the compiler (the case for Visual C++ 2008).  Otherwise, we define different overloads of the function
-// _popCountImpl() that are given the length of the word as a template argument.  If necessary, we copy the word in a
-// variable of next largest size and call the best suited builtin on this copy.
 
-// ----------------------------------------------------------------------------
-// Function _popCountImplGeneric()
-// ----------------------------------------------------------------------------
-// Generic implementation of counting bits.  Taken from http://graphics.stanford.edu/~seander/bithacks.html
-//
-// Brian Kernighan's method goes through as many iterations as there are set bits. So if we have a 32-bit word with
-// only the high bit set, then it will only go once through the loop.
-//
-// Published in 1988, the C Programming Language 2nd Ed. (by Brian W. Kernighan and Dennis M. Ritchie) mentions this
-// in exercise 2-9. On April 19, 2006 Don Knuth pointed out to me that this method "was first published by Peter
-// Wegner in CACM 3 (1960), 322. (Also discovered independently by Derrick Lehmer and published in 1964 in a book
-// edited by Beckenbach.)"
-
-template <typename TWord>
-inline unsigned
-_popCountImplGeneric(TWord word)  // Note that word is copied!
-{
-    typename MakeUnsigned<TWord>::Type x = word;
-    unsigned int c = 0;  // c accumulates the total bits set in v
-    for (c = 0; x; c++)
-        x &= x - 1;  // clear the least significant bit set
-    return c;
-}
+#if defined(__CUDA_ARCH__)
 
 // ----------------------------------------------------------------------------
 // Function _popCountImpl()
 // ----------------------------------------------------------------------------
 // CUDA implementations.
-
-#if defined(__CUDA_ARCH__)
 
 template <typename TWord>
 SEQAN_DEVICE
@@ -329,33 +300,13 @@ inline unsigned _popCountImpl(TWord word, WordSize_<8> const & /*tag*/)
     return __popc(static_cast<uint32_t>(word));
 }
 
-#else   // #if defined(__CUDA_ARCH__)
+// MSVC >= 2008, has intrinsic
+#elif defined(_MSC_VER)   // #if !defined(__CUDA_ARCH__) && defined(_MSC_VER)
 
 // ----------------------------------------------------------------------------
 // Function _popCountImpl()
 // ----------------------------------------------------------------------------
 // MSVC implementations.
-
-#if defined(_MSC_VER) // MSVC >= 2008, has intrinsic
-
-#if defined(__SSE4_2__)
-
-template <typename TWord>
-inline unsigned
-_popCountImpl(TWord word, WordSize_<64> const & /*tag*/)
-{
-    // 64-bit Windows, 64 bit intrinsic available
-    return __popcnt64(static_cast<uint64_t>(word));
-}
-
-template <typename TWord>
-inline unsigned
-_popCountImpl(TWord word, WordSize_<32> const & /*tag*/)
-{
-    return __popcnt(static_cast<uint32_t>(word));
-}
-
-#else // #if defined(__SSE4_2__)
 
 template <typename TWord>
 inline unsigned
@@ -391,8 +342,6 @@ _popCountImpl(TWord word, WordSize_<32> const & /*tag*/)
 #endif
 }
 
-#endif // #if defined(__SSE4_2__)
-
 template <typename TWord>
 inline unsigned
 _popCountImpl(TWord word, WordSize_<16> const & /*tag*/)
@@ -407,15 +356,14 @@ _popCountImpl(TWord word, WordSize_<8> const & /*tag*/)
     return _popCountImpl(static_cast<const uint16_t>(word), WordSize_<16>());
 }
 
-#endif  // #if defined(_MSC_VER)
+// GCC or CLANG
+#elif !defined(_MSC_VER)  // #if !defined(__CUDA_ARCH__) && !defined(_MSC_VER)
 
 // ----------------------------------------------------------------------------
 // Function _popCountImpl()
 // ----------------------------------------------------------------------------
 // GCC or CLANG implementations.
 // SSE4.2 popcnt is emitted when compiling with -mpopcnt or -march=corei7
-
-#if !defined(_MSC_VER)  // GCC or CLANG
 
 template <typename TWord>
 inline unsigned
@@ -445,9 +393,7 @@ _popCountImpl(TWord word, WordSize_<8> const & /*tag*/)
     return _popCountImpl(static_cast<uint32_t>(word), WordSize_<32>());
 }
 
-#endif    // GCC or CLANG
-
-#endif    // #if !defined(__CUDA_ARCH__)
+#endif // #if !defined(__CUDA_ARCH__) && !defined(_MSC_VER)
 
 // ----------------------------------------------------------------------------
 // Function printBits()

--- a/include/seqan/misc/bit_twiddling.h
+++ b/include/seqan/misc/bit_twiddling.h
@@ -636,7 +636,7 @@ inline TWord
 _bitScanReverse(TWord word, WordSize_<64>)
 {
     unsigned long index;
-    _BitScanReverse64(&index, static_cast<unsigned int64_t>(word));
+    _BitScanReverse64(&index, static_cast<uint64_t>(word));
     return index;
 }
 
@@ -645,7 +645,7 @@ inline TWord
 _bitScanForward(TWord word, WordSize_<64>)
 {
     unsigned long index;
-    _BitScanForward64(&index, static_cast<unsigned int64_t>(word));
+    _BitScanForward64(&index, static_cast<uint64_t>(word));
     return index;
 }
 #else

--- a/include/seqan/misc/bit_twiddling.h
+++ b/include/seqan/misc/bit_twiddling.h
@@ -573,8 +573,9 @@ _bitScanForward(TWord word, WordSize_<32>)
 {
     return __builtin_ctz(static_cast<unsigned int>(word));
 }
-#else
-#ifdef PLATFORM_WINDOWS
+
+#elif defined(PLATFORM_WINDOWS) // #if !defined(PLATFORM_GCC) && defined(PLATFORM_WINDOWS)
+
 #if (SEQAN_IS_64_BIT)
 
 template <typename TWord>
@@ -644,8 +645,7 @@ _bitScanForward(TWord word, WordSize_<32>)
     _BitScanForward(&index, static_cast<unsigned long>(word));
     return index;
 }
-#endif  // #if defined(PLATFORM_GCC)
-#endif  // #ifdef PLATFORM_GCC
+#endif  // #if !defined(PLATFORM_GCC) && defined(PLATFORM_WINDOWS)
 
 // ----------------------------------------------------------------------------
 // Function bitScanReverse()


### PR DESCRIPTION
Fixes a VS bug in bit_twiddling, see [build log](http://cdash.seqan.de/viewBuildError.php?buildid=163211):

> C:\seqan-nightly\co-git-develop\seqan-Nightly-64\include\seqan/misc/bit_twiddling.h(639): error C2146: syntax error: missing '>' before identifier 'int64_t'

-----
And removes _popCountImplGeneric, because it was only introduced for backward compatibility as stated in the following comment

>  The functions below are implemented as follows.  _popCountImplGeneric() is used if there are no intrinsics provided by the compiler (the case for Visual C++ 2008)

This [commit](https://github.com/seqan/seqan/pull/1369/files#diff-6274dcb7db964b2f07ae413d59f8bba3L339) removed the last use of the function.