### PR TITLE
[INTERNAL] Fix warning C4146: unary minus operator applied to unsigne…

### DIFF
--- a/tests/basic/test_basic_alphabet_adapt_builtins.h
+++ b/tests/basic/test_basic_alphabet_adapt_builtins.h
@@ -218,9 +218,11 @@ SEQAN_DEFINE_TEST(test_basic_alphabet_adapt_builtins_concepts_int)
     {
         int b = 0, c = 42;
 
-        SEQAN_ASSERT_EQ(minValue(int()), -2147483648);
-        SEQAN_ASSERT_EQ(minValue<int>(), -2147483648);
-        SEQAN_ASSERT_EQ(+(MinValue<int>::VALUE), -2147483648);
+        // note(marehr): -2147483648 would produce the compiler warning C4146:
+        // unary minus operator applied to unsigned type, result still unsigned
+        SEQAN_ASSERT_EQ(minValue(int()), -2147483647 - 1);
+        SEQAN_ASSERT_EQ(minValue<int>(), -2147483647 - 1);
+        SEQAN_ASSERT_EQ(+(MinValue<int>::VALUE), -2147483647 - 1);
         SEQAN_ASSERT_EQ(maxValue(int()), 2147483647);
         SEQAN_ASSERT_EQ(maxValue<int>(), 2147483647);
         SEQAN_ASSERT_EQ(+(MaxValue<int>::VALUE), 2147483647);
@@ -501,9 +503,11 @@ SEQAN_DEFINE_TEST(test_basic_alphabet_adapt_builtins_concepts_int32)
     {
         int32_t b = 0, c = 42;
 
-        SEQAN_ASSERT_EQ(minValue(int32_t()), -2147483648);
-        SEQAN_ASSERT_EQ(minValue<int32_t>(), -2147483648);
-        SEQAN_ASSERT_EQ(+(MinValue<int32_t>::VALUE), -2147483648);
+        // note(marehr): -2147483648 would produce the compiler warning C4146:
+        // unary minus operator applied to unsigned type, result still unsigned
+        SEQAN_ASSERT_EQ(minValue(int32_t()), -2147483647 - 1);
+        SEQAN_ASSERT_EQ(minValue<int32_t>(), -2147483647 - 1);
+        SEQAN_ASSERT_EQ(+(MinValue<int32_t>::VALUE), -2147483647 - 1);
         SEQAN_ASSERT_EQ(maxValue(int32_t()), 2147483647);
         SEQAN_ASSERT_EQ(maxValue<int32_t>(), 2147483647);
         SEQAN_ASSERT_EQ(+(MaxValue<int32_t>::VALUE), 2147483647);


### PR DESCRIPTION
cdash fails with
```
warning C4146: unary minus operator applied to unsigned type, result still unsigned
```
on msvc 