### PR TITLE
[FIX, DOC] Mark Pizza&Chili as deprecated

### DIFF
--- a/include/seqan/index/index_pizzachili.h
+++ b/include/seqan/index/index_pizzachili.h
@@ -54,9 +54,11 @@ namespace seqan {
  * @see PizzaChiliIndex
  *
  * @tag PizzaChiliIndexFibres#PizzaChiliText
+ * @deprecated Module is outdated and is not maintained anymore. Will presumably be removed in the next major release.
  * @brief The original text the index is based on.
  *
  * @tag PizzaChiliIndexFibres#PizzaChiliCompressed
+ * @deprecated Module is outdated and is not maintained anymore. Will presumably be removed in the next major release.
  * @brief The compressed suffix array.
  */
 
@@ -70,6 +72,8 @@ typedef FibrePizzaChiliCompressed PizzaChiliCompressed;
 
 /*!
  * @class PizzaChiliIndex Pizza & Chili Index
+ *
+ * @deprecated Module is outdated and is not maintained anymore. Will presumably be removed in the next major release.
  *
  * @extends Index
  *

--- a/include/seqan/index/index_pizzachili_string.h
+++ b/include/seqan/index/index_pizzachili_string.h
@@ -44,6 +44,8 @@ namespace seqan {
 /*!
  * @class PizzaChiliString Pizza &amp; Chili String
  *
+ * @deprecated Module is outdated and is not maintained anymore. Will presumably be removed in the next major release.
+ *
  * @extends String
  *
  * @headerfile <seqan/index.h>

--- a/include/seqan/index/pizzachili_api.h
+++ b/include/seqan/index/pizzachili_api.h
@@ -69,6 +69,8 @@ struct PizzaChiliCodeProvider {
  *
  * @tag PizzaChiliIndexTags#PizzaChiliSada
  *
+ * @deprecated Module is outdated and is not maintained anymore. Will presumably be removed in the next major release.
+ *
  * @brief the compressed suffix array index.
  *
  * @section Remarks
@@ -77,9 +79,13 @@ struct PizzaChiliCodeProvider {
  *
  * @tag PizzaChiliIndexTags#PizzaChiliAF
  *
+ * @deprecated Module is outdated and is not maintained anymore. Will presumably be removed in the next major release.
+ *
  * @brief The alphabet-friendly FM index.
  *
  * @tag PizzaChiliIndexTags#PizzaChiili_RSA
+ *
+ * @deprecated Module is outdated and is not maintained anymore. Will presumably be removed in the next major release.
  *
  * @brief The repair suffix array index.
  *
@@ -89,6 +95,8 @@ struct PizzaChiliCodeProvider {
  *
  * @tag PizzaChiliIndexTags#PizzaChiliSA
  *
+ * @deprecated Module is outdated and is not maintained anymore. Will presumably be removed in the next major release.
+ *
  * @brief The simple suffix array index.
  *
  * @section Remarks
@@ -97,9 +105,13 @@ struct PizzaChiliCodeProvider {
  *
  * @tag PizzaChiliIndexTags#PizzaChiliFM
  *
+ * @deprecated Module is outdated and is not maintained anymore. Will presumably be removed in the next major release.
+ *
  * @brief The FM (full-text in minute space) index.
  *
  * @tag PizzaChiliIndexTags#PizzaChiliCcsa
+ *
+ * @deprecated Module is outdated and is not maintained anymore. Will presumably be removed in the next major release.
  *
  * @brief The compressed compact suffix array index.
  */


### PR DESCRIPTION
Referring to issue #1526.

I couldn't easily fix the Pizza&Chili-Index and thus just marked it as deprecated.