### PR TITLE
use c++14 by default and complain if it isn't set

### DIFF
--- a/include/seqan/platform.h
+++ b/include/seqan/platform.h
@@ -51,6 +51,9 @@
  */
 #ifdef _MSC_VER
 #define STDLIB_VS
+#if _MSC_VER < 1900
+#error Visual Studio versions older than version 14 / "2015" are not supported. Please upgrade.
+#endif
 #endif
 
 /*!
@@ -95,6 +98,11 @@
  */
 #if defined(__GNUC__) && !defined(__ICC) && !defined(__clang__)
 #define COMPILER_GCC
+#define COMPILER_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+#if COMPILER_VERSION < 40901
+    #warning GCC versions older than 4.9.1 are not supported, many modules will not work.
+#endif
+#undef COMPILER_VERSION
 #endif
 
 /*!
@@ -105,6 +113,9 @@
  */
 #if defined(__ICC)
 #define COMPILER_INTEL
+#if _ICC < 1600
+    #warning ICC versions older than 16 are not supported, many modules will not work.
+#endif
 #endif
 
 /*!
@@ -115,6 +126,21 @@
  */
 #if defined(__clang__)
 #define COMPILER_CLANG
+#define COMPILER_VERSION (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__)
+#if COMPILER_VERSION < 30500
+    #warning Clang versions older than 3.5.0 are not supported, many modules will not work.
+#endif
+#undef COMPILER_VERSION
+#endif
+
+// ==========================================================================
+// C++ standard macros
+// ==========================================================================
+
+#ifndef STDLIB_VS // all Visual Studio >= 2015 compilers are c++14 by default
+#if __cplusplus < 201300
+    #error SeqAn requires C++14! You must compile your application with -std=c++14, -std=gnu++14 or -std=c++1y.
+#endif
 #endif
 
 // ==========================================================================

--- a/include/seqan/platform.h
+++ b/include/seqan/platform.h
@@ -52,7 +52,7 @@
 #ifdef _MSC_VER
 #define STDLIB_VS
 #if _MSC_VER < 1900
-#error Visual Studio versions older than version 14 / "2015" are not supported. Please upgrade.
+#error Visual Studio versions older than version 14 / "2015" are not supported.
 #endif
 #endif
 
@@ -100,7 +100,7 @@
 #define COMPILER_GCC
 #define COMPILER_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #if COMPILER_VERSION < 40901
-    #warning GCC versions older than 4.9.1 are not supported, many modules will not work.
+    #warning GCC versions older than 4.9.1 are not supported.
 #endif
 #undef COMPILER_VERSION
 #endif
@@ -114,7 +114,7 @@
 #if defined(__ICC)
 #define COMPILER_INTEL
 #if _ICC < 1600
-    #warning ICC versions older than 16 are not supported, many modules will not work.
+    #warning ICC versions older than 16 are not supported.
 #endif
 #endif
 
@@ -128,7 +128,7 @@
 #define COMPILER_CLANG
 #define COMPILER_VERSION (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__)
 #if COMPILER_VERSION < 30500
-    #warning Clang versions older than 3.5.0 are not supported, many modules will not work.
+    #warning Clang versions older than 3.5.0 are not supported.
 #endif
 #undef COMPILER_VERSION
 #endif

--- a/manual/source/Infrastructure/Use/CMakeBuildDirs.rst
+++ b/manual/source/Infrastructure/Use/CMakeBuildDirs.rst
@@ -70,12 +70,6 @@ Debug and release builds:
 
 Of course the above can also be combined to have ``debug_clang37`` et cetera.
 
-.. caution::
-
-    **SeqAn requires C++11**
-
-    Depending on your setup you might get an error related to C++11 support. In this case you need to tell the compiler explicitly to use modern C++ standards by adding ``-DCMAKE_CXX_FLAGS=-std=c++11`` or ``-DCMAKE_CXX_FLAGS=-std=c++14``.
-
 Visual Studio
 ^^^^^^^^^^^^^
 

--- a/manual/source/Infrastructure/Use/CustomBuildSystem.rst
+++ b/manual/source/Infrastructure/Use/CustomBuildSystem.rst
@@ -17,6 +17,27 @@ You should be able to adapt the descriptions to configure your build system and/
 
    Simply adding its include folder to your include path or installing it globally makes it available to your program.
 
+
+C++14 Standard
+--------------
+
+On GNU/Linux, BSD and macOS, always add ``-std=c++14`` (or a newer standard) when building on the command line.
+
+For XCode on macOS you need to set this option in the project settings.
+
+As of Visual Studio 2015 our subset of C++14 is already available in all supported compilers.
+
+
+OpenMP
+------
+
+On GNU/Linux, BSD and macOS, add ``-fopenmp`` unless you are using Clang versions older than 3.8.0.
+
+For XCode on macOS OpenMP is not yet available.
+
+With Visual Studio OpenMP is switched on by default.
+
+
 Operating System specifics
 --------------------------
 
@@ -25,19 +46,18 @@ GNU/Linux
 
 **Libraries**
 
-Add the flag ``-lrt -lpthread`` to the ``g++`` compiler call.
+Add ``-lrt -lpthread`` to the compiler call.
 
 BSD
 ^^^
 
 **Libraries**
 
-Add the flag ``-lpthread -lexecinfo -lelf`` to the ``g++`` compiler call.
+Add ``-lpthread -lexecinfo -lelf`` to the compiler call.
 
 **Misc**
 
-Also define ``-D_GLIBCXX_USE_C99=1``.
-
+Also define ``-D_GLIBCXX_USE_C99=1`` if you are using gcc-4.9.
 
 Warning levels
 --------------
@@ -45,20 +65,13 @@ Warning levels
 It is recommended to compile your programs with as many warnings enabled as possible.
 This section explains which flags to set for different compilers.
 
-GCC
-^^^
+GCC, Clang, ICC (unix)
+^^^^^^^^^^^^^^^^^^^^^^
 
-For GCC, the following flags are recommended:
-
-::
-
-    -W -Wall -pedantic
-
-Explanation:
+The following flags are recommended:
 
 ``-W -Wall -pedantic``
   Maximal sensitivity of compiler against possible problems.
-
 
 
 Visual Studio
@@ -165,20 +178,6 @@ meaning
  If set to 1 then zlib is expected to be available.
  You have to link against the library (e.g. add ``-lz`` to your linker flags) and ``zlib.h`` must be in your include path.
 
-SEQAN_HAS_OPENMP
-^^^^^^^^^^^^^^^^
-
-possible value
-  0, 1
-
-default
-  0
-
-meaning
- If set to 1 then OpenMP is expected to be available.
- You might have to add ``-fopenmp`` and possibly ``-lgomp`` to your build. And OpenMP needs to be supported by your compiler.
-
-
 Settings Projects Using Seqan
 -----------------------------
 
@@ -217,7 +216,6 @@ This translates into the following GCC flags:
 .. caution::
 
     While some guides tell you to not use ``-O3`` this is absolutely crucial for SeqAn based applications to perform well. Unoptimized builds are slower by multiple factors!
-
 
 An Example Project Based On Makefiles
 -------------------------------------
@@ -302,7 +300,16 @@ For example, we could create a directory ``include`` parallel to ``src``, copy t
 Short Version
 -------------
 
-* Add both ``include`` to your include path (``-I``).
-* Linux/GCC flags: ``-lrt`` (required) ``-W -Wall -pedantic`` (optional).
-* Windows/MSVC flags: ``/W2 /wd4996 -D_CRT_SECURE_NO_WARNINGS`` (optional).
-* Defines: ``NDEBUG`` to also disable SeqAn assertions in release mode.
++---------+---------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
+| OS      | Compiler            | Flags                                                                                                                                       |
++=========+=====================+=============================================================================================================================================+
+| Linux   | GCC/Clang≥3.8/ICC   | ``-I /path/to/seqan/include -std=c++14 -O3 -DNDEBUG -W -Wall -pedantic -fopenmp -lpthread -lrt``                                            |
++---------+---------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
+| BSD     | GCC/Clang≥3.8/ICC   | ``-I /path/to/seqan/include -std=c++14 -O3 -DNDEBUG -W -Wall -pedantic -fopenmp -lpthread -lexecinfo -lelf -D_GLIBCXX_USE_C99=1``           |
++---------+---------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
+| macOS   | system's Clang      | ``-I /path/to/seqan/include -std=c++14 -O3 -DNDEBUG -W -Wall -pedantic``                                                                    |
++---------+---------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
+| Windows | Visual Studio MSVC  | ``/W2 /wd4996 -D_CRT_SECURE_NO_WARNINGS``                                                                                                   |
++---------+---------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
+
+Adapt the include path to the actual place of SeqAn's ``include`` folder!

--- a/manual/source/Infrastructure/Use/CustomBuildSystem.rst
+++ b/manual/source/Infrastructure/Use/CustomBuildSystem.rst
@@ -17,7 +17,6 @@ You should be able to adapt the descriptions to configure your build system and/
 
    Simply adding its include folder to your include path or installing it globally makes it available to your program.
 
-
 C++14 Standard
 --------------
 
@@ -27,7 +26,6 @@ For XCode on macOS you need to set this option in the project settings.
 
 As of Visual Studio 2015 our subset of C++14 is already available in all supported compilers.
 
-
 OpenMP
 ------
 
@@ -36,7 +34,6 @@ On GNU/Linux, BSD and macOS, add ``-fopenmp`` unless you are using Clang version
 For XCode on macOS OpenMP is not yet available.
 
 With Visual Studio OpenMP is switched on by default.
-
 
 Operating System specifics
 --------------------------

--- a/manual/source/Infrastructure/Use/FindSeqAnCMake.rst
+++ b/manual/source/Infrastructure/Use/FindSeqAnCMake.rst
@@ -99,7 +99,7 @@ If you instead did a full git checkout to your home-directory in the previous st
 
 .. tip::
 
-    Depending on your setup you might need to manually choose a more modern compiler and/or activate C++11 support! Please read :ref:`this page <infra-use-cmake-build-dirs>` for more information on configuring CMake builds.
+    Depending on your setup you might need to manually choose a more modern compiler! Please read :ref:`this page <infra-use-cmake-build-dirs>` for more information on configuring CMake builds. Don't forget to clean your CMake build directory after changing the compiler!
 
 Finally you can then build the application by calling
 
@@ -205,7 +205,7 @@ From within CMake you can check the variables ``ZLIB_FOUND`` or ``OpenMP_FOUND``
 ``SEQAN_HAS_BZIP2``
   ``TRUE`` if libbz2 was found.
 
-``SEQAN_HAS_OPENMP``
+``_OPENMP``
   ``TRUE`` if OpenMP was found.
 
 CMake build variables
@@ -226,3 +226,7 @@ Required additions to C++ compiler flags are in the following variable:
 
 ``SEQAN_CXX_FLAGS``
   C++ Compiler flags to add.
+
+  .. caution::
+
+    Please note that these variables include whatever has been added by the dependencies mentioned above so **do not add** e.g. ``${OpenMP_CXX_FLAGS}`` yourself!

--- a/util/cmake/FindSeqAn.cmake
+++ b/util/cmake/FindSeqAn.cmake
@@ -183,11 +183,11 @@ elseif (NOT MSVC) # this implies all compilers within visual studio
     #error NOCXX14
     #endif
     int main() {}")
-    check_cxx_source_compiles("${CXXSTD_TEST_SOURCE}" CXX14_DETECTED)
-    if (NOT CXX14_DETECTED)
+    check_cxx_source_compiles("${CXXSTD_TEST_SOURCE}" CXX14_BUILTIN)
+    if (NOT CXX14_BUILTIN)
         set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-        check_cxx_source_compiles("${CXXSTD_TEST_SOURCE}" CXX14_DETECTED)
-        if (NOT CXX14_DETECTED)
+        check_cxx_source_compiles("${CXXSTD_TEST_SOURCE}" CXX14_FLAG)
+        if (NOT CXX14_FLAG)
             message (FATAL_ERROR "SeqAn requires C++14 since v2.2.0, but your compiler does not support it.")
             return ()
         endif ()

--- a/util/cmake/FindSeqAn.cmake
+++ b/util/cmake/FindSeqAn.cmake
@@ -164,8 +164,6 @@ elseif (COMPILER_IS_MSVC)
     # require at least MSVC 19.0
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.0")
         message(FATAL_ERROR "MSVC version (${CMAKE_CXX_COMPILER_VERSION}) must be at least 19.0 (Visual Studio 2015)!")
-    else ()
-        set (CXX11_FOUND TRUE CACHE INTERNAL "Availability of c++11") # always active
     endif ()
 
 else ()
@@ -176,22 +174,25 @@ endif ()
 # Require C++11
 # ----------------------------------------------------------------------------
 
-if (NOT CXX11_FOUND)
+if (NOT (CMAKE_VERSION VERSION_LESS "3.1"))
+    set(CMAKE_CXX_STANDARD 14)
+    set(CMAKE_CXX_STANDARD_REQUIRED on)
+elseif (NOT MSVC) # this implies all compilers within visual studio
     set(CXXSTD_TEST_SOURCE
-    "#if !defined(__cplusplus) || (__cplusplus < 201103L)
-    #error NOCXX11
+    "#if !defined(__cplusplus) || (__cplusplus < 201300L)
+    #error NOCXX14
     #endif
     int main() {}")
-    check_cxx_source_compiles("${CXXSTD_TEST_SOURCE}" CXX11_DETECTED)
-    set (CXX11_FOUND ${CXX11_DETECTED} CACHE INTERNAL "Availability of c++11")
-    if (NOT CXX11_FOUND)
-        message (FATAL_ERROR "SeqAn requires C++11 since v2.1.0, but your compiler does "
-                "not support it. Make sure that you specify -std=c++11 in your CMAKE_CXX_FLAGS. "
-                "If you absolutely know what you are doing, you can overwrite this check "
-                " by defining CXX11_FOUND.")
-        return ()
-    endif (NOT CXX11_FOUND)
-endif (NOT CXX11_FOUND)
+    check_cxx_source_compiles("${CXXSTD_TEST_SOURCE}" CXX14_DETECTED)
+    if (NOT CXX14_DETECTED)
+        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+        check_cxx_source_compiles("${CXXSTD_TEST_SOURCE}" CXX14_DETECTED)
+        if (NOT CXX14_DETECTED)
+            message (FATAL_ERROR "SeqAn requires C++14 since v2.2.0, but your compiler does not support it.")
+            return ()
+        endif ()
+    endif ()
+endif ()
 
 # ----------------------------------------------------------------------------
 # Compile-specific settings and workarounds around missing CMake features.

--- a/util/cmake/SeqAnBuildSystem.cmake
+++ b/util/cmake/SeqAnBuildSystem.cmake
@@ -260,21 +260,6 @@ macro (seqan_build_system_init)
     # TODO(h-2): for icc on windows, replace the " -" in SEQAN_CXX_FLAGS with " /"
     #            find out whether clang/c2 takes - or / options
 
-    # automatic c++ standard detection/selection
-    if (NOT MSVC)
-        # find the highest c++ standard and select it
-        check_cxx_compiler_flag("-std=c++11" CXX11_DETECTED)
-        check_cxx_compiler_flag("-std=c++14" CXX14_DETECTED)
-    endif ()
-
-    set (CXX11_FOUND ${CXX11_DETECTED} CACHE INTERNAL "Availability of c++11")
-    set (CXX14_FOUND ${CXX14_DETECTED} CACHE INTERNAL "Availability of c++14")
-
-    if (CXX14_FOUND)
-        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-    elseif (CXX11_FOUND)
-        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-    endif ()
 endmacro (seqan_build_system_init)
 
 # ---------------------------------------------------------------------------

--- a/util/makefile_project/Makefile.rules
+++ b/util/makefile_project/Makefile.rules
@@ -1,5 +1,5 @@
 SRC=../src
-CXXFLAGS+=-I../../../include
+CXXFLAGS+=-I../include -std=c++14
 
 default: all
 all: main

--- a/util/makefile_project/release/Makefile
+++ b/util/makefile_project/release/Makefile
@@ -1,3 +1,3 @@
 include ../Makefile.rules
 
-CXXFLAGS+=-O3
+CXXFLAGS+=-O3 -DNDEBUG


### PR DESCRIPTION
* do source-coded checks for c++14 and minimum compiler versions
* improve documentation for non-cmake consumers of SeqAn
* minor design fixes ans improvements to manual
* remove references to c++-standard from the cmake-manual

The last point depends on @marehr changing our cmake-module so that it automatically set the c++-standard to 14 if required. I am convinced this is the only right thing to do.