### PR TITLE
Build System Cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,9 @@ option (SEQAN_ENABLE_CUDA
         "Enable CUDA, if the toolkit is available."
 	OFF)
 
+option (SEQAN_STATIC_APPS "Build static apps." OFF)
+option (SEQAN_OPTIMIZED_BUILDS "Build optimized binaries." OFF)
+
 # ===========================================================================
 # Setup Modules and Find Packages.
 # ===========================================================================


### PR DESCRIPTION
@h-2 @rrahn I am proposing some modification to the build system, following recent changes in #1560:
* Split cmake flag SEQAN_OFFICIAL_PKG as SEQAN_STATIC_APPS and SEQAN_OPTIMIZED_BUILDS
* Removed optimizations in DEVELOP builds

The reasons for these modifications should be pretty obvious. As soon as you agree, I will update the documentation and submit a PR for develop.
