### PR TITLE
[DOC] Add alignment tags of LinearGaps and AffineGaps to the docs (develop)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,12 +37,11 @@ Some of the official applications might have additional requirements or work onl
 Documentation Resources
 -----------------------
 
-* `Getting Started <http://seqan.readthedocs.org/en/master/Tutorial/GettingStarted.html>`_
+* `Getting Started <http://seqan.readthedocs.org/en/master/Tutorial/GettingStarted>`_
 * `Manual <http://seqan.readthedocs.org/en/master>`_
-* `Tutorial <http://seqan.readthedocs.org/en/master/Tutorial.html>`_
-* `How-Tos <http://seqan.readthedocs.org/en/master/HowTo.html>`_
+* `Tutorial <http://seqan.readthedocs.org/en/master/index.html#tutorials>`_
+* `How-Tos <http://seqan.readthedocs.org/en/master/Tutorial/HowTo>`_
 * `API Documentation (stable) <http://docs.seqan.de/seqan/master/>`_
-
 
 Contact
 =======

--- a/include/seqan/align/dp_profile.h
+++ b/include/seqan/align/dp_profile.h
@@ -183,6 +183,14 @@ typedef Tag<TracebackOff_> TracebackOff;
 // Tag LinearGaps
 // ----------------------------------------------------------------------------
 
+/*!
+ * @tag AlignmentAlgorithmTags#LinearGaps
+ * @headerfile <seqan/align.h>
+ * @brief Tag for selecting linear gap cost model. This tag can be used for all standard DP algorithms.
+ *
+ * @signature struct LinearGaps_;
+ * @signature typedef Tag<LinearGaps_> LinearGaps;
+ */
 struct LinearGaps_;
 typedef Tag<LinearGaps_> LinearGaps;
 
@@ -190,6 +198,14 @@ typedef Tag<LinearGaps_> LinearGaps;
 // Tag AffineGaps
 // ----------------------------------------------------------------------------
 
+/*!
+ * @tag AlignmentAlgorithmTags#AffineGaps
+ * @headerfile <seqan/align.h>
+ * @brief Tag for selecting affine gap cost model. This tag can be used for all standard DP algorithms.
+ *
+ * @signature struct AffineGaps_;
+ * @signature typedef Tag<AffineGaps_> AffineGaps;
+ */
 struct AffineGaps_;
 typedef Tag<AffineGaps_> AffineGaps;
 

--- a/include/seqan/stream/formatted_file.h
+++ b/include/seqan/stream/formatted_file.h
@@ -609,10 +609,11 @@ _checkThatStreamOutputFormatIsSet(FormattedFile<TFileFormat, Output, TSpec> cons
  * @fn FormattedFile#open
  * @brief Open a FormattedFile.
  *
- * @signature bool open(file, fileName);
+ * @signature bool open(file, fileName, mode);
  *
  * @param[in,out] file The FormattedFile to open.
  * @param[in]     fileName The name of the file open.
+ * @param[in]     mode The open mode: @link FileOpenMode @endlink.
  * @return bool <tt>true</tt> in the case of success, <tt>false</tt> otherwise.
  */
 

--- a/manual/source/Tutorial/DataStructures/Indices/index.rst
+++ b/manual/source/Tutorial/DataStructures/Indices/index.rst
@@ -71,8 +71,6 @@ node as you can see in the next figure (suffix "i"):
 
 **Figure 2:** Relaxed suffix tree of "mississippi"
 
-.. image:: ../../../under_construction.jpg
-
 .. raw:: mediawiki
 
     {{TracNotice|{{PAGENAME}}}}


### PR DESCRIPTION
http://docs.seqan.de/seqan/2.1.1/group_AlignmentAlgorithmTags.html is currently missing the tags for LinearGaps and AffineGaps