### PR TITLE
[INTERNAL] Fix non-constexpr function strcmp cannot be used in a cons…

### DIFF
--- a/tests/blast/test_blast_misc.h
+++ b/tests/blast/test_blast_misc.h
@@ -77,7 +77,7 @@ SEQAN_DEFINE_TEST(test_blast_program)
     /*** TEST string functions ***/
     // gcc can do the following, because it provides a constexpr strcmp implementation (not required by the standard)
     // it is not really important, though, just for demonstration purposes:
-#if defined(STDLIB_GNU)
+#if defined(COMPILER_GCC) || defined(COMPILER_INTEL)
     static_assert(strcmp(_programTagToString(n), "BLASTN") == 0,       "static assertion failed!");
 #endif
     SEQAN_ASSERT_EQ(_programTagToString(n2), "BLASTN");


### PR DESCRIPTION
…tant expression

Fixes current failing test of `Linux-3.16.0-4-amd64_clang++-3.5_32` on [cdash].(cdash.seqan.de/index.php?project=SeqAn)

```
In file included from /.../Linux-3.16.0-4-amd64_clang++-3.5_64/tests/blast/test_blast.cpp:45:

/.../Linux-3.16.0-4-amd64_clang++-3.5_64/tests/blast/test_blast_misc.h:81:19: error: static_assert expression is not an integral constant expression

    static_assert(strcmp(_programTagToString(n), "BLASTN") == 0,       "static assertion failed!");
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```