### PR TITLE
bugfix: accept '=' operations in CIGAR string

### DIFF
--- a/include/seqan/bam_io/read_sam.h
+++ b/include/seqan/bam_io/read_sam.h
@@ -316,7 +316,7 @@ readRecord(BamAlignmentRecord & record,
         do
         {
             clear(buffer);
-            readUntil(buffer, iter, OrFunctor<IsAlpha, AssertFunctor<NotFunctor<IsNewline>, ParseError, Sam> >());
+            readUntil(buffer, iter, OrFunctor<NotFunctor<IsDigit>, AssertFunctor<NotFunctor<IsNewline>, ParseError, Sam> >());
             element.count = lexicalCast<uint32_t>(buffer);
             element.operation = value(iter);
             skipOne(iter);
@@ -397,4 +397,3 @@ readRecord(BamAlignmentRecord & record,
 }  // namespace seqan
 
 #endif  // #ifndef INCLUDE_SEQAN_BAM_IO_READ_SAM_H_
-


### PR DESCRIPTION
The official [SAM format spec](https://samtools.github.io/hts-specs/SAMv1.pdf) defines the operations {M,I,D,N,S,H,P,=,X}. Of these, '=' does not match the functor `IsAlpha`. Some tools, e.g. [ART](http://www.niehs.nih.gov/research/resources/software/biostatistics/art/) actually make use of that operation so parsing their output leads to an error like:
```
std::runtime_error: Unable to convert '150=	=	475654	-501	' into unsigned int.
```
using `NotFunctor<IsDigit>` (in place of `IsAlpha`) in `readUntil` fixes the issue.

I'll attach an example SAM file so you can reproduce the problem.

--Cheers

[pers_reads.min.sam.zip](https://github.com/seqan/seqan/files/334836/pers_reads.min.sam.zip)
