### PR TITLE
Hot fix for travis llvm builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,28 +32,42 @@ matrix:
       #install: export CXX="g++-6" CC="gcc-6"
 
     - os: linux
-      compiler: clang-3.5
+      #compiler: clang-3.5  #TODO: Revert if llvm-toolchain-precise is available again.
+      env:
+        - LLVM_VERSION=3.5.2
+        - LLVM_ARCHIVE_PATH=$HOME/clang+llvm.tar.xz
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test', 'george-edison55-precise-backports', 'llvm-toolchain-precise-3.5']
-          packages: ['clang-3.5', 'g++-4.9', 'cmake', 'cmake-data', 'zlib1g-dev', 'libbz2-dev', 'libboost-dev', 'python', 'python-nose', 'python-jinja2', 'python-pip'] # g++ required for newer libstdc++
-      install: export CXX="clang++-3.5" CC="clang-3.5"
+          sources: ['ubuntu-toolchain-r-test', 'george-edison55-precise-backports'] #, 'llvm-toolchain-precise-3.5']
+          packages: ['g++-4.9', 'cmake', 'cmake-data', 'zlib1g-dev', 'libbz2-dev', 'libboost-dev', 'python', 'python-nose', 'python-jinja2', 'python-pip'] # g++ required for newer libstdc++
+      before_install:
+        - wget http://llvm.org/releases/$LLVM_VERSION/clang+llvm-$LLVM_VERSION-x86_64-linux-gnu-ubuntu-14.04.tar.xz -O $LLVM_ARCHIVE_PATH
+        - mkdir $HOME/clang+llvm
+        - tar xf $LLVM_ARCHIVE_PATH -C $HOME/clang+llvm --strip-components 1
+        - export PATH=$HOME/clang+llvm/bin:$PATH
+      install: export CXX="clang++" CC="clang" LD_LIBRARY_PATH=$HOME/clang+llvm/lib:$LD_LIBRARY_PATH
 
     - os: linux
-      compiler: clang-3.6
+      #compiler: clang-3.6  #TODO: Revert if llvm-toolchain-precise is available again.
+      env:
+        - LLVM_VERSION=3.6.2
+        - LLVM_ARCHIVE_PATH=$HOME/clang+llvm.tar.xz
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test', 'george-edison55-precise-backports', 'llvm-toolchain-precise-3.6']
-          packages: ['clang-3.6', 'g++-4.9', 'cmake', 'cmake-data', 'zlib1g-dev', 'libbz2-dev', 'libboost-dev', 'python', 'python-nose', 'python-jinja2', 'python-pip'] # g++ required for newer libstdc++
-      install: export CXX="clang++-3.6" CC="clang-3.6"
+          sources: ['ubuntu-toolchain-r-test', 'george-edison55-precise-backports'] #, 'llvm-toolchain-precise-3.6']
+          packages: ['g++-4.9', 'cmake', 'cmake-data', 'zlib1g-dev', 'libbz2-dev', 'libboost-dev', 'python', 'python-nose', 'python-jinja2', 'python-pip'] # g++ required for newer libstdc++
+      install: export CXX="clang++" CC="clang" LD_LIBRARY_PATH=$HOME/clang+llvm/lib:$LD_LIBRARY_PATH
 
     - os: linux
-      compiler: clang-3.7
+      #compiler: clang-3.7  #TODO: Revert if llvm-toolchain-precise is available again.
+      env:
+        - LLVM_VERSION=3.7.1
+        - LLVM_ARCHIVE_PATH=$HOME/clang+llvm.tar.xz
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test', 'george-edison55-precise-backports', 'llvm-toolchain-precise-3.7']
-          packages: ['clang-3.7', 'g++-4.9', 'cmake', 'cmake-data', 'zlib1g-dev', 'libbz2-dev', 'libboost-dev', 'python', 'python-nose', 'python-jinja2', 'python-pip'] # g++ required for newer libstdc++
-      install: export CXX="clang++-3.7" CC="clang-3.7"
+          sources: ['ubuntu-toolchain-r-test', 'george-edison55-precise-backports']#, 'llvm-toolchain-precise-3.7']
+          packages: ['g++-4.9', 'cmake', 'cmake-data', 'zlib1g-dev', 'libbz2-dev', 'libboost-dev', 'python', 'python-nose', 'python-jinja2', 'python-pip'] # g++ required for newer libstdc++
+      install: export CXX="clang++" CC="clang" LD_LIBRARY_PATH=$HOME/clang+llvm/lib:$LD_LIBRARY_PATH
 
 # currently too slow on osx
     #- os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,6 @@ matrix:
         - mkdir $HOME/clang+llvm
         - tar xf $LLVM_ARCHIVE_PATH -C $HOME/clang+llvm --strip-components 1
         - ln -s clang++ $HOME/clang+llvm/bin/clang++-3.7
-        - ln -s clang $HOME/clang+llvm/bin/clang-3.7
         - export PATH=$HOME/clang+llvm/bin:$PATH
       install: export CXX="clang++-3.7" CC="clang-3.7" LD_LIBRARY_PATH=$HOME/clang+llvm/lib:$LD_LIBRARY_PATH
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,10 @@ matrix:
         - wget http://llvm.org/releases/$LLVM_VERSION/clang+llvm-$LLVM_VERSION-x86_64-linux-gnu-ubuntu-14.04.tar.xz -O $LLVM_ARCHIVE_PATH
         - mkdir $HOME/clang+llvm
         - tar xf $LLVM_ARCHIVE_PATH -C $HOME/clang+llvm --strip-components 1
+        - ln -s clang++ $HOME/clang+llvm/bin/clang++-3.5
+        - ln -s clang $HOME/clang+llvm/bin/clang-3.5
         - export PATH=$HOME/clang+llvm/bin:$PATH
-      install: export CXX="clang++" CC="clang" LD_LIBRARY_PATH=$HOME/clang+llvm/lib:$LD_LIBRARY_PATH
+      install: export CXX="clang++-3.5" CC="clang-3.5" LD_LIBRARY_PATH=$HOME/clang+llvm/lib:$LD_LIBRARY_PATH
 
     - os: linux
       #compiler: clang-3.6  #TODO: Revert if llvm-toolchain-precise is available again.
@@ -56,7 +58,14 @@ matrix:
         apt:
           sources: ['ubuntu-toolchain-r-test', 'george-edison55-precise-backports'] #, 'llvm-toolchain-precise-3.6']
           packages: ['g++-4.9', 'cmake', 'cmake-data', 'zlib1g-dev', 'libbz2-dev', 'libboost-dev', 'python', 'python-nose', 'python-jinja2', 'python-pip'] # g++ required for newer libstdc++
-      install: export CXX="clang++" CC="clang" LD_LIBRARY_PATH=$HOME/clang+llvm/lib:$LD_LIBRARY_PATH
+      before_install:
+        - wget http://llvm.org/releases/$LLVM_VERSION/clang+llvm-$LLVM_VERSION-x86_64-linux-gnu-ubuntu-14.04.tar.xz -O $LLVM_ARCHIVE_PATH
+        - mkdir $HOME/clang+llvm
+        - tar xf $LLVM_ARCHIVE_PATH -C $HOME/clang+llvm --strip-components 1
+        - ln -s clang++ $HOME/clang+llvm/bin/clang++-3.6
+        - ln -s clang $HOME/clang+llvm/bin/clang-3.6
+        - export PATH=$HOME/clang+llvm/bin:$PATH
+      install: export CXX="clang++-3.6" CC="clang-3.6" LD_LIBRARY_PATH=$HOME/clang+llvm/lib:$LD_LIBRARY_PATH
 
     - os: linux
       #compiler: clang-3.7  #TODO: Revert if llvm-toolchain-precise is available again.
@@ -67,7 +76,14 @@ matrix:
         apt:
           sources: ['ubuntu-toolchain-r-test', 'george-edison55-precise-backports']#, 'llvm-toolchain-precise-3.7']
           packages: ['g++-4.9', 'cmake', 'cmake-data', 'zlib1g-dev', 'libbz2-dev', 'libboost-dev', 'python', 'python-nose', 'python-jinja2', 'python-pip'] # g++ required for newer libstdc++
-      install: export CXX="clang++" CC="clang" LD_LIBRARY_PATH=$HOME/clang+llvm/lib:$LD_LIBRARY_PATH
+      before_install:
+        - wget http://llvm.org/releases/$LLVM_VERSION/clang+llvm-$LLVM_VERSION-x86_64-linux-gnu-ubuntu-14.04.tar.xz -O $LLVM_ARCHIVE_PATH
+        - mkdir $HOME/clang+llvm
+        - tar xf $LLVM_ARCHIVE_PATH -C $HOME/clang+llvm --strip-components 1
+        - ln -s clang++ $HOME/clang+llvm/bin/clang++-3.7
+        - ln -s clang $HOME/clang+llvm/bin/clang-3.7
+        - export PATH=$HOME/clang+llvm/bin:$PATH
+      install: export CXX="clang++-3.7" CC="clang-3.7" LD_LIBRARY_PATH=$HOME/clang+llvm/lib:$LD_LIBRARY_PATH
 
 # currently too slow on osx
     #- os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,15 +32,14 @@ matrix:
       #install: export CXX="g++-6" CC="gcc-6"
 
     - os: linux
-      #compiler: clang-3.5  #TODO: Revert if llvm-toolchain-precise is available again.
-      env:
-        - LLVM_VERSION=3.5.2
-        - LLVM_ARCHIVE_PATH=$HOME/clang+llvm.tar.xz
+      compiler: clang-3.5  #TODO: Revert if llvm-toolchain-precise is available again.
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test', 'george-edison55-precise-backports'] #, 'llvm-toolchain-precise-3.5']
           packages: ['g++-4.9', 'cmake', 'cmake-data', 'zlib1g-dev', 'libbz2-dev', 'libboost-dev', 'python', 'python-nose', 'python-jinja2', 'python-pip'] # g++ required for newer libstdc++
       before_install:
+        - export LLVM_VERSION=3.5.2
+        - export LLVM_ARCHIVE_PATH=$HOME/clang+llvm.tar.xz
         - wget http://llvm.org/releases/$LLVM_VERSION/clang+llvm-$LLVM_VERSION-x86_64-linux-gnu-ubuntu-14.04.tar.xz -O $LLVM_ARCHIVE_PATH
         - mkdir $HOME/clang+llvm
         - tar xf $LLVM_ARCHIVE_PATH -C $HOME/clang+llvm --strip-components 1
@@ -50,15 +49,14 @@ matrix:
       install: export CXX="clang++-3.5" CC="clang-3.5" LD_LIBRARY_PATH=$HOME/clang+llvm/lib:$LD_LIBRARY_PATH
 
     - os: linux
-      #compiler: clang-3.6  #TODO: Revert if llvm-toolchain-precise is available again.
-      env:
-        - LLVM_VERSION=3.6.2
-        - LLVM_ARCHIVE_PATH=$HOME/clang+llvm.tar.xz
+      compiler: clang-3.6  #TODO: Revert if llvm-toolchain-precise is available again.
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test', 'george-edison55-precise-backports'] #, 'llvm-toolchain-precise-3.6']
           packages: ['g++-4.9', 'cmake', 'cmake-data', 'zlib1g-dev', 'libbz2-dev', 'libboost-dev', 'python', 'python-nose', 'python-jinja2', 'python-pip'] # g++ required for newer libstdc++
       before_install:
+        - export LLVM_VERSION=3.6.2
+        - export LLVM_ARCHIVE_PATH=$HOME/clang+llvm.tar.xz
         - wget http://llvm.org/releases/$LLVM_VERSION/clang+llvm-$LLVM_VERSION-x86_64-linux-gnu-ubuntu-14.04.tar.xz -O $LLVM_ARCHIVE_PATH
         - mkdir $HOME/clang+llvm
         - tar xf $LLVM_ARCHIVE_PATH -C $HOME/clang+llvm --strip-components 1
@@ -68,15 +66,14 @@ matrix:
       install: export CXX="clang++-3.6" CC="clang-3.6" LD_LIBRARY_PATH=$HOME/clang+llvm/lib:$LD_LIBRARY_PATH
 
     - os: linux
-      #compiler: clang-3.7  #TODO: Revert if llvm-toolchain-precise is available again.
-      env:
-        - LLVM_VERSION=3.7.1
-        - LLVM_ARCHIVE_PATH=$HOME/clang+llvm.tar.xz
+      compiler: clang-3.7  #TODO: Revert if llvm-toolchain-precise is available again.
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test', 'george-edison55-precise-backports']#, 'llvm-toolchain-precise-3.7']
           packages: ['g++-4.9', 'cmake', 'cmake-data', 'zlib1g-dev', 'libbz2-dev', 'libboost-dev', 'python', 'python-nose', 'python-jinja2', 'python-pip'] # g++ required for newer libstdc++
       before_install:
+        - export LLVM_VERSION=3.7.1
+        - export LLVM_ARCHIVE_PATH=$HOME/clang+llvm.tar.xz
         - wget http://llvm.org/releases/$LLVM_VERSION/clang+llvm-$LLVM_VERSION-x86_64-linux-gnu-ubuntu-14.04.tar.xz -O $LLVM_ARCHIVE_PATH
         - mkdir $HOME/clang+llvm
         - tar xf $LLVM_ARCHIVE_PATH -C $HOME/clang+llvm --strip-components 1


### PR DESCRIPTION
Downloads the llvm binaries and uses them instead of using apt package manager, since llvm-toolchain-precise repo is temporarily switched off.
See here for more details: http://lists.llvm.org/pipermail/llvm-dev/2016-May/100303.html