### PR TITLE
static build fixes (and made optional)

### DIFF
--- a/util/cmake/SeqAnBuildSystem.cmake
+++ b/util/cmake/SeqAnBuildSystem.cmake
@@ -48,22 +48,6 @@ include (SeqAnUsabilityAnalyzer)
 include (CheckCXXCompilerFlag)
 
 # ---------------------------------------------------------------------------
-# Normalize CMAKE_CXX_FLAGS to be a string.
-#
-# If we do not do this then setting the environment variable CXXFLAGS will
-# cause CMAKE_CXX_FLAGS to become a list and this will generate compiler
-# command lines including the list item separator semicolon ";".  This makes
-# the compiler command fail.
-# ---------------------------------------------------------------------------
-
-#if (CMAKE_CXX_FLAGS)
-#  foreach (_FLAG ${CMAKE_CXX_FLAGS})
-#    set (_FLAGS "${_FLAGS} ${_FLAG}")
-#  endforeach (_FLAG ${CMAKE_CXX_FLAGS})
-#  set (CMAKE_CXX_FLAGS "${_FLAGS}")
-#endif (CMAKE_CXX_FLAGS)
-
-# ---------------------------------------------------------------------------
 # Enable /bigobj flag on Windows.
 # ---------------------------------------------------------------------------
 
@@ -121,17 +105,6 @@ function (add_executable NAME)
     # Add dependency on the SUA target.
     seqan_add_sua_dependency (${NAME})
 endfunction (add_executable)
-
-# ---------------------------------------------------------------------------
-# Macro seqan_add_app_subdirectory (APP_NAME)
-# ---------------------------------------------------------------------------
-
-# macro (seqan_add_app_subdirectory APP_NAME)
-#     if (("${SEQAN_BUILD_SYSTEM}" STREQUAL "SEQAN_RELEASE") OR
-#          "${SEQAN_BUILD_SYSTEM}" STREQUAL "APP:${APP_NAME}")
-#         add_subdirectory (${APP_NAME})
-#     endif ()
-# endmacro (seqan_add_app_subdirectory)
 
 # ---------------------------------------------------------------------------
 # Macro seqan_register_apps ()

--- a/util/cmake/SeqAnBuildSystem.cmake
+++ b/util/cmake/SeqAnBuildSystem.cmake
@@ -158,7 +158,7 @@ macro (seqan_register_apps)
         else (APPLE)
             set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
 
-            # make sure -Wl,-Bdynamic isn't added automatically
+            # make sure -rdynamic isn't added automatically
             set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS)
             # make sure -fPIC isn't added automatically
             set(CMAKE_SHARED_LIBRARY_CXX_FLAGS)
@@ -168,13 +168,10 @@ macro (seqan_register_apps)
             # .so when building DEVELOP. In the latter case it also encloses the
             # static libs with -Bdynamic which turns static off for system libs.
             # Here we remove these (so statics works), but only for NON-DEVELOP
-            # on non-linux.
-
-            # this one must not be unset on FreeBSD if not building APPs individually
-            if ((CMAKE_SYSTEM_NAME MATCHES "Linux") OR (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP"))
-                # make sure -rdynamic isn't added automatically
+            if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
+                # make sure -Wl,-Bdynamic isn't added automatically
                 set(CMAKE_EXE_LINK_DYNAMIC_CXX_FLAGS)
-            endif ((CMAKE_SYSTEM_NAME MATCHES "Linux") OR (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP"))
+            endif (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
         endif (APPLE)
     endif (SEQAN_STATIC_APPS AND (NOT CMAKE_SYSTEM_NAME MATCHES "Windows"))
 


### PR DESCRIPTION
  - fixes static builds on non DEVELOP build_systems and make default, i.e. for shipping binaries
  - makes static build optional for DEVELOP build system vie SEQAN_STATIC_APPS and off by default

This works, but is not very understandable. Long-term cleanup to be achieved via #1448 