### PR TITLE
Knime packaging - configuration options for plugin.properties

### DIFF
--- a/util/cmake/SeqAnCtdSetup.cmake
+++ b/util/cmake/SeqAnCtdSetup.cmake
@@ -221,6 +221,9 @@ add_custom_command (OUTPUT ${WORKFLOW_PLUGIN_DIR}/plugin.properties
                                              "-DWORKFLOW_PLUGIN_DIR=${WORKFLOW_PLUGIN_DIR}"
                                              "-DSEQAN_VERSION_STRING=${SEQAN_VERSION_STRING}"
                                              "-DSEQAN_DATE=${SEQAN_DATE}"
+                                             "-DCTD_PLUGIN_PACKAGE=${CTD_PLUGIN_PACKAGE}"
+                                             "-DCTD_PLUGIN_NAME=${CTD_PLUGIN_NAME}"
+                                             "-DCTD_REPO_SUB_FOLDER=${CTD_REPO_SUB_FOLDER}"
                                              -P "${CMAKE_SOURCE_DIR}/util/cmake/ctd/configure_profile_properties.cmake"
                     DEPENDS ${WORKFLOW_PLUGIN_DIR}
                             ${CMAKE_SOURCE_DIR}/util/cmake/ctd/plugin.properties.in)

--- a/util/cmake/SeqAnCtdSetup.cmake
+++ b/util/cmake/SeqAnCtdSetup.cmake
@@ -223,7 +223,6 @@ add_custom_command (OUTPUT ${WORKFLOW_PLUGIN_DIR}/plugin.properties
                                              "-DSEQAN_DATE=${SEQAN_DATE}"
                                              "-DCTD_PLUGIN_PACKAGE=${CTD_PLUGIN_PACKAGE}"
                                              "-DCTD_PLUGIN_NAME=${CTD_PLUGIN_NAME}"
-                                             "-DCTD_REPO_SUB_FOLDER=${CTD_REPO_SUB_FOLDER}"
                                              -P "${CMAKE_SOURCE_DIR}/util/cmake/ctd/configure_profile_properties.cmake"
                     DEPENDS ${WORKFLOW_PLUGIN_DIR}
                             ${CMAKE_SOURCE_DIR}/util/cmake/ctd/plugin.properties.in)

--- a/util/cmake/ctd/configure_profile_properties.cmake
+++ b/util/cmake/ctd/configure_profile_properties.cmake
@@ -9,5 +9,13 @@ else ()
   set (CF_SEQAN_VERSION "${SEQAN_VERSION_STRING}")
 endif ()
 
+if (NOT CTD_PLUGIN_PACKAGE)
+  set (CTD_PLUGIN_PACKAGE "de.seqan")
+endif ()
+
+if (NOT CTD_PLUGIN_NAME)
+  set (CTD_PLUGIN_NAME  "SeqAn")
+endif ()
+
 # Actually configure the file.
 configure_file (${SEQAN_SOURCE_DIR}/util/cmake/ctd/plugin.properties.in ${WORKFLOW_PLUGIN_DIR}/plugin.properties)

--- a/util/cmake/ctd/plugin.properties.in
+++ b/util/cmake/ctd/plugin.properties.in
@@ -1,14 +1,14 @@
 # the package of the plugin
-pluginPackage=de.seqan
+pluginPackage=@CTD_PLUGIN_PACKAGE@
 
 # the name of the plugin
-pluginName=SeqAn
+pluginName=@CTD_PLUGIN_NAME@
 
 # the version of the plugin
 pluginVersion=@CF_SEQAN_VERSION@
 
 # the path (starting from KNIMEs Community Nodes node)
-nodeRepositoyRoot=community
+nodeRepositoyRoot=community/@CTD_REPO_SUB_FOLDER@
 
 
 executor=com.genericworkflownodes.knime.execution.impl.LocalToolExecutor

--- a/util/cmake/ctd/plugin.properties.in
+++ b/util/cmake/ctd/plugin.properties.in
@@ -8,7 +8,7 @@ pluginName=@CTD_PLUGIN_NAME@
 pluginVersion=@CF_SEQAN_VERSION@
 
 # the path (starting from KNIMEs Community Nodes node)
-nodeRepositoyRoot=community/@CTD_REPO_SUB_FOLDER@
+nodeRepositoyRoot=community
 
 
 executor=com.genericworkflownodes.knime.execution.impl.LocalToolExecutor


### PR DESCRIPTION
This gives flexibility to non native/external seqan apps to generate KNIME plugins that can co-exist with the seqan KNIME plugin. Right now If you generate a KNIME plugin and try to install it, that will replace the already existing SeqAn plugin, which is not nice. 

Another reason for this change is, In my opinion, not everyone is happy to name their package seqan.de.*** just because they used seqan library.