### PR TITLE
[FIX] defaulted to Exact()  CharString

### DIFF
--- a/include/seqan/bam_io/read_sam.h
+++ b/include/seqan/bam_io/read_sam.h
@@ -164,7 +164,7 @@ readRecord(BamHeaderRecord & record,
     {
         skipOne(iter, IsTab());
 
-        appendValue(record.tags, Pair<CharString>());
+        appendValue(record.tags, Pair<CharString>(), Exact());
 
         clear(buffer);
         readLine(buffer, iter);
@@ -177,7 +177,7 @@ readRecord(BamHeaderRecord & record,
         {
             skipOne(iter, IsTab());
 
-            appendValue(record.tags, Pair<CharString>());
+            appendValue(record.tags, Pair<CharString>(), Exact());
 
             clear(buffer);
             readUntil(buffer, iter, EqualsChar<':'>());


### PR DESCRIPTION
The references in bam files are now stored in  Exact()  CharString. This brings about 5X lower memory footprint for the case specified in #1653 

credit to @rrahn 

This fixes #1653 