### PR TITLE
make async io optional

### DIFF
--- a/include/seqan/basic/debug_test_system.h
+++ b/include/seqan/basic/debug_test_system.h
@@ -387,6 +387,7 @@ void printDebugLevel(TStream & stream)
     stream << "SEQAN_ENABLE_DEBUG == " << SEQAN_ENABLE_DEBUG << std::endl;
     stream << "SEQAN_ENABLE_TESTING == " << SEQAN_ENABLE_TESTING << std::endl;
     stream << "SEQAN_CXX_FLAGS == \"" << SEQAN_CXX_FLAGS << "\"" << std::endl;
+    stream << "SEQAN_ASYNC_IO == " << SEQAN_ASYNC_IO << std::endl;
 }
 
 #if defined(PLATFORM_WINDOWS) || !SEQAN_HAS_EXECINFO

--- a/include/seqan/file/file_interface.h
+++ b/include/seqan/file/file_interface.h
@@ -69,8 +69,14 @@ struct Sync;
  * @tparam TSpec Further specializing type.  Default: <tt>void</tt>.
  */
 
+#if SEQAN_ASYNC_IO
 template <typename TSpec = void>
 struct Async;
+#else
+// define async as sync
+template <typename TSpec = void>
+using Async = Sync<TSpec>;
+#endif
 
 /*!
  * @class File

--- a/include/seqan/platform.h
+++ b/include/seqan/platform.h
@@ -104,13 +104,13 @@
 #ifndef SEQAN_ASYNC_IO
 // FreeBSD only has proper support on 64Bit
 #if defined(__FreeBSD__)
-    #if defined(__x86_64__)
+    #if defined(__x86_64__) || defined(__aarch64__) || defined(__ia64__) || defined(__ppc64__)
         #define SEQAN_ASYNC_IO 1
     #else
         #define SEQAN_ASYNC_IO 0
     #endif
 // Clang (and future gcc) can detect it
-#elif defined(__has_include)
+#elif defined(__has_include) && defined(__unix__)
     #if __has_include(<aio.h>)
         #define SEQAN_ASYNC_IO 1
     #else

--- a/include/seqan/platform.h
+++ b/include/seqan/platform.h
@@ -100,4 +100,29 @@
 // backwards compatibility
 #define SEQAN_UNUSED_TYPEDEF SEQAN_UNUSED
 
+// ASYNCHRONOUS I/O
+#ifndef SEQAN_ASYNC_IO
+// FreeBSD only has proper support on 64Bit
+#if defined(__FreeBSD__)
+    #if defined(__x86_64__)
+        #define SEQAN_ASYNC_IO 1
+    #else
+        #define SEQAN_ASYNC_IO 0
+    #endif
+// Clang (and future gcc) can detect it
+#elif defined(__has_include)
+    #if __has_include(<aio.h>)
+        #define SEQAN_ASYNC_IO 1
+    #else
+        #define SEQAN_ASYNC_IO 0
+    #endif
+// OpenBSD doesn't have it
+#elif defined(__OpenBSD__)
+    #define SEQAN_ASYNC_IO 0
+// we assume the rest have it (Linux, OSX, Win)
+#else
+    #define SEQAN_ASYNC_IO 1
+#endif
+#endif //ndef SEQAN_ASYNC_IO
+
 #endif

--- a/include/seqan/system.h
+++ b/include/seqan/system.h
@@ -30,10 +30,10 @@
 //
 // ==========================================================================
 
-#include <seqan/file.h>
-
 #ifndef SEQAN_HEADER_SYSTEM_H
 #define SEQAN_HEADER_SYSTEM_H
+
+#include <seqan/file.h>
 
 //____________________________________________________________________________
 // prerequisites
@@ -54,7 +54,9 @@
 #include <pthread.h>
 #include <errno.h>
 #include <semaphore.h>
+#if SEQAN_ASYNC_IO
 #include <aio.h>
+#endif
 #include <sys/mman.h>
 
 #ifndef O_LARGEFILE
@@ -86,7 +88,9 @@
 // synchronous and asynchronous files
 
 #include <seqan/system/file_sync.h>
+#if SEQAN_ASYNC_IO
 #include <seqan/system/file_async.h>
+#endif
 #include <seqan/system/file_directory.h>
 
 #endif //#ifndef SEQAN_HEADER_...

--- a/include/seqan/system/file_forwards.h
+++ b/include/seqan/system/file_forwards.h
@@ -67,13 +67,13 @@ typedef Tag<TagAllocateAligned_> const TagAllocateAligned;           // "include
 //////////////////////////////////////////////////////////////////////////////
 // FUNCTIONS
 //////////////////////////////////////////////////////////////////////////////
-
+#if SEQAN_ASYNC_IO
 //____________________________________________________________________________
 // allocate
-#if SEQAN_ASYNC_IO
+
 template <typename T, typename TValue, typename TSize> inline void allocate(T const & me, TValue * & data, TSize count, TagAllocateAligned const);           // "include/seqan/file/file_async.h"(292)
 template <typename TSpec, typename TValue, typename TSize> inline void allocate( File<Async<TSpec> > const & me, TValue * & data, TSize count);           // "include/seqan/file/file_async.h"(351)
-#endif
+
 //____________________________________________________________________________
 // asyncReadAt
 
@@ -91,24 +91,14 @@ template <typename TSpec> inline bool cancel(File<Async<TSpec> > & me, AiocbWrap
 
 //____________________________________________________________________________
 // deallocate
-#if SEQAN_ASYNC_IO
+
 template <typename T, typename TValue, typename TSize> inline void deallocate( T const & me, TValue * data, TSize count, TagAllocateAligned const);           // "include/seqan/file/file_async.h"(310)
 template <typename TSpec, typename TValue, typename TSize> inline void deallocate( File<Async<TSpec> > const & me, TValue * data, TSize count);           // "include/seqan/file/file_async.h"(360)
-#endif
+
 //____________________________________________________________________________
 // error
 
 inline int error(AiocbWrapper const &request);           // "include/seqan/file/file_async.h"(246)
-
-//____________________________________________________________________________
-// fileExists
-
-inline bool fileExists(const char *fileName);           // "include/seqan/file/file_sync.h"(189)
-
-//____________________________________________________________________________
-// fileUnlink
-
-inline bool fileUnlink(const char *fileName);           // "include/seqan/file/file_sync.h"(194)
 
 //____________________________________________________________________________
 // flush
@@ -120,11 +110,6 @@ template <typename TSpec> inline bool flush(File<Async<TSpec> > & me);          
 
 inline void printRequest(AiocbWrapper &request, const char *_hint);           // "include/seqan/file/file_async.h"(125)
 inline void printRequest(AiocbWrapper &request);           // "include/seqan/file/file_async.h"(125)
-
-//____________________________________________________________________________
-// read
-
-template <typename TSpec, typename TValue, typename TSize > inline bool read(File<Sync<TSpec> > & me, TValue *memPtr, TSize const count);           // "include/seqan/file/file_sync.h"(226)
 
 //____________________________________________________________________________
 // release
@@ -147,11 +132,27 @@ inline bool waitFor(AiocbWrapper &request, long timeoutMilliSec, bool &inProgres
 
 template <typename TSize > inline TSize waitForAny(AiocbWrapper const * const contexts[], TSize count);           // "include/seqan/file/file_async.h"(223)
 template <typename TSize > inline TSize waitForAny(AiocbWrapper const * const contexts[], TSize count, long timeoutMilliSec);           // "include/seqan/file/file_async.h"(231)
+#endif
+
+//____________________________________________________________________________
+// read
+
+template <typename TSpec, typename TValue, typename TSize > inline bool read(File<Sync<TSpec> > & me, TValue *memPtr, TSize const count);           // "include/seqan/file/file_sync.h"(226)
 
 //____________________________________________________________________________
 // write
 
 template <typename TSpec, typename TValue, typename TSize > inline bool write(File<Sync<TSpec> > & me, TValue const *memPtr, TSize const count);           // "include/seqan/file/file_sync.h"(231)
+
+//____________________________________________________________________________
+// fileExists
+
+inline bool fileExists(const char *fileName);           // "include/seqan/file/file_sync.h"(189)
+
+//____________________________________________________________________________
+// fileUnlink
+
+inline bool fileUnlink(const char *fileName);           // "include/seqan/file/file_sync.h"(194)
 
 } //namespace seqan
 

--- a/include/seqan/system/file_forwards.h
+++ b/include/seqan/system/file_forwards.h
@@ -70,10 +70,10 @@ typedef Tag<TagAllocateAligned_> const TagAllocateAligned;           // "include
 
 //____________________________________________________________________________
 // allocate
-
+#if SEQAN_ASYNC_IO
 template <typename T, typename TValue, typename TSize> inline void allocate(T const & me, TValue * & data, TSize count, TagAllocateAligned const);           // "include/seqan/file/file_async.h"(292)
 template <typename TSpec, typename TValue, typename TSize> inline void allocate( File<Async<TSpec> > const & me, TValue * & data, TSize count);           // "include/seqan/file/file_async.h"(351)
-
+#endif
 //____________________________________________________________________________
 // asyncReadAt
 
@@ -91,10 +91,10 @@ template <typename TSpec> inline bool cancel(File<Async<TSpec> > & me, AiocbWrap
 
 //____________________________________________________________________________
 // deallocate
-
+#if SEQAN_ASYNC_IO
 template <typename T, typename TValue, typename TSize> inline void deallocate( T const & me, TValue * data, TSize count, TagAllocateAligned const);           // "include/seqan/file/file_async.h"(310)
 template <typename TSpec, typename TValue, typename TSize> inline void deallocate( File<Async<TSpec> > const & me, TValue * data, TSize count);           // "include/seqan/file/file_async.h"(360)
-
+#endif
 //____________________________________________________________________________
 // error
 

--- a/include/seqan/system/file_sync.h
+++ b/include/seqan/system/file_sync.h
@@ -74,7 +74,7 @@ namespace seqan
 
 
     template <typename TSpec /* = void */>
-    struct Sync;
+    struct Sync {};
 
 
 #ifdef PLATFORM_WINDOWS


### PR DESCRIPTION
This PR introduces the SEQAN_ASYNC_IO macro which guards all asynchronous io code and forces use of synchronous IO if 0.
If not set manually it will set itself based on platform where the default is 0 for FreeBSD 32Bit and OpenBSD, and 1 otherwise.