### PR TITLE
[NOP, DOC] changed INPUTPREFIX to INPUT_PREFIX

### DIFF
--- a/apps/yara/mapper.cpp
+++ b/apps/yara/mapper.cpp
@@ -113,7 +113,7 @@ void setupArgumentParser(ArgumentParser & parser, Options const & options)
     addUsageLine(parser, "[\\fIOPTIONS\\fP] <\\fIREFERENCE INDEX PREFIX\\fP> <\\fISE-READS FILE\\fP>");
     addUsageLine(parser, "[\\fIOPTIONS\\fP] <\\fIREFERENCE INDEX PREFIX\\fP> <\\fIPE-READS FILE 1\\fP> <\\fIPE-READS FILE 2\\fP>");
 
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTPREFIX, "REFERENCE INDEX PREFIX"));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_PREFIX, "REFERENCE INDEX PREFIX"));
     setHelpText(parser, 0, "An indexed reference genome.");
 
     addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE, "READS FILE", true));

--- a/include/seqan/arg_parse/arg_parse_argument.h
+++ b/include/seqan/arg_parse/arg_parse_argument.h
@@ -101,6 +101,12 @@ inline std::string getFileExtension(ArgParseArgument const & me, unsigned pos);
  *
  * @val ArgParseArgument::ArgumentType ArgParseArgument::OUTPUT_FILE;
  * @brief Argument is an output file.
+ *
+ * @val ArgParseArgument::ArgumentType ArgParseArgument::INPUT_PREFIX;
+ * @brief Argument is a prefix to input file(s).
+ *
+ * @val ArgParseArgument::ArgumentType ArgParseArgument::OUTPUT_PREFIX;
+ * @brief Argument is a prefix to output file(s).
  */
 
 /*!
@@ -128,7 +134,7 @@ public:
         DOUBLE,      // .. a float
         INPUT_FILE,   // .. an inputfile (implicitly also a string)
         OUTPUT_FILE,  // .. an outputfile (implicitly also a string)
-        INPUTPREFIX, // .. an inputprefix (implicitly also a string)
+        INPUT_PREFIX, // .. an inputprefix (implicitly also a string)
         OUTPUT_PREFIX // .. an outoutprefix (implicitly also a string)
     };
 
@@ -229,7 +235,7 @@ inline std::string _typeToString(ArgParseArgument const & me)
         typeName = "outputfile";
         break;
 
-    case ArgParseArgument::INPUTPREFIX:
+    case ArgParseArgument::INPUT_PREFIX:
         typeName = "inputprefix";
         break;
 
@@ -289,7 +295,7 @@ inline bool isStringArgument(ArgParseArgument const & me)
     return (me._argumentType == ArgParseArgument::STRING) ||
            (me._argumentType == ArgParseArgument::INPUT_FILE) ||
            (me._argumentType == ArgParseArgument::OUTPUT_FILE) ||
-           (me._argumentType == ArgParseArgument::INPUTPREFIX) ||
+           (me._argumentType == ArgParseArgument::INPUT_PREFIX) ||
            (me._argumentType == ArgParseArgument::OUTPUT_PREFIX) ;
 }
 
@@ -437,7 +443,7 @@ inline bool isOutputPrefixArgument(ArgParseArgument const & me)
 
 inline bool isInputPrefixArgument(ArgParseArgument const & me)
 {
-    return me._argumentType == ArgParseArgument::INPUTPREFIX;
+    return me._argumentType == ArgParseArgument::INPUT_PREFIX;
 }
 
 // ----------------------------------------------------------------------------

--- a/tests/arg_parse/test_arg_parse_ctd_support.h
+++ b/tests/arg_parse/test_arg_parse_ctd_support.h
@@ -66,7 +66,7 @@ SEQAN_DEFINE_TEST(test_arg_parse_ctd_support)
     setValidValues(parser, "f", "fasta");
     addOption(parser, seqan::ArgParseOption("o", "out", "set an output file", seqan::ArgParseArgument::OUTPUT_FILE));
     setValidValues(parser, "o", "sam");
-    addOption(parser, seqan::ArgParseOption("ip", "input-prefix-option", "set an input prefix", seqan::ArgParseArgument::INPUTPREFIX));
+    addOption(parser, seqan::ArgParseOption("ip", "input-prefix-option", "set an input prefix", seqan::ArgParseArgument::INPUT_PREFIX));
     setValidValues(parser, "ip", "btx");
     addOption(parser, seqan::ArgParseOption("op", "output-prefix-option", "set an output prefix", seqan::ArgParseArgument::OUTPUT_PREFIX));
     setValidValues(parser, "output-prefix-option", "blub");


### PR DESCRIPTION
- changed INPUTPREFIX to INPUT_PREFIX to be consistent with other ArgumentTypes
- added missing documentation in the dox for INPUT_PREFIX and OUTPUT_PREFIX ArgumentTypes.

@esiragusa Yara_mapper (mapper.cpp, line 116)  is affected by this could you please adjust to this change?
