### PR TITLE
[FIXES-#1779] deactivate one test on llvm35/freebsd

### DIFF
--- a/include/seqan/platform.h
+++ b/include/seqan/platform.h
@@ -436,4 +436,15 @@ typedef int8_t __int8;     // nolint
     #endif
 #endif //ndef SEQAN_ASYNC_IO
 
+// There is a bug in clang35 on FreeBSD that crashes the compiler.
+// Since this is only triggered on some codepaths we define a macro
+// here that we can later access.
+#if defined(__FreeBSD__) && defined(COMPILER_CLANG)
+#define COMPILER_VERSION (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__)
+#if (COMPILER_VERSION >= 30500) && (COMPILER_VERSION < 30600)
+    #define SEQAN_CLANG35_FREEBSD_BUG 1
+#endif
+#undef COMPILER_VERSION
+#endif
+
 #endif

--- a/include/seqan/sequence/container_view_zip.h
+++ b/include/seqan/sequence/container_view_zip.h
@@ -282,6 +282,9 @@ template <typename... TContTypes>
 inline ContainerView<std::tuple<typename std::remove_reference<TContTypes>::type...>, ZipContainer<> >
 makeZipView(TContTypes && ...contArgs)
 {
+#ifdef SEQAN_CLANG35_FREEBSD_BUG
+    static_assert(false, "The Zip Container triggers a bug on FreeBSD+clang-3.5, please upgrade you compiler!");
+#endif
     return ContainerView<std::tuple<typename std::remove_reference<TContTypes>::type...>, ZipContainer<> >(std::forward<TContTypes>(contArgs)...);
 }
 

--- a/tests/align/CMakeLists.txt
+++ b/tests/align/CMakeLists.txt
@@ -10,6 +10,14 @@ cmake_minimum_required (VERSION 3.0.0)
 project (seqan_tests_align CXX)
 message (STATUS "Configuring tests/align")
 
+set (ALIGN_SIMD_TEST TRUE CACHE INTERNAL "Whether to build test_align_simd.")
+# workaround a bug in llvm35 on FreeBSD
+if ((${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD") AND
+    (COMPILER_CLANG) AND
+    (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.6.0))
+    set (ALIGN_SIMD_TEST FALSE CACHE INTERNAL "Whether to build test_align_simd.")
+endif ()
+
 # ----------------------------------------------------------------------------
 # Dependencies
 # ----------------------------------------------------------------------------
@@ -54,13 +62,15 @@ add_executable (test_align
 # Add dependencies found by find_package (SeqAn).
 target_link_libraries (test_align ${SEQAN_LIBRARIES})
 
-# Add executable for simd tests.
-add_executable(test_align_simd
-               test_align_simd.cpp
-               test_align_simd.h)
+if (ALIGN_SIMD_TEST)
+    # Add executable for simd tests.
+    add_executable (test_align_simd
+                    test_align_simd.cpp
+                    test_align_simd.h)
 
-# Add dependencies found by find_package (SeqAn).
-target_link_libraries (test_align_simd ${SEQAN_LIBRARIES})
+    # Add dependencies found by find_package (SeqAn).
+    target_link_libraries (test_align_simd ${SEQAN_LIBRARIES})
+endif()
 
 # Add CXX flags found by find_package (SeqAn).
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SEQAN_CXX_FLAGS}")
@@ -70,4 +80,6 @@ set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SEQAN_CXX_FLAGS}")
 # ----------------------------------------------------------------------------
 
 add_test (NAME test_test_align COMMAND $<TARGET_FILE:test_align>)
-add_test (NAME test_test_align_simd COMMAND $<TARGET_FILE:test_align_simd>)
+if (ALIGN_SIMD_TEST)
+    add_test (NAME test_test_align_simd COMMAND $<TARGET_FILE:test_align_simd>)
+endif ()


### PR DESCRIPTION
removes the failed test we see on cdash-nightlies