### PR TITLE
use xz for unix packages

### DIFF
--- a/util/cmake/SeqAnBuildSystem.cmake
+++ b/util/cmake/SeqAnBuildSystem.cmake
@@ -331,7 +331,7 @@ macro (seqan_configure_cpack_app APP_NAME APP_DIR)
   if (CMAKE_SYSTEM_NAME MATCHES "Windows")
     set (CPACK_GENERATOR "ZIP")
   else ()
-    set (CPACK_GENERATOR "ZIP;TBZ2")
+    set (CPACK_GENERATOR "ZIP;TXZ")
   endif ()
 
   # Set defaults for CPACK_PACKAGE_DESCRIPTION_FILE and CPACK_RESOURCE_FILE_LICENSE


### PR DESCRIPTION
zip + tar.xz instead of zip + tar.bz2
higher compression ratio and supported everywhere nowadays.