### PR TITLE
rework of seeds

### DIFF
--- a/demos/tutorial/seeds/example1.cpp
+++ b/demos/tutorial/seeds/example1.cpp
@@ -1,0 +1,38 @@
+//![header]
+#include <seqan/sequence.h>
+#include <seqan/stream.h>
+#include <seqan/seeds.h>
+
+using namespace seqan;
+
+int main()
+{
+//![header]
+//![example]
+    // Default-construct seed.
+    Seed<Simple> seed1;
+    std::cout << "seed1\n"
+              << "beginPositionH == " << beginPositionH(seed1) << "\n"
+              << "endPositionH == " << endPositionH(seed1) << "\n"
+              << "beginPositionV == " << beginPositionV(seed1) << "\n"
+              << "endPositionV == " << endPositionV(seed1) << "\n"
+              << "lowerDiagonal == " << lowerDiagonal(seed1) << "\n"
+              << "upperDiagonal == " << upperDiagonal(seed1) << "\n\n";
+
+    // Construct seed with begin and end position in both sequences.
+    Seed<Simple> seed2(3, 10, 7, 14);
+    setUpperDiagonal(seed2, -7);
+    setLowerDiagonal(seed2, -9);
+    std::cout << "seed2\n"
+              << "beginPositionH == " << beginPositionH(seed2) << "\n"
+              << "endPositionH == " << endPositionH(seed2) << "\n"
+              << "beginPositionV == " << beginPositionV(seed2) << "\n"
+              << "endPositionV == " << endPositionV(seed2) << "\n"
+              << "lowerDiagonal == " << lowerDiagonal(seed2) << "\n"
+              << "upperDiagonal == " << upperDiagonal(seed2) << "\n\n";
+//![example]
+
+//![footer]
+    return 0;
+}
+//![footer]

--- a/demos/tutorial/seeds/example1.cpp.stdout
+++ b/demos/tutorial/seeds/example1.cpp.stdout
@@ -1,0 +1,16 @@
+seed1
+beginPositionH == 0
+endPositionH == 0
+beginPositionV == 0
+endPositionV == 0
+lowerDiagonal == 0
+upperDiagonal == 0
+
+seed2
+beginPositionH == 3
+endPositionH == 7
+beginPositionV == 10
+endPositionV == 14
+lowerDiagonal == -9
+upperDiagonal == -7
+

--- a/demos/tutorial/seeds/solution1.cpp
+++ b/demos/tutorial/seeds/solution1.cpp
@@ -1,0 +1,35 @@
+#include <seqan/stream.h>
+#include <seqan/seeds.h>
+#include <seqan/sequence.h>
+
+using namespace seqan;
+
+int main()
+{
+    // Default-construct seed.
+    Seed<Simple> seed1;
+
+    // Construct seed with begin and end position in both sequences.
+    Seed<Simple> seed2(3, 10, 7, 14);
+    setUpperDiagonal(seed2, -7);
+    setLowerDiagonal(seed2, -9);
+
+    // Update seed1.
+    setBeginPositionH(seed1, 2 * beginPositionH(seed2));
+    setEndPositionH(seed1, 2 * endPositionH(seed2));
+    setBeginPositionV(seed1, 2 * beginPositionV(seed2));
+    setEndPositionV(seed1, 2 * endPositionV(seed2));
+    setLowerDiagonal(seed1, 2 * lowerDiagonal(seed2));
+    setUpperDiagonal(seed1, 2 * upperDiagonal(seed2));
+
+    // Print resulting seed1.
+    std::cout << "seed1\n"
+              << "beginPositionH == " << beginPositionH(seed1) << "\n"
+              << "endPositionH == " << endPositionH(seed1) << "\n"
+              << "beginPositionV == " << beginPositionV(seed1) << "\n"
+              << "endPositionV == " << endPositionV(seed1) << "\n"
+              << "lowerDiagonal == " << lowerDiagonal(seed1) << "\n"
+              << "upperDiagonal == " << upperDiagonal(seed1) << "\n\n";
+
+    return 0;
+}

--- a/manual/source/Tutorial/DataStructures/Seeds.rst
+++ b/manual/source/Tutorial/DataStructures/Seeds.rst
@@ -8,21 +8,18 @@ Seeds
 =====
 
 Learning Objective
-  In this tutorial, you will learn about the seeds-related SeqAn functionality.
-  You will learn how to do seed-and-extend with SeqAn, how to do local and global chaining of seeds.
-  Finally, we will show how to create a banded alignment around a seed chain.
+  In this tutorial, you will learn about the seeds-related SeqAn class.
 
 Difficulty
-  Average
+  Basic 
 
 Duration
-  2 h
+  15 min 
 
 Prerequisites
   :ref:`tutorial-datastructures-sequences`
 
-Many efficient heuristics to find high scoring, but inexact, local alignments between two sequences start with small exact (or at least highly similar) segments, so called **seeds**, and extend or combine them to get larger highly similar regions.
-Probably the most prominent tool of this kind is BLAST :cite:`Altschul1990`, but there are many other examples like FASTA :cite:`Pearson1990` or LAGAN :cite:`Brudno2003`.
+Many efficient heuristics to find high scoring, but inexact, local alignments between two sequences start with small exact (or at least highly similar) segments, so called **seeds** and extend or combine them to get larger highly similar regions. Probably the most prominent tool of this kind is BLAST :cite:`Altschul1990`, but there are many other examples like FASTA :cite:`Pearson1990` or LAGAN :cite:`Brudno2003`. You will learn seed-and-extend and many applications including local and global chianing in :ref:`tutorial-algorithms-seed-extension`.
 
 SeqAn's header file for all data structures and functions related to two-dimensional seeds is ``<seqan/seeds.h>``.
 
@@ -35,8 +32,7 @@ The Seed Class
 
 The :dox:`Seed` class allows to store seeds. Seeds have a begin and end position in each sequence. Often, two or more close seeds are combined into a larger seed, possibly causing a shift in horizontal or vertical direction between the begin position of the upper left seed and the end position of the lower right seed. For this reason, the :dox:`Seed` class also stores an upper and a lower diagonal to reflect the expansion between those shifted seeds.
 
-The image to the right shows an example where three smaller seeds (black diagonals) were combined (or "chained locally") into one larger seed (green nine-sided area).
-The first seed lies on the begin diagonal, the lowermost seed on the lower diagonal and the uppermost seed on the upper diagonal.
+The image to the right shows an example where three smaller seeds (black diagonals) were combined (or "chained locally") into one larger seed (green area).
 
 The :dox:`SimpleSeed Simple Seed` specialization only stores the begin and end positions of the seed (left-uppermost and right-lowermost corners of green surface) in both sequences and the upper and lower diagonal.
 The initial diagonals are not stored. The :dox:`ChainedSeed` specialization additionally stores these information.
@@ -44,16 +40,16 @@ In most cases, the :dox:`SimpleSeed Simple Seed` class is sufficient since the b
 
 You can get/set the begin and end position in the horizontal/vertical sequences using the functions :dox:`Seed#beginPositionH`, :dox:`Seed#beginPositionV`, :dox:`Seed#setBeginPositionH`, and :dox:`Seed#setBeginPositionV`.
 The band information can be queried and updated using :dox:`Seed#lowerDiagonal`, :dox:`Seed#upperDiagonal`, :dox:`Seed#setLowerDiagonal`, and :dox:`Seed#setUpperDiagonal`.
-Note, we use the capital letters 'H' and 'V' to indicate horizontal direction and vertical direction, respectively, while the database is always considered as the horizontal sequence and the query as the vertical sequence in the context of sequence alignments.
+Note, we use the capital letters 'H' and 'V' to indicate horizontal direction and vertical direction, respectively, while the **database** is always considered as the **horizontal sequence** and the **query** as the **vertical sequence** in the context of sequence alignments.
 
 The following program gives an example of creating seeds as well as setting and reading properties.
 
-.. includefrags:: demos/tutorial/seed_and_extend/example1.cpp
+.. includefrags:: demos/tutorial/seeds/example1.cpp
    :fragment: example
 
 The output to the console is as follows.
 
-.. includefrags:: demos/tutorial/seed_and_extend/example1.cpp.stdout
+.. includefrags:: demos/tutorial/seeds/example1.cpp.stdout
 
 Assignment 1
 ^^^^^^^^^^^^
@@ -70,4 +66,4 @@ Assignment 1
    Solution
      .. container:: foldable
 
-        .. includefrags:: demos/tutorial/seed_and_extend/solution1.cpp
+        .. includefrags:: demos/tutorial/seeds/solution1.cpp


### PR DESCRIPTION
The previous "seed and extend" section was divided into "seed" and "seed and extend" sections.
This PR will separate the seed section from the ancestor more clearly.