### PR TITLE
database/reference -> subject sequence

### DIFF
--- a/manual/source/Tutorial/Algorithms/Alignment/PairwiseSequenceAlignment.rst
+++ b/manual/source/Tutorial/Algorithms/Alignment/PairwiseSequenceAlignment.rst
@@ -538,8 +538,8 @@ Assignment 5
          .. includefrags:: demos/tutorial/pairwise_sequence_alignment/assignment5.cpp
             :fragment: main
 
-         In the first part of the algorithm we implement am alignment based verification process to identify positions in the `database` at which we can find our pattern with at most `2` errors.
-         We slide the `5*5` alignment matrix position by position over the `database` and use the `MeyersBitVector` to verify the hits.
+         In the first part of the algorithm we implement am alignment based verification process to identify positions in the `subject sequence` at which we can find our pattern with at most `2` errors.
+         We slide the `5*5` alignment matrix position by position over the `subject sequence` and use the `MeyersBitVector` to verify the hits.
          If the score is greater or equal than `-2`, then we have found a hit.
          We store the begin position of the hit in `locations`.
 

--- a/manual/source/Tutorial/DataStructures/Seeds.rst
+++ b/manual/source/Tutorial/DataStructures/Seeds.rst
@@ -40,7 +40,7 @@ In most cases, the :dox:`SimpleSeed Simple Seed` class is sufficient since the b
 
 You can get/set the begin and end position in the horizontal/vertical sequences using the functions :dox:`Seed#beginPositionH`, :dox:`Seed#beginPositionV`, :dox:`Seed#setBeginPositionH`, and :dox:`Seed#setBeginPositionV`.
 The band information can be queried and updated using :dox:`Seed#lowerDiagonal`, :dox:`Seed#upperDiagonal`, :dox:`Seed#setLowerDiagonal`, and :dox:`Seed#setUpperDiagonal`.
-Note, we use the capital letters 'H' and 'V' to indicate horizontal direction and vertical direction, respectively, while the **database** is always considered as the **horizontal sequence** and the **query** as the **vertical sequence** in the context of sequence alignments.
+Note, we use the capital letters 'H' and 'V' to indicate horizontal direction and vertical direction, respectively, while the **subject sequence** is always considered as the **horizontal sequence** and the **query** as the **vertical sequence** in the context of sequence alignments.
 
 The following program gives an example of creating seeds as well as setting and reading properties.
 

--- a/manual/source/Tutorial/DataStructures/Sequence/Sequences.rst
+++ b/manual/source/Tutorial/DataStructures/Sequence/Sequences.rst
@@ -309,8 +309,8 @@ Assignment 4
      In this task you will compare whole sequences.
      Reuse the code from above. Instead of a ``String<Dna5>`` we will now deal with a ``String<Dna5String>``.
      Build a string which contains the Dna5Strings "ATATANGCGT", "AAGCATGANT" and "TGAAANTGAC".
-     Now check for all elements of the container, if they are lexicographically smaller or bigger than the  given reference sequence "GATGCATGAT" and append them to a appropriate list.
-     Print out the final lists.
+     Now check for all elements of the container, if they are lexicographically smaller or bigger than the  given subject sequence "GATGCATGAT" and append them to a appropriate list.
+     Print out the final list.
 
    Hints
      Try to avoid unnecessary sequence scans.

--- a/manual/source/Tutorial/DataStructures/Sequence/Sequences.rst
+++ b/manual/source/Tutorial/DataStructures/Sequence/Sequences.rst
@@ -310,7 +310,7 @@ Assignment 4
      Reuse the code from above. Instead of a ``String<Dna5>`` we will now deal with a ``String<Dna5String>``.
      Build a string which contains the Dna5Strings "ATATANGCGT", "AAGCATGANT" and "TGAAANTGAC".
      Now check for all elements of the container, if they are lexicographically smaller or bigger than the  given subject sequence "GATGCATGAT" and append them to a appropriate list.
-     Print out the final list.
+     Print out the final lists.
 
    Hints
      Try to avoid unnecessary sequence scans.

--- a/manual/source/Tutorial/GettingStarted/AFirstExample.rst
+++ b/manual/source/Tutorial/GettingStarted/AFirstExample.rst
@@ -38,7 +38,7 @@ This tutorial will walk you through a simple example program that highlights the
 Running Example
 ---------------
 
-Let's start with a simple example programm. The program will do a pattern search of a short query sequence (pattern) in a long database sequence (text).
+Let's start with a simple example programm. The program will do a pattern search of a short query sequence (pattern) in a long subject sequence (text).
 We define the score for each position of the database sequence as the sum of matching characters between the pattern and the text.
 
 The following figure shows an expected result:


### PR DESCRIPTION
Based on @h-2 's suggestion  from #1529 
This PR is related to #1532 

Obviously, we have to use "database" and "reference" for some cases.
For example, when we say "FragmentStore is a database",  we should not change the word "database" to "subject sequence".
That's same in "reference", "contig" and "read".

So this PR changes only a part of them, that means only changes obvious cases.
For other parts, I think we need a discussion.