### PR TITLE
[FIX] temporarily disable warnings on windows when a temp directory c…

### DIFF
--- a/include/seqan/basic/debug_test_system.h
+++ b/include/seqan/basic/debug_test_system.h
@@ -784,14 +784,18 @@ int _deleteTempFile(std::string tempFilename)
             if (strcmp(data.cFileName, ".") == 0 || strcmp(data.cFileName, "..") == 0)
                 continue;  // Skip these.
             if (!DeleteFile(tempp.c_str()))
-                std::cerr << "WARNING: Could not delete file " << tempp << "\n";
+            {
+                //std::cerr << "WARNING: Could not delete file " << tempp << "\n";
+            }
         }
         while (FindNextFile(hFind, &data));
         FindClose(hFind);
     }
 
     if (!RemoveDirectory(tempFilename.c_str()))
-        std::cerr << "WARNING: Could not delete directory " << tempFilename << "\n";
+    {
+        //std::cerr << "WARNING: Could not delete directory " << tempFilename << "\n";
+    }
 #else  // #ifdef PLATFORM_WINDOWS
     DIR * dpdf;
     struct dirent * epdf;


### PR DESCRIPTION
…annot be removed

Fixing #1557 for the release by disabling the warnings on windows when the SeqAn tmp directory cannot be removed.

It's not a nice solution but since it only concerns tests, I think it's the easiest and fastest solution for the release. We can fix the problem itself and revert the commit it afterwards.