### PR TITLE
[WORKAROUND] fix insert() in packed_string

### DIFF
--- a/include/seqan/sequence/string_packed.h
+++ b/include/seqan/sequence/string_packed.h
@@ -612,7 +612,7 @@ resize(String<TValue, Packed<THostspec> > & me,
 
     // create WORD
     String<TValue, Packed<THostspec> > tmp;
-    resize(tmp, TTraits::VALUES_PER_HOST_VALUE, Exact());
+    resize(tmp, static_cast<unsigned>(TTraits::VALUES_PER_HOST_VALUE), Exact());
     for (unsigned i = 0; i < TTraits::VALUES_PER_HOST_VALUE; ++i)
         tmp[i] = newValue;
 

--- a/include/seqan/sequence/string_packed.h
+++ b/include/seqan/sequence/string_packed.h
@@ -37,8 +37,6 @@
 #ifndef SEQAN_SEQUENCE_STRING_PACKED_H_
 #define SEQAN_SEQUENCE_STRING_PACKED_H_
 
-#include <bitset>
-
 namespace seqan {
 
 // ============================================================================

--- a/include/seqan/sequence/string_packed.h
+++ b/include/seqan/sequence/string_packed.h
@@ -609,7 +609,7 @@ resize(String<TValue, Packed<THostspec> > & me,
 
     // create WORD
     THostValue tmp;
-    tmp.i = 0ul;
+    tmp.i = 0;
     __uint64 ord = ordValue(TValue(newValue));
     for (unsigned j = 0; j < TTraits::VALUES_PER_HOST_VALUE; ++j)
         tmp.i |= ord << (j * TTraits::BITS_PER_VALUE);
@@ -627,7 +627,7 @@ resize(String<TValue, Packed<THostspec> > & me,
         TStringSize alreadySet = old_length % TTraits::VALUES_PER_HOST_VALUE;
 
         // clear non-set positions (which may be uninitialized ( != 0 )
-        tmp.i = (~0ul << (64 - alreadySet * TTraits::BITS_PER_VALUE)) >> TTraits::WASTED_BITS;
+        tmp.i = (~static_cast<__uint64>(0) << (64 - alreadySet * TTraits::BITS_PER_VALUE)) >> TTraits::WASTED_BITS;
         host(me)[old_host_length-1].i &= tmp.i;
 
         for (TStringSize i = alreadySet; i < TTraits::VALUES_PER_HOST_VALUE; ++i)


### PR DESCRIPTION
  * resize() without value is unchanged
  * more efficient host-based resize() with value added
  * insert() changed to where clearUnusedBits() is called before the real insert to fix the bugs we where seeing with #1074 

There is probably a larger problem hidden within ClearSpaceStringPacked_ or even the memcpy functions, but the problem only appeared with inserts and they have a workaround now, so everything is usable and regular resizes are not affected (initializing resizes should even be faster now).

PLEASE NOTE that some valgrind warnings for unintialized reads are unrelated to this and simply part of the implementation, i.e. seqan resizes() dont initialize and if only the first n bits are read and written, this implicitly read/writes the other bits although there value is irrelevant to the implementation.  This could be worked around (to silence the warnings) but this can be done for one of the next releases.