### PR TITLE
[INTERNAL] Disable warning 4503 on windows

### DIFF
--- a/include/seqan/platform.h
+++ b/include/seqan/platform.h
@@ -152,6 +152,22 @@
 #endif
 
 // ==========================================================================
+// Disable Warnings
+// ==========================================================================
+
+// Disable warning for identifer name truncation.  There is not much we can
+// do about this.  Boost also has this problem and they chose to suppress
+// it globally.  So did we.
+//
+// Documentation of C4503 from Microsoft:
+//   https://msdn.microsoft.com/en-us/library/074af4b6%28v=vs.140%29.aspx
+// Boost Warnings Guidelines:
+//   https://svn.boost.org/trac/boost/wiki/Guidelines/WarningsGuidelines
+#ifdef COMPILER_MSVC
+#pragma warning( disable : 4503 )
+#endif
+
+// ==========================================================================
 // Define Integers
 // ==========================================================================
 


### PR DESCRIPTION
Suppresses [C4503](https://msdn.microsoft.com/en-us/library/074af4b6%28v=vs.140%29.aspx) in msvc.