### PR TITLE
[FIX] Alignment: Fixing MyersHirschberg implementation.

### DIFF
--- a/include/seqan/align/global_alignment_hirschberg_impl.h
+++ b/include/seqan/align/global_alignment_hirschberg_impl.h
@@ -62,11 +62,11 @@ typedef Tag<Hirschberg_> Hirschberg;
 class HirschbergSet_
 {
 public:
-    unsigned x1 = 0;
-    unsigned x2 = 0;
-    unsigned y1 = 0;
-    unsigned y2 = 0;
-    int score   = 0;
+    unsigned x1;
+    unsigned x2;
+    unsigned y1;
+    unsigned y2;
+    int score;
 };
 
 // ============================================================================

--- a/include/seqan/align/global_alignment_hirschberg_impl.h
+++ b/include/seqan/align/global_alignment_hirschberg_impl.h
@@ -62,31 +62,11 @@ typedef Tag<Hirschberg_> Hirschberg;
 class HirschbergSet_
 {
 public:
-    int x1,x2,y1,y2;
-    int score;
-
-    HirschbergSet_()
-        : x1(0), x2(0), y1(0), y2(0), score(0)
-    {}
-
-    HirschbergSet_(int a1,int a2,int b1,int b2,int sc)
-        : x1(a1), x2(a2), y1(b1), y2(b2), score(sc)
-    {
-        SEQAN_ASSERT_LEQ(a1, a2);
-        SEQAN_ASSERT_LEQ(b1, b2);
-    }
-
-    HirschbergSet_ &
-    operator=(HirschbergSet_ const & other_)
-    {
-        x1 = other_.x1;
-        x2 = other_.x2;
-        y1 = other_.y1;
-        y2 = other_.y2;
-        score = other_.score;
-        return *this;
-    }
-
+    unsigned x1 = 0;
+    unsigned x2 = 0;
+    unsigned y1 = 0;
+    unsigned y2 = 0;
+    int score   = 0;
 };
 
 // ============================================================================
@@ -101,13 +81,13 @@ public:
 // Function _begin1()
 // ----------------------------------------------------------------------------
 
-inline int&
+inline unsigned&
 _begin1(HirschbergSet_ & me) {
     return me.x1;
 }
 
 
-inline int const&
+inline unsigned const&
 _begin1(HirschbergSet_ const & me) {
     return me.x1;
 }
@@ -117,7 +97,7 @@ _begin1(HirschbergSet_ const & me) {
 // ----------------------------------------------------------------------------
 
 inline void
-_setBegin1(HirschbergSet_ & me, int const & new_begin) {
+_setBegin1(HirschbergSet_ & me, unsigned const & new_begin) {
     me.x1 = new_begin;
 }
 
@@ -125,12 +105,12 @@ _setBegin1(HirschbergSet_ & me, int const & new_begin) {
 // Function _end1()
 // ----------------------------------------------------------------------------
 
-inline int&
+inline unsigned&
 _end1(HirschbergSet_ & me) {
     return me.x2;
 }
 
-inline int const&
+inline unsigned const&
 _end1(HirschbergSet_ const & me) {
     return me.x2;
 }
@@ -140,7 +120,7 @@ _end1(HirschbergSet_ const & me) {
 // ----------------------------------------------------------------------------
 
 inline void
-_setEnd1(HirschbergSet_ & me, int const & new_end) {
+_setEnd1(HirschbergSet_ & me, unsigned const & new_end) {
     me.x2 = new_end;
 }
 
@@ -148,12 +128,12 @@ _setEnd1(HirschbergSet_ & me, int const & new_end) {
 // Function _begin2()
 // ----------------------------------------------------------------------------
 
-inline int&
+inline unsigned&
 _begin2(HirschbergSet_ & me) {
     return me.y1;
 }
 
-inline int const&
+inline unsigned const&
 _begin2(HirschbergSet_ const & me) {
     return me.y1;
 }
@@ -163,7 +143,7 @@ _begin2(HirschbergSet_ const & me) {
 // ----------------------------------------------------------------------------
 
 inline void
-_setBegin2(HirschbergSet_ & me, int const & new_begin) {
+_setBegin2(HirschbergSet_ & me, unsigned const & new_begin) {
     me.y1 = new_begin;
 }
 
@@ -171,12 +151,12 @@ _setBegin2(HirschbergSet_ & me, int const & new_begin) {
 // Function _end2()
 // ----------------------------------------------------------------------------
 
-inline int&
+inline unsigned&
 _end2(HirschbergSet_ & me) {
     return me.y2;
 }
 
-inline int const&
+inline unsigned const&
 _end2(HirschbergSet_ const & me) {
     return me.y2;
 }
@@ -186,7 +166,7 @@ _end2(HirschbergSet_ const & me) {
 // ----------------------------------------------------------------------------
 
 inline void
-_setEnd2(HirschbergSet_ & me, int const & new_end) {
+_setEnd2(HirschbergSet_ & me, unsigned const & new_end) {
     me.y2 = new_end;
 }
 
@@ -403,7 +383,7 @@ _globalAlignment(Gaps<TSequenceH, TGapsSpecH> & gapsH,
     String<TScoreValue> c_score;
     resize(c_score,len2 + 1);
     // string to strore the backpointers
-    String<int> pointer;
+    String<unsigned> pointer;
     resize(pointer,len2 + 1);
 
     // scoring-scheme specific score values
@@ -417,9 +397,9 @@ _globalAlignment(Gaps<TSequenceH, TGapsSpecH> & gapsH,
     std::stack<HirschbergSet_> to_process;
     HirschbergSet_ target;
 
-    int i,j;
+    unsigned i,j;
 
-    HirschbergSet_ hs_complete(0,len1,0,len2,0);
+    HirschbergSet_ hs_complete {0, static_cast<unsigned>(len1), 0, static_cast<unsigned>(len2), 0};
     to_process.push(hs_complete);
 
     while(!to_process.empty())
@@ -617,7 +597,7 @@ _globalAlignment(Gaps<TSequenceH, TGapsSpecH> & gapsH,
                 using a backpointer to remember the position where the optimal alignment passes
                 the mid column
             */
-            int mid = static_cast<int>(floor( static_cast<double>((_begin1(target) + _end1(target))/2) ));
+            unsigned mid = static_cast<unsigned>(floor( static_cast<double>((_begin1(target) + _end1(target))/2) ));
 
 #ifdef SEQAN_HIRSCHBERG_DEBUG_CUT
             std::cout << "calculate cut for s1 " << _begin1(target) << " to " << _end1(target) << " and s2 " << _begin2(target) << " to " << _end2(target) << std::endl;
@@ -701,8 +681,8 @@ _globalAlignment(Gaps<TSequenceH, TGapsSpecH> & gapsH,
             std::cout << "requested position in c_score and pointer is " << _end2(target) << std::endl;
             std::cout << "alignment score is " << c_score[_end2(target)] << std::endl << std::endl;
 #endif
-            to_process.push(HirschbergSet_(mid,_end1(target),pointer[_end2(target)],_end2(target),0));
-            to_process.push(HirschbergSet_(_begin1(target),mid,_begin2(target),pointer[_end2(target)],0));
+            to_process.push(HirschbergSet_ { mid, _end1(target), pointer[_end2(target)], _end2(target), 0});
+            to_process.push(HirschbergSet_ { _begin1(target), mid, _begin2(target), pointer[_end2(target)], 0});
         }
         /* END CUT */
     }

--- a/include/seqan/align/global_alignment_hirschberg_impl.h
+++ b/include/seqan/align/global_alignment_hirschberg_impl.h
@@ -81,13 +81,13 @@ public:
 // Function _begin1()
 // ----------------------------------------------------------------------------
 
-inline unsigned&
+inline unsigned &
 _begin1(HirschbergSet_ & me) {
     return me.x1;
 }
 
 
-inline unsigned const&
+inline unsigned const &
 _begin1(HirschbergSet_ const & me) {
     return me.x1;
 }
@@ -105,12 +105,12 @@ _setBegin1(HirschbergSet_ & me, unsigned const & new_begin) {
 // Function _end1()
 // ----------------------------------------------------------------------------
 
-inline unsigned&
+inline unsigned &
 _end1(HirschbergSet_ & me) {
     return me.x2;
 }
 
-inline unsigned const&
+inline unsigned const &
 _end1(HirschbergSet_ const & me) {
     return me.x2;
 }
@@ -128,12 +128,12 @@ _setEnd1(HirschbergSet_ & me, unsigned const & new_end) {
 // Function _begin2()
 // ----------------------------------------------------------------------------
 
-inline unsigned&
+inline unsigned &
 _begin2(HirschbergSet_ & me) {
     return me.y1;
 }
 
-inline unsigned const&
+inline unsigned const &
 _begin2(HirschbergSet_ const & me) {
     return me.y1;
 }
@@ -151,12 +151,12 @@ _setBegin2(HirschbergSet_ & me, unsigned const & new_begin) {
 // Function _end2()
 // ----------------------------------------------------------------------------
 
-inline unsigned&
+inline unsigned &
 _end2(HirschbergSet_ & me) {
     return me.y2;
 }
 
-inline unsigned const&
+inline unsigned const &
 _end2(HirschbergSet_ const & me) {
     return me.y2;
 }
@@ -174,7 +174,7 @@ _setEnd2(HirschbergSet_ & me, unsigned const & new_end) {
 // Function _score()
 // ----------------------------------------------------------------------------
 
-inline int&
+inline int &
 _score(HirschbergSet_ & me)    {
     return me.score;
 }
@@ -183,7 +183,7 @@ _score(HirschbergSet_ & me)    {
 // Function _score()
 // ----------------------------------------------------------------------------
 
-inline int const&
+inline int const &
 _score(HirschbergSet_ const & me)
 {
     return me.score;
@@ -681,8 +681,8 @@ _globalAlignment(Gaps<TSequenceH, TGapsSpecH> & gapsH,
             std::cout << "requested position in c_score and pointer is " << _end2(target) << std::endl;
             std::cout << "alignment score is " << c_score[_end2(target)] << std::endl << std::endl;
 #endif
-            to_process.push(HirschbergSet_ { mid, _end1(target), pointer[_end2(target)], _end2(target), 0});
-            to_process.push(HirschbergSet_ { _begin1(target), mid, _begin2(target), pointer[_end2(target)], 0});
+            to_process.push(HirschbergSet_ {mid, _end1(target), pointer[_end2(target)], _end2(target), 0});
+            to_process.push(HirschbergSet_ {_begin1(target), mid, _begin2(target), pointer[_end2(target)], 0});
         }
         /* END CUT */
     }

--- a/include/seqan/align/global_alignment_hirschberg_impl.h
+++ b/include/seqan/align/global_alignment_hirschberg_impl.h
@@ -399,7 +399,7 @@ _globalAlignment(Gaps<TSequenceH, TGapsSpecH> & gapsH,
 
     unsigned i,j;
 
-    HirschbergSet_ hs_complete {0, static_cast<unsigned>(len1), 0, static_cast<unsigned>(len2), 0};
+    HirschbergSet_ hs_complete{0, static_cast<unsigned>(len1), 0, static_cast<unsigned>(len2), 0};
     to_process.push(hs_complete);
 
     while(!to_process.empty())
@@ -681,8 +681,8 @@ _globalAlignment(Gaps<TSequenceH, TGapsSpecH> & gapsH,
             std::cout << "requested position in c_score and pointer is " << _end2(target) << std::endl;
             std::cout << "alignment score is " << c_score[_end2(target)] << std::endl << std::endl;
 #endif
-            to_process.push(HirschbergSet_ {mid, _end1(target), pointer[_end2(target)], _end2(target), 0});
-            to_process.push(HirschbergSet_ {_begin1(target), mid, _begin2(target), pointer[_end2(target)], 0});
+            to_process.push(HirschbergSet_{mid, _end1(target), pointer[_end2(target)], _end2(target), 0});
+            to_process.push(HirschbergSet_{_begin1(target), mid, _begin2(target), pointer[_end2(target)], 0});
         }
         /* END CUT */
     }

--- a/include/seqan/align/global_alignment_myers_hirschberg_impl.h
+++ b/include/seqan/align/global_alignment_myers_hirschberg_impl.h
@@ -167,6 +167,21 @@ namespace seqan {
 // Function globalAlignment()
 // ----------------------------------------------------------------------------
 
+template <typename TStream, typename T>
+inline void
+_printBinary(TStream & stream, T const n)
+{
+    auto bits = BitsPerValue<T>::VALUE;
+    while (bits--)
+    {
+        if ((n >> bits) & 1)
+            stream << '1';
+        else
+            stream << '0';
+    }
+    stream << '\n';
+}
+
 // When using different alphabets, we will internally use the pattern alphabet
 // for the comparison.  This means that the text character is converted to the
 // pattern alphabet.  Here, the "pattern" is the shorter source sequence.
@@ -226,7 +241,7 @@ _globalAlignment(Gaps<TSequenceH, TGapsSpecH> & gapsH,
     TScoreValue score_gap = -1;
 
     // additional vars
-    int i;
+    unsigned i;
 
     // stack with parts of matrix that have to be processed
     std::stack<HirschbergSet_> to_process;
@@ -254,7 +269,7 @@ _globalAlignment(Gaps<TSequenceH, TGapsSpecH> & gapsH,
         reverseBitMask[blockCount * ordValue(getValue(y,len_y - j - 1)) + j/BLOCK_SIZE] = reverseBitMask[blockCount * ordValue(getValue(y,len_y - j - 1)) + j/BLOCK_SIZE] | 1 << (j%BLOCK_SIZE);
     }
 
-    HirschbergSet_ hs_complete(0,len_x,0,len_y,1);
+    HirschbergSet_ hs_complete {0, static_cast<unsigned>(len_x), 0, static_cast<unsigned>(len_y), 1};
     to_process.push(hs_complete);
 
     while(!to_process.empty())
@@ -472,7 +487,7 @@ _globalAlignment(Gaps<TSequenceH, TGapsSpecH> & gapsH,
             unsigned int X, D0, HN, HP;
 
             /* compute cut position */
-            int mid = static_cast<int>(floor( static_cast<double>((_begin2(target) + _end2(target))/2) ));
+            unsigned mid = static_cast<int>(floor( static_cast<double>((_begin2(target) + _end2(target))/2) ));
 
             /* debug infos */
 #ifdef MYERS_HIRSCHBERG_VERBOSE
@@ -485,22 +500,22 @@ _globalAlignment(Gaps<TSequenceH, TGapsSpecH> & gapsH,
             std::cout << std::endl;
 #endif
             /* compute blocks and score masks */
-            int fStartBlock = _begin2(target) / BLOCK_SIZE;
-            int fEndBlock = (mid - 1) / BLOCK_SIZE;
-            int fSpannedBlocks = (fEndBlock - fStartBlock) + 1;
+            unsigned fStartBlock = _begin2(target) / BLOCK_SIZE;
+            unsigned fEndBlock = (mid - 1) / BLOCK_SIZE;
+            unsigned fSpannedBlocks = (fEndBlock - fStartBlock) + 1;
 
-            unsigned int fScoreMask = 1 << ((mid  - 1) % BLOCK_SIZE);
+            unsigned int fScoreMask = 1 << ((mid - 1) % BLOCK_SIZE);
 
             unsigned int fOffSet = _begin2(target) % BLOCK_SIZE;
             unsigned int fSilencer = ~0;
             fSilencer <<= fOffSet;
 
             /* reset v-bitvectors */
-            std::fill(begin(VP, Standard()) + fStartBlock, end(VP, Standard()) + fEndBlock + 1, maxValue<unsigned>());
-            std::fill(begin(VN, Standard()) + fStartBlock, end(VN, Standard()) + fEndBlock + 1, 0);
+            std::fill(begin(VP, Standard()) + fStartBlock, begin(VP, Standard()) + fEndBlock + 1, maxValue<unsigned>());
+            std::fill(begin(VN, Standard()) + fStartBlock, begin(VN, Standard()) + fEndBlock + 1, 0);
 
             /* determine start-position and start-score */
-            int pos = _begin1(target);
+            auto pos = _begin1(target);
             score = (mid - _begin2(target)) * score_gap;
             c_score[pos] = score;
 
@@ -530,7 +545,7 @@ _globalAlignment(Gaps<TSequenceH, TGapsSpecH> & gapsH,
             } /* end - short patten */
             else
             {
-                int shift, currentBlock;
+                unsigned shift, currentBlock;
                 unsigned int temp, carryD0, carryHP, carryHN;
 
                 while (pos < _end1(target))
@@ -596,9 +611,9 @@ _globalAlignment(Gaps<TSequenceH, TGapsSpecH> & gapsH,
             /* compute with myers - forward - end */
 
             /* compute blocks and score masks */
-            int rStartBlock = (len_y - _end2(target)) / BLOCK_SIZE;
-            int rEndBlock = (len_y - mid - 1) / BLOCK_SIZE;
-            int rSpannedBlocks = (rEndBlock - rStartBlock) + 1;
+            unsigned rStartBlock = (len_y - _end2(target)) / BLOCK_SIZE;
+            unsigned rEndBlock = (len_y - mid - 1) / BLOCK_SIZE;
+            unsigned rSpannedBlocks = (rEndBlock - rStartBlock) + 1;
 
             unsigned int rScoreMask = 1 <<  ((len_y - mid - 1) % BLOCK_SIZE);
             unsigned int rOffSet = (len_y - _end2(target)) % BLOCK_SIZE;
@@ -606,11 +621,11 @@ _globalAlignment(Gaps<TSequenceH, TGapsSpecH> & gapsH,
             rSilencer <<= rOffSet;
 
             /* reset v-bitvectors */
-            std::fill(begin(VP, Standard()) + rStartBlock, end(VP, Standard()) + rEndBlock + 1, maxValue<unsigned>());
-            std::fill(begin(VN, Standard()) + rStartBlock, end(VN, Standard()) + rEndBlock + 1, 0);
+            std::fill(begin(VP, Standard()) + rStartBlock, begin(VP, Standard()) + rEndBlock + 1, maxValue<unsigned>());
+            std::fill(begin(VN, Standard()) + rStartBlock, begin(VN, Standard()) + rEndBlock + 1, 0);
 
             /* determine start-position and start-score */
-            pos = _end1(target)-1;
+            pos = _end1(target);
             score = (_end2(target) - mid) * score_gap;
 
             /* set start score */
@@ -624,7 +639,7 @@ _globalAlignment(Gaps<TSequenceH, TGapsSpecH> & gapsH,
             /* compute with myers - reverse - begin */
             if(rSpannedBlocks == 1)
             {
-                while (pos >= _begin1(target)) {
+                while (pos-- > _begin1(target)) {
                     X = (rSilencer & reverseBitMask[(blockCount * ordValue(static_cast<TPatternAlphabet>(getValue(x,pos)))) + rStartBlock]) | VN[rStartBlock];
 
                     D0 = ((VP[rStartBlock] + (X & VP[rStartBlock])) ^ VP[rStartBlock]) | X;
@@ -649,16 +664,14 @@ _globalAlignment(Gaps<TSequenceH, TGapsSpecH> & gapsH,
                         max = c_score[pos];
                         rmax =  score;
                     }
-
-                    --pos;
                 }
             } /* end - short pattern */
             else
             {
-                int shift, currentBlock;
+                unsigned shift, currentBlock;
                 unsigned int temp, carryD0, carryHP, carryHN;
 
-                while (pos >= _begin1(target))
+                while (pos-- > _begin1(target))
                 {
                     carryD0 = carryHP = carryHN = 0;
                     shift = blockCount * ordValue(static_cast<TPatternAlphabet>(getValue(x,pos)));
@@ -720,8 +733,6 @@ _globalAlignment(Gaps<TSequenceH, TGapsSpecH> & gapsH,
                         max = c_score[pos];
                         rmax = score;
                     }
-
-                    --pos;
                 }
 
             }  /* end - long pattern */
@@ -735,8 +746,8 @@ _globalAlignment(Gaps<TSequenceH, TGapsSpecH> & gapsH,
             printf("Optimal cut is at %i and %i with forward score %i and reverse score %i\n\n",mid,pos_max,(max - rmax),rmax);
 #endif
             /* push the two computed parts of the dp-matrix on process stack */
-            to_process.push(HirschbergSet_(pos_max,_end1(target),mid,_end2(target),rmax));
-            to_process.push(HirschbergSet_(_begin1(target),pos_max,_begin2(target),mid,max - rmax));
+            to_process.push(HirschbergSet_ {pos_max, _end1(target), mid, _end2(target), rmax});
+            to_process.push(HirschbergSet_ {_begin1(target), pos_max, _begin2(target), mid, max - rmax});
 
         }
         /* END CUT */

--- a/include/seqan/align/global_alignment_myers_hirschberg_impl.h
+++ b/include/seqan/align/global_alignment_myers_hirschberg_impl.h
@@ -269,7 +269,7 @@ _globalAlignment(Gaps<TSequenceH, TGapsSpecH> & gapsH,
         reverseBitMask[blockCount * ordValue(getValue(y,len_y - j - 1)) + j/BLOCK_SIZE] = reverseBitMask[blockCount * ordValue(getValue(y,len_y - j - 1)) + j/BLOCK_SIZE] | 1 << (j%BLOCK_SIZE);
     }
 
-    HirschbergSet_ hs_complete {0, static_cast<unsigned>(len_x), 0, static_cast<unsigned>(len_y), 1};
+    HirschbergSet_ hs_complete{0, static_cast<unsigned>(len_x), 0, static_cast<unsigned>(len_y), 1};
     to_process.push(hs_complete);
 
     while(!to_process.empty())
@@ -746,8 +746,8 @@ _globalAlignment(Gaps<TSequenceH, TGapsSpecH> & gapsH,
             printf("Optimal cut is at %i and %i with forward score %i and reverse score %i\n\n",mid,pos_max,(max - rmax),rmax);
 #endif
             /* push the two computed parts of the dp-matrix on process stack */
-            to_process.push(HirschbergSet_ {pos_max, _end1(target), mid, _end2(target), rmax});
-            to_process.push(HirschbergSet_ {_begin1(target), pos_max, _begin2(target), mid, max - rmax});
+            to_process.push(HirschbergSet_{pos_max, _end1(target), mid, _end2(target), rmax});
+            to_process.push(HirschbergSet_{_begin1(target), pos_max, _begin2(target), mid, max - rmax});
 
         }
         /* END CUT */

--- a/include/seqan/align/global_alignment_myers_hirschberg_impl.h
+++ b/include/seqan/align/global_alignment_myers_hirschberg_impl.h
@@ -35,6 +35,8 @@
 #ifndef SEQAN_INCLUDE_SEQAN_ALIGN_GLOBAL_ALIGNMENT_MYERS_HIRSCHBERG_IMPL_H_
 #define SEQAN_INCLUDE_SEQAN_ALIGN_GLOBAL_ALIGNMENT_MYERS_HIRSCHBERG_IMPL_H_
 
+#include <bitset>
+
 namespace seqan {
 
 // ============================================================================
@@ -164,23 +166,22 @@ namespace seqan {
 #endif
 
 // ----------------------------------------------------------------------------
-// Function globalAlignment()
+// Function _printBinary()
 // ----------------------------------------------------------------------------
 
+// Debug integer types in binary format.
 template <typename TStream, typename T>
 inline void
 _printBinary(TStream & stream, T const n)
 {
-    auto bits = BitsPerValue<T>::VALUE;
-    while (bits--)
-    {
-        if ((n >> bits) & 1)
-            stream << '1';
-        else
-            stream << '0';
-    }
+    std::bitset<BitsPerValue<T>::VALUE> bits(n);
+    stream << bits;
     stream << '\n';
 }
+
+// ----------------------------------------------------------------------------
+// Function globalAlignment()
+// ----------------------------------------------------------------------------
 
 // When using different alphabets, we will internally use the pattern alphabet
 // for the comparison.  This means that the text character is converted to the
@@ -596,6 +597,7 @@ _globalAlignment(Gaps<TSequenceH, TGapsSpecH> & gapsH,
                          VP[currentBlock] = temp | ~(X | D0);
                     }
 
+                    _printBinary(std::cout, HP);
                     /* update score */
                     if (HP & fScoreMask)
                         score--;


### PR DESCRIPTION
Hopefully fixes #1711.
I could not reproduce the same error, but I found some general issues with the current code.

1. Removed all constructors and assignment operator from ```HirschbergSet_``` and let compiler generate them.
2. Resetting the vectors ```VP``` and ```VN``` was ill formed and exceeded the vector boundaries.