### PR TITLE
Review of infrastructure - typos and grammer

### DIFF
--- a/manual/source/Infrastructure/Contribute/DoxApiDocs.rst
+++ b/manual/source/Infrastructure/Contribute/DoxApiDocs.rst
@@ -17,7 +17,7 @@ extension to SeqAn-specific things like documenting concepts.
 General Documentation Structure
 -------------------------------
 
-Dox comments are placed in C-style comments with an exclamation mark, see below.
+Dox comments are placed in C-style comments with an exclamation mark (see below).
 The first dox tag should be placed on the next line, each line should begin with a correctly indented star.
 The first line only contains the slash-star-exclamation-mark and the last line only contains the star-slash.
 
@@ -30,7 +30,7 @@ The first line only contains the slash-star-exclamation-mark and the last line o
 
 The documentation and the code are independent. Each item to be documented (adaption, class, concept, enum, function, group, macro, metafunction, page, tag, typedef, variable) has to be epxlicitely given (see tags below). The available top level tags are [#adaption @adaption], [#class @class], [#concept @concept], [#defgroup @defgroup], [#enum @enum], [#fn @fn], [#macro @macro], [#metafunction @mfn], [#page @page], [#tag @tag], [#typedef @typedef], and [#variable @var].
 
-Each top level tag creates a documentation entry. For example, the
+Each top-level tag creates a documentation entry. For example, the
 following defines a class ``Klass`` with two global interface functions
 ``f1`` and ``f2`` for this class:
 
@@ -107,10 +107,10 @@ Tag Documentation
 Below, we differentiate between **names** and **labels**.
 
 **Names** are used to identify documentation items and must follow
-extended C++ identifier rules. An sub name consists of only alphanumeric
+extended C++ identifier rules. A sub name consists of only alphanumeric
 characters and the underscore is allowed, must not start with a number.
 Sub names can be glued together with ``::`` for class members and ``#``
-for interface functions. In contracts, **labels** are used for the
+for interface functions. In contrast, **labels** are used for the
 display to the user. For example, the alloc string has the name
 ``AllocString`` but the label "Alloc String", the constructor of
 ``AllocString`` has name ``AllocString::String``, and its length
@@ -123,7 +123,7 @@ function has name ``AllocString#length``.
 
 Top-level tag.
 
-Definition of an adaption with the given name and an optional label.
+Defines an adaption with the given name and an optional label.
 
 An adaption is a collection of global interface functions and
 metafunctions that adapt a type outside the SeqAn library to a concept
@@ -144,7 +144,7 @@ adapted to the interface of the ``StringConcept`` concept.
 
 Second-level entry.
 
-Assign an alias name for a function, metafunction, class, concept, or
+Assigns an alias name for a function, metafunction, class, concept, or
 enum. The list of aliases will be printed for each code entry. Also, the
 aliases will be incorporated into search results.
 
@@ -187,7 +187,7 @@ can use HTML in the description.
 
 Top-level tag.
 
-Define a class with the given name ``ClassName`` and an optional label.
+Defines a class with the given name ``ClassName`` and an optional label.
 
 .. code-block:: cpp
 
@@ -263,7 +263,7 @@ Note that you can use the extension value ``.console`` to see console output.
 
 Top-level tag.
 
-Create a documentation entry for a concept with the given name and an
+Creates a documentation entry for a concept with the given name and an
 optional label. All concept names should have the suffix ``Concept``.
 Use the fake keyword ``concept`` in the ``@signature``.
 
@@ -287,7 +287,7 @@ construct used in the documentation.
 
 Top-level tag.
 
-Create a documentation entry for a group with a given name and an
+Creates a documentation entry for a group with a given name and an
 optional label. Groups are for rough grouping of global functions and/or
 tags.
 
@@ -327,7 +327,7 @@ or concept.
 
 Second-level entry.
 
-Mark a given function, metafunction, class, concept, or enum as
+Marks a given function, metafunction, class, concept, or enum as
 deprecated. A deprecation message will be generated in the API
 documentation.
 
@@ -348,7 +348,7 @@ documentation.
 
 Top-level entry.
 
-Documentation for an enum with given name and optional label.
+Provides documentation for an enum with given name and optional label.
 
 .. code-block:: cpp
 
@@ -398,7 +398,7 @@ concept.
 
 Top-level entry.
 
-Document a function (global, global interface, or member) with given
+Documents a function (global, global interface, or member) with given
 name and label. The type of the function is given by its name.
 
 .. code-block:: cpp
@@ -415,7 +415,7 @@ name and label. The type of the function is given by its name.
 
 Second-level entry.
 
-Give the required ``#include`` path for a code entry.
+Gives the required ``#include`` path for a code entry.
 
 **Note:** Use angular brackets as below for SeqAn includes.
 
@@ -452,7 +452,7 @@ Marks a class to implement a given concept.
 
 Second-level entry.
 
-Include a C++ source file as an example. See [#snippet @snippet] for
+Includes a C++ source file as an example. See [#snippet @snippet] for
 including fragments.
 
 .. code-block:: cpp
@@ -472,7 +472,7 @@ including fragments.
 
 Second-level entry.
 
-Mark a given function, metafunction, class, concept, or enum as
+Marks a given function, metafunction, class, concept, or enum as
 internal. You can also provide a comment that is ignored/not used in the
 output.
 
@@ -493,7 +493,7 @@ output.
 
 In-text tag.
 
-Tag to link to a documentation entry with a given label.
+Provides tag to link to a documentation entry with a given label.
 
 The difference to [#see @see] is that ``@link .. @endlink`` is used
 inline in text whereas ``@see`` is a second-level tag and adds a ``see``
@@ -517,7 +517,7 @@ external resources.
 
 Top-level tag.
 
-Document a macro.
+Documents a macro.
 
 .. code-block:: cpp
 
@@ -540,7 +540,7 @@ Document a macro.
 
 Top-level tag.
 
-Document a metafunction.
+Documents a metafunction.
 
 .. code-block:: cpp
 
@@ -566,7 +566,7 @@ Document a metafunction.
 
 Second-level entry.
 
-Add an informative note to a function, metafunction, class, concept,
+Adds an informative note to a function, metafunction, class, concept,
 enum, or group.
 
 .. code-block:: cpp
@@ -586,7 +586,7 @@ enum, or group.
 
 Top-level entry.
 
-Create a documentation page.
+Creates a documentation page.
 
 .. code-block:: cpp
 
@@ -611,7 +611,7 @@ Create a documentation page.
 
 Second-level entry.
 
-Document a value (and non-type) parameter from a function or member
+Documents a value (and non-type) parameter from a function or member
 function.
 
 .. code-block:: cpp
@@ -632,7 +632,7 @@ function.
 
 **Signature** ``@return Type Label``
 
-Define the return value for a function or metafunction.
+Defines the return value for a function or metafunction.
 
 Also see the example for [#param @param].
 
@@ -660,7 +660,7 @@ metafunction then use a ``TXyz`` return type in ``@return`` and document
 
 **Signature** ``@return Exception Label``
 
-Add note on a function or macro throwing an exception.
+Adds a note on a function or macro throwing an exception.
 
 .. code-block:: cpp
 
@@ -680,7 +680,7 @@ Add note on a function or macro throwing an exception.
 
 **Signature** ``@datarace Description``
 
-Describe possible data races for functions and macros.
+Describes possible data races for functions and macros.
 If this value is not specified it defaults to ``Thread safety unknown!``
 
 .. code-block:: cpp
@@ -715,7 +715,7 @@ See the example for [#page @page].
 
 Second-level entry.
 
-Add "see also" link to a documentation entry.
+Adds "see also" link to a documentation entry.
 
 .. code-block:: cpp
 
@@ -750,7 +750,7 @@ And here is the file with the snippet.
 
 Top-level entry.
 
-Document a tag. Mostly, you would group tags in a group using [#defgroup
+Documents a tag. Mostly, you would group tags in a group using [#defgroup
 @defgroup].
 
 .. code-block:: cpp
@@ -769,7 +769,7 @@ Document a tag. Mostly, you would group tags in a group using [#defgroup
 
 Second-level entry.
 
-Document a template parameter of a metafunction or class template.
+Documents a template parameter of a metafunction or class template.
 
 .. code-block:: cpp
 
@@ -788,7 +788,7 @@ Document a template parameter of a metafunction or class template.
 
 Top-level entry.
 
-Document a typedef.
+Documents a typedef.
 
 .. code-block:: cpp
 
@@ -826,7 +826,7 @@ Top-level entry. Document a global variable or member variable.
 **Signature** ``@val EnumType EnumValueName``
 
 Top-level entry.
-Document an enum value.
+Documents an enum value.
 
 .. code-block:: cpp
 
@@ -855,7 +855,7 @@ Document an enum value.
 
 Second-level entry.
 
-Add a warning to a function, metafunction, class, concept, enum, or group.
+Adds a warning to a function, metafunction, class, concept, enum, or group.
 
 .. code-block:: cpp
 
@@ -1086,11 +1086,11 @@ Documenting Enums
 Difference to Doxygen
 ---------------------
 
-If you already know Doxygen, the following major difference apply.
+If you already know Doxygen, the following major differences apply.
 
 * The documentation is more independent of the actual code.
   Doxygen creates a documentation entry for all functions that are present in the code and allows the additional documentation, e.g. using ``@fn`` for adding functions.
-  With the SeqAn dox system, you have to explicitely use a top level tag for adding documentationitems.
+  With the SeqAn dox system, you have to explicitely use a top level tag for adding documentation items.
 * Documentation entries are not identified by their signature but by their name.
 * We allow the definition of interface functions and metafunctions (e.g. ``@fn Klass#func`` and ``@mfn Klass#Func``) in addition to member functions (``@fn Klass::func``).
 * We do not allow tags with backslashes but consistently use at signs (``@``).

--- a/manual/source/Infrastructure/Contribute/GitWorkflow.rst
+++ b/manual/source/Infrastructure/Contribute/GitWorkflow.rst
@@ -80,7 +80,7 @@ Develop new modules and apps
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Create a new module or app `branch <https://www.atlassian.com/git/tutorial/git-branches#branch>`_ where to develop your new module or application.
-The branch should be based on master if your module or application doesn’t rely on any recently developed features.
+The branch should be based on master if your module or application doesn't rely on any recently developed features.
 If a new feature becomes necessary later on, the branch can be `rebased <https://www.atlassian.com/git/tutorial/rewriting-git-history#rebase>`_ onto develop.
 When the development is complete, the branch can be merged back into the corresponding base branch - either master or develop.
 
@@ -88,5 +88,5 @@ Rules
 -----
 
 * Never push feature branches to the SeqAn repository.
-* Sumit code reviews through GitHub.
+* Submit code reviews through GitHub.
 

--- a/manual/source/Infrastructure/Contribute/StyleCpp.rst
+++ b/manual/source/Infrastructure/Contribute/StyleCpp.rst
@@ -7,7 +7,7 @@
 C++ Code Style
 ==============
 
-The aim of this style guide is to enforce a certain level of canonicality on all SeqAn code.
+The aim of this style guide is to enforce a certain level of canonicity on all SeqAn code.
 Besides good comments, having a common style guide is the key to being able to understand and change code written by others easily.
 
 (The style guide partially follows the `Google C++ Code Style Guide <http://google-styleguide.googlecode.com/svn/trunk/cppguide.xml>`_.)
@@ -18,7 +18,7 @@ C++ Features
 Reference Arguments
 ^^^^^^^^^^^^^^^^^^^
 
-We prefer reference arguments over pointer arguments.
+We prefer reference arguments to pointer arguments.
 Use ``const`` where possible.
 
 Use C-Style Logical Operators
@@ -35,7 +35,7 @@ Default Arguments
 ^^^^^^^^^^^^^^^^^
 
 Default arguments to global functions are problematic with generated forwards.
-They can be replaced with function overloading, so do not use them.
+They can be replaced with function overloading. So do not use them!
 
 .. container:: foldable
 
@@ -84,12 +84,12 @@ Virtual member functions cannot be inlined and are thus slow when used in tight 
 ``static_cast<>``
 ^^^^^^^^^^^^^^^^^
 
-Prefer ``static_cast<>`` over C-style casts.
+Prefer ``static_cast<>`` to C-style casts.
 
 ``const_cast<>``
 ^^^^^^^^^^^^^^^^
 
-Use const-casts only to make an object const, do not remove consts.
+Use const-casts only to make an object const. Do not remove consts.
 Rather, use the ``mutable`` keyword on selected members.
 ``const_cast<>`` is allowed for interfacing with external (C) APIs where the ``const`` keyword is missing but which do not modify the variable.
 
@@ -171,10 +171,10 @@ Style Conformance
 ^^^^^^^^^^^^^^^^^
 
 Follow this code style whenever possible.
-However, prefer consistency over conformance.
+However, prefer consistency to conformance.
 
 If you are editing code that is non-conforming consider whether you could/should adapt the whole file to the new style.
-If this is not feasible, prefer consistency over conformance.
+If this is not feasible, prefer consistency to conformance.
 
 Semantics
 ---------
@@ -342,14 +342,14 @@ All files should be UTF-8, non-ASCII characters should not occur in them neverth
 Spaces VS Tabs
 ^^^^^^^^^^^^^^
 
-Do not use tabs, use spaces.
+Do not use tabs! Use spaces.
 Use ``"\t"`` in strings instead of plain tabs.
 
 .. container:: foldablej
 
     After some discussion, we settled on this.
     All programmer's editors can be configured to use spaces instead of tabs.
-    We use a four spaces to a tab.
+    We use four spaces instead of a tab.
 
     There can be problems when indenting in for loops with tabs, for example.
     Consider the following (``-->|`` is a tab, ``_`` is a space):

--- a/manual/source/Infrastructure/Contribute/WriteCommitMessages.rst
+++ b/manual/source/Infrastructure/Contribute/WriteCommitMessages.rst
@@ -112,7 +112,7 @@ A fix that does not have a ticket:
     [FIX] Fixed reading of CIGAR string in module bam_io.
 
     There was a bug when reading the operation "F", which was translated to
-    FLABBERGASTED.  Fixed this to the documented behaviour.
+    FLABBERGASTED.  Fixed this to the documented behavior.
 
 Example: Internal Changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/manual/source/Infrastructure/Manage/WriteAppTests.rst
+++ b/manual/source/Infrastructure/Manage/WriteAppTests.rst
@@ -51,7 +51,7 @@ Running Tests
 ^^^^^^^^^^^^^
 
 The app tests are then run in the nightly CMake builds and their results are submitted to CDash.
-There are two steps involed here: (1) Executing the programs and (2) comparing their result with the expected ones.
+There are two steps involved here: (1) Executing the programs and (2) comparing their result with the expected ones.
 There is a Python test driver program (called *run_tests.py* by convention) for each collection of app tests.
 
 These programs us the Python module *seqan.app_tests* for running and usually mirror the corresponding *generate_outputs.sh* file.

--- a/manual/source/Infrastructure/Manage/WriteTutorials.rst
+++ b/manual/source/Infrastructure/Manage/WriteTutorials.rst
@@ -182,7 +182,7 @@ Assignments
 The assignments' purpose in general is to support the reader's understanding of the topic in question.
 For this each assignment is of a special type (Review, Application and Transfer), has an objective, hints and a link to the complete solution.
 
-Depending on the assignment‘s type the reader is guided through the assignment solving by providing him with partial solutions.
+Depending on the type of assignment type the reader is guided through the assignment solving by providing him with partial solutions.
 
 There must always be an assignments of type Review.
 Assignments must always appear in an ascending order concerning their types and no "type gap" must occur.
@@ -235,7 +235,7 @@ Language
 
 Make use of a simple language.
 This is neither about academic decadence nor about increasing the learning barrier.
-You are not forced to over-simplify your subject but still try to use a language that is also appropriate for those who don‘t fully meet the tutorials prerequisites.
+You are not forced to over-simplify your subject but still try to use a language that is also appropriate for those who don't fully meet the tutorials prerequisites.
 
 Mental Model
 ^^^^^^^^^^^^
@@ -327,7 +327,7 @@ Tutorial Template
 
     .. important::
 
-       What are importants for?
+       What are important blocks for?
 
        These boxes contain information that **should be kept in mind** since the described phenomenon is very likely to be encountered by the reader again and again when working with SeqAn.
 

--- a/manual/source/Infrastructure/Manage/WriteTutorials.rst
+++ b/manual/source/Infrastructure/Manage/WriteTutorials.rst
@@ -182,7 +182,7 @@ Assignments
 The assignments' purpose in general is to support the reader's understanding of the topic in question.
 For this each assignment is of a special type (Review, Application and Transfer), has an objective, hints and a link to the complete solution.
 
-Depending on the type of assignment type the reader is guided through the assignment solving by providing him with partial solutions.
+Depending on the type of assignment the reader is guided through the assignment solving by providing him with partial solutions.
 
 There must always be an assignments of type Review.
 Assignments must always appear in an ascending order concerning their types and no "type gap" must occur.

--- a/manual/source/Infrastructure/Manage/WriteUnitTests.rst
+++ b/manual/source/Infrastructure/Manage/WriteUnitTests.rst
@@ -275,7 +275,7 @@ Example:
        SEQAN_ASSERT_EQ(abs(0), 0);
    }
 
-   // Test abs() function with -1, a Representative for negative values.
+   // Test abs() function with -1, a representative for negative values.
    SEQAN_DEFINE_TEST(test_abs_with_minus_one)
    {
        SEQAN_ASSERT_EQ(abs(-1), 1);

--- a/manual/source/Infrastructure/Manage/WriteUnitTests.rst
+++ b/manual/source/Infrastructure/Manage/WriteUnitTests.rst
@@ -263,7 +263,7 @@ Example:
 
 .. code-block:: cpp
 
-   // Test abs() function with 1, a representant for positive values.
+   // Test abs() function with 1, a representative for positive values.
    SEQAN_DEFINE_TEST(test_abs_with_one)
    {
        SEQAN_ASSERT_EQ(abs(1), 1);
@@ -275,7 +275,7 @@ Example:
        SEQAN_ASSERT_EQ(abs(0), 0);
    }
 
-   // Test abs() function with -1, a representant for negative values.
+   // Test abs() function with -1, a Representative for negative values.
    SEQAN_DEFINE_TEST(test_abs_with_minus_one)
    {
        SEQAN_ASSERT_EQ(abs(-1), 1);

--- a/manual/source/Infrastructure/Misc/WriteNiceUnixPrograms.rst
+++ b/manual/source/Infrastructure/Misc/WriteNiceUnixPrograms.rst
@@ -173,7 +173,7 @@ For paired-end read mapping, the program *bwa* consists of multiple calls.
 
 #. Call bwa to build an index on your genome.
 #. Map the left-end reads, yielding a position file.
-#. Map the right-end reads, yielding a positon file.
+#. Map the right-end reads, yielding a position file.
 #. Combine the two position files previously created.
 
 While it is OK to first create an index file (this file can be used for many reads files), the last three steps could be combine into one umbrella command.

--- a/manual/source/Infrastructure/Use/CMakeBuildDirs.rst
+++ b/manual/source/Infrastructure/Use/CMakeBuildDirs.rst
@@ -29,7 +29,7 @@ CMake Parameters
 
 A central question with CMake is the choice of the so called generator. Enter ``cmake -G`` to get a list of the supported ones. The most common generators are the **Unix Makefiles** which are default on Linux/Mac/BSD. But there are also specific generators for IDEs, such as Visual Studio, XCode or CodeBlocks.
 
-For most of the IDEs further choices like "Release or Debug" are available from the graphical user interface of the IDE, where as, for the Unix Makefile generator, we can specify the *build types* using a command line option.
+For most of the IDEs further choices like "Release or Debug" are available from the graphical user interface of the IDE, whereas, for the Unix Makefile generator, we can specify the *build types* using a command line option.
 Also, the compiler program (and version) can be switched using a command line option.
 
 Examples

--- a/manual/source/Infrastructure/Use/CMakeBuildDirs.rst
+++ b/manual/source/Infrastructure/Use/CMakeBuildDirs.rst
@@ -14,7 +14,7 @@ Why would you need more than one build directory or more than one IDE project fi
 This is very useful
 
 * if you want to use the same set of source files from multiple version of the same IDE (e.g. two Visual Studio versions),
-* if you want to have both debug builds (for debugging) and release builds (for performance tests) in paralell,
+* if you want to have both debug builds (for debugging) and release builds (for performance tests) in parallel,
 * if you have your source files stored on a shared network location and want to have build files on two computer and/or operating systems, or
 * if you want to build the sources with two different compilers or compiler versions at the same time (e.g. to see whether you can figure out compiler errors better from the messages by another compiler).
 
@@ -29,7 +29,7 @@ CMake Parameters
 
 A central question with CMake is the choice of the so called generator. Enter ``cmake -G`` to get a list of the supported ones. The most common generators are the **Unix Makefiles** which are default on Linux/Mac/BSD. But there are also specific generators for IDEs, such as Visual Studio, XCode or CodeBlocks.
 
-For most of the IDEs further choices like "Release or Debug" can be done from the graphical user interface, but for the Unix Makefile generator, we can select the *build types* using a command line option.
+For most of the IDEs further choices like "Release or Debug" are available from the graphical user interface of the IDE, where as, for the Unix Makefile generator, we can specify the *build types* using a command line option.
 Also, the compiler program (and version) can be switched using a command line option.
 
 Examples

--- a/manual/source/Infrastructure/Use/FindSeqAnCMake.rst
+++ b/manual/source/Infrastructure/Use/FindSeqAnCMake.rst
@@ -10,16 +10,15 @@ Using SeqAn in CMake-based projects
 Overview
 --------
 
-`CMake <http://cmake.org/>`_ is a cross-platform build system generator.
-That is, you describe the different executables and binaries and their dependencies in ``CMakeLists.txt`` files.
-Then, CMake generates build systems from this, for example in the form of Makefiles or Visual Studio projects. This article will only describe the most basic things about CMake in general and focus on how to use SeqAn easily from within CMake projects.
+`CMake <http://cmake.org/>`_ is a cross-platform build system generator where you describe different executables, binaries and their dependencies in ``CMakeLists.txt`` files.
+Then, CMake generates build systems such as Makefiles or Visual Studio projects from these files. This article describes only the most basic things about CMake in general and focuses on how to use SeqAn easily from within CMake projects.
 
 In CMake projects, one uses `modules to find libraries <http://www.vtk.org/Wiki/CMake:How_To_Find_Libraries>`_ such as SeqAn.
 SeqAn ships with such a module.
 
 In the following we assume that you have installed CMake on your operating system. If you have not yet, install it via the operating systems mechanisms (see also :ref:`Setting up SeqAn <infra-use-install>`) and/or `download from the CMake homepage <https://cmake.org/download/>`_.
 
-You should also have a valid C++-Compiler installed, refer to the `GitHub-README <https://github.com/seqan/seqan>`_ to see which compilers are currently supported.
+You should also have a valid C++-Compiler installed. Refer to the `GitHub-README <https://github.com/seqan/seqan>`_ to see which compilers are currently supported.
 
 A Running Example
 -----------------
@@ -116,7 +115,7 @@ Finally you can then build the application by calling
 
         # cmake --build .
 
-**The above step is the only step you need to repeat when changing your source code.** CMake only has to be re-run if you change the ``CMakeLists.txt``.
+**The above step is the only step you need to repeat when changing your source code.** You only have to run CMake again, if you have changed the ``CMakeLists.txt``.
 
 You can then execute the application in the usual way
 
@@ -221,7 +220,7 @@ As can be seen from the example above, the following variables need to be passed
   A list of libraries to link against.
 
 ``SEQAN_DEFINITIONS``
-  A list of definitions to be passted to the compiler.
+  A list of definitions to be passed to the compiler.
 
 Required additions to C++ compiler flags are in the following variable:
 


### PR DESCRIPTION
I made a review of the Infrastructure Manual as requested by @h-2. Most of them are just :nail_care: and typos.