### PR TITLE
Add ARM compatibility

### DIFF
--- a/include/seqan/align.h
+++ b/include/seqan/align.h
@@ -155,7 +155,7 @@
 #include <seqan/align/dp_context.h>
 #include <seqan/align/dp_setup.h>
 
-#if SEQAN_SIMD_ENABLED
+#ifdef SEQAN_SIMD_ENABLED
 #include <seqan/align/dp_scout_simd.h>
 #include <seqan/align/dp_align_simd_helper.h>
 #endif  // SEQAN_SIMD_ENABLED

--- a/include/seqan/align/align_interface_wrapper.h
+++ b/include/seqan/align/align_interface_wrapper.h
@@ -167,7 +167,7 @@ _alignWrapperSequential(StringSet<Gaps<TSequenceH, TGapsSpecH>, TSetSpecH> & gap
 template <typename... TArgs>
 inline auto _alignWrapper(TArgs && ...args)
 {
-#if SEQAN_SIMD_ENABLED
+#ifdef SEQAN_SIMD_ENABLED
     return _alignWrapperSimd(std::forward<TArgs>(args)...);
 #else
     return _alignWrapperSequential(std::forward<TArgs>(args)...);

--- a/include/seqan/basic/basic_allocator.h
+++ b/include/seqan/basic/basic_allocator.h
@@ -44,7 +44,6 @@
 #include <seqan/platform.h>
 #include <seqan/basic/basic_fundamental.h>
 #include <seqan/basic/basic_smart_pointer.h>
-#include <seqan/basic/basic_simd_vector.h>
 
 // --------------------------------------------------------------------------
 // Sub Module Headers

--- a/include/seqan/basic/basic_simd_vector.h
+++ b/include/seqan/basic/basic_simd_vector.h
@@ -43,15 +43,26 @@
 #include <tuple>
 //#include <seqan/basic/iterator_zip.h>
 
-#if defined(PLATFORM_WINDOWS_VS)
-  /* Microsoft C/C++-compatible compiler */
-  #include <intrin.h>
-#elif defined(PLATFORM_GCC) && (defined(__x86_64__) || defined(__i386__))
-  /* GCC-compatible compiler, targeting x86/x86-64 */
-  #include <x86intrin.h>
-#else
- #warning "No supported platform for SIMD vectorization!"
-#endif
+#if !defined(__arm__) || !defined(_M_ARM)  // We do not support arm architecture.
+#if defined(STDLIB_VS)  // Microsoft C/C++-compatible compiler
+    #include <intrin.h>
+#else  // GCC-compatible compiler, targeting x86/x86-64
+    #include <x86intrin.h>
+#endif  // defined(STDLIB_VS)
+
+// Define global macro to check if simd instructions are enabled.
+#define SEQAN_SIMD_ENABLED
+
+// Define maximal size of vector in byte.
+#if defined(__AVX2__)
+    #define SEQAN_SIZEOF_MAX_VECTOR 32
+#elif defined(__SSE4_1__) && defined(__SSE4_2__)
+    #define SEQAN_SSE4
+    #define SEQAN_SIZEOF_MAX_VECTOR 16
+#else  // defined(__AVX2__)
+    #undef SEQAN_SIMD_ENABLED  // Disable simd instructions.
+#endif  // defined(__AVX2__)
+#endif  // !defined(__arm__) || !defined(_M_ARM)
 
 namespace seqan {
 
@@ -63,7 +74,6 @@ namespace seqan {
 #define SEQAN_VECTOR_CAST_(T, v) reinterpret_cast<T>(v)
 #define SEQAN_VECTOR_CAST_LVALUE_(T, v) reinterpret_cast<T>(v)
 #endif
-
 
 // ============================================================================
 // Forwards
@@ -106,26 +116,12 @@ assignValue(TSimdVector &vector, TPosition pos, TValue2 value)                  
     vector[pos] = value;                                                                                \
 }
 
-// Define global macro to check if simd instructions are enabled.
-#define SEQAN_SIMD_ENABLED 1
-
-// Define maximal size of vector in byte.
-#if defined(__AVX2__)
-    #define SEQAN_SIZEOF_MAX_VECTOR 32
-#elif defined(__SSE4_1__) && defined(__SSE4_2__)
-    #define SEQAN_SSE4
-    #define SEQAN_SIZEOF_MAX_VECTOR 16
-#else
-    #undef SEQAN_SIMD_ENABLED
-    #define SEQAN_SIMD_ENABLED 0  // Disable simd instructions.
-#endif
-
 // define a concept and its models
 // they allow us to define generic vector functions
 SEQAN_CONCEPT(SimdVectorConcept, (T)) {};
 
 // Only include following code if simd instructions are enabled.
-#if SEQAN_SIMD_ENABLED
+#ifdef SEQAN_SIMD_ENABLED
 
 // ============================================================================
 // Tags, Classes, Enums

--- a/include/seqan/basic/basic_simd_vector.h
+++ b/include/seqan/basic/basic_simd_vector.h
@@ -41,9 +41,8 @@
 
 #include <utility>
 #include <tuple>
-//#include <seqan/basic/iterator_zip.h>
 
-#if !defined(__arm__) && !defined(_M_ARM)  // We do not support arm architecture.
+#if defined(amd64) || defined(x86__64) || defined(i386)  // Only support these architectures at the moment.
 #if defined(STDLIB_VS)  // Microsoft C/C++-compatible compiler
     #include <intrin.h>
 #else  // GCC-compatible compiler, targeting x86/x86-64
@@ -62,7 +61,7 @@
 #else  // defined(__AVX2__)
     #undef SEQAN_SIMD_ENABLED  // Disable simd instructions.
 #endif  // defined(__AVX2__)
-#endif  // !defined(__arm__) || !defined(_M_ARM)
+#endif  // defined(amd64) || defined(x86__64) || defined(i386)
 
 namespace seqan {
 

--- a/include/seqan/basic/basic_simd_vector.h
+++ b/include/seqan/basic/basic_simd_vector.h
@@ -43,7 +43,7 @@
 #include <tuple>
 //#include <seqan/basic/iterator_zip.h>
 
-#if !defined(__arm__) || !defined(_M_ARM)  // We do not support arm architecture.
+#if !defined(__arm__) && !defined(_M_ARM)  // We do not support arm architecture.
 #if defined(STDLIB_VS)  // Microsoft C/C++-compatible compiler
     #include <intrin.h>
 #else  // GCC-compatible compiler, targeting x86/x86-64

--- a/include/seqan/parallel/parallel_lock.h
+++ b/include/seqan/parallel/parallel_lock.h
@@ -213,7 +213,9 @@ struct ScopedWriteLock<TLock, Serial>
 inline void
 yieldProcessor()
 {
-#if defined(STDLIB_VS)
+#if defined(__arm__) || defined(_M_ARM)
+    asm volatile ("yield" ::: "memory");
+#elif defined(STDLIB_VS)
     YieldProcessor();
 #elif defined(__SSE2__)
     _mm_pause();

--- a/include/seqan/score.h
+++ b/include/seqan/score.h
@@ -49,7 +49,7 @@
 #include <seqan/score/score_matrix_dyn.h>
 #include <seqan/score/score_simple.h>
 
-#if SEQAN_SIMD_ENABLED
+#ifdef SEQAN_SIMD_ENABLED
 #include <seqan/score/score_simd_wrapper.h>
 #endif  // SEQAN_SIMD_ENABLED
 

--- a/tests/basic/test_basic_simd_vector.cpp
+++ b/tests/basic/test_basic_simd_vector.cpp
@@ -39,7 +39,8 @@
 
 SEQAN_BEGIN_TESTSUITE(test_basic_simd_vector)
 {
-#ifdef __SSE4_1__
+#ifdef SEQAN_SIMD_ENABLED
+#ifdef SEQAN_SSE4
     SEQAN_CALL_TEST(test_basic_simd_shuffle);
     SEQAN_CALL_TEST(test_basic_simd_transpose_8x8);
     SEQAN_CALL_TEST(test_basic_simd_transpose_16x16);
@@ -47,7 +48,8 @@ SEQAN_BEGIN_TESTSUITE(test_basic_simd_vector)
     SEQAN_CALL_TEST(test_basic_simd_shuffle_avx);
     SEQAN_CALL_TEST(test_basic_simd_transpose_32x32);
 #endif  // #ifdef __AVX2__
-#endif  // #ifdef __SSE4_1__
+#endif  // #ifdef SEQAN_SSE4
+#endif
 }
 SEQAN_END_TESTSUITE
 

--- a/tests/basic/test_basic_simd_vector.h
+++ b/tests/basic/test_basic_simd_vector.h
@@ -37,14 +37,13 @@
 #ifndef SEQAN_CORE_TESTS_BASIC_TEST_BASIC_SIMD_VECTOR_H_
 #define SEQAN_CORE_TESTS_BASIC_TEST_BASIC_SIMD_VECTOR_H_
 
-#if SEQAN_SIMD_ENABLED
-
 #include <random>
 
 #include <seqan/sequence.h>
 #include <seqan/misc/bit_twiddling.h>
 #include <seqan/basic/basic_simd_vector.h>
 
+#if SEQAN_SIMD_ENABLED
 namespace seqan {
 
 template <int ROWS, typename TVector>
@@ -84,7 +83,7 @@ inline void test_matrix_transpose()
 
 }
 
-#ifdef __SSE4_1__
+#ifdef SEQAN_SSE4
 
 SEQAN_DEFINE_TEST(test_basic_simd_shuffle)
 {
@@ -150,7 +149,7 @@ SEQAN_DEFINE_TEST(test_basic_simd_transpose_32x32)
 }
 
 #endif  // #ifdef __AVX2__
-#endif  // #ifdef __SSE4_1__
+#endif  // #ifdef SEQAN_SSE4
 #endif  // SEQAN_SIMD_ENABLED
 
 #endif  // #ifndef SEQAN_CORE_TESTS_BASIC_TEST_BASIC_SIMD_VECTOR_H_


### PR DESCRIPTION
Disables SIMD code and fixes parallel module on ARM architecture.
Note, we still need to deactivate the tests for bs_tools for ARM, due to some rounding errors. 