### PR TITLE
Nonrecursive dfs

### DIFF
--- a/include/seqan/graph_algorithms.h
+++ b/include/seqan/graph_algorithms.h
@@ -36,6 +36,8 @@
 // External / STL
 #include <set>
 #include <queue>
+#include <vector>
+#include <utility>
 
 // Seqan
 #include <seqan/graph_types.h>

--- a/include/seqan/graph_algorithms/depth_first_search.h
+++ b/include/seqan/graph_algorithms/depth_first_search.h
@@ -38,9 +38,6 @@
 #ifndef INCLUDE_SEQAN_GRAPH_ALGORITHMS_DEPTH_FIRST_SEARCH_H_
 #define INCLUDE_SEQAN_GRAPH_ALGORITHMS_DEPTH_FIRST_SEARCH_H_
 
-#include <vector>
-#include <utility>
-
 namespace seqan {
 
 // ============================================================================

--- a/include/seqan/graph_algorithms/depth_first_search.h
+++ b/include/seqan/graph_algorithms/depth_first_search.h
@@ -29,13 +29,15 @@
 // DAMAGE.
 //
 // ==========================================================================
-// Authors: Tobias Raussch <rausch@embl.de>, Ryan Wick <rrwick@gmail.com>
+// Author: Tobias Raussch <rausch@embl.de>
+// Author: Ryan Wick <rrwick@gmail.com>
 // ==========================================================================
 // Implementation of Depth-First-Search algorithm.
 // ==========================================================================
 
 #ifndef INCLUDE_SEQAN_GRAPH_ALGORITHMS_DEPTH_FIRST_SEARCH_H_
 #define INCLUDE_SEQAN_GRAPH_ALGORITHMS_DEPTH_FIRST_SEARCH_H_
+
 #include <vector>
 #include <utility>
 
@@ -97,7 +99,7 @@ void depthFirstSearch(TPredecessorMap & predecessor,
     typedef typename Value<TPredecessorMap>::Type TPredVal;
     typedef typename Iterator<Graph<TSpec>, AdjacencyIterator>::Type TAdjacencyIterator;
 
-    enum class Task : uint8_t
+    enum class _DfsTask : uint8_t
     {
         EXPLORE,
         FINISH
@@ -121,7 +123,7 @@ void depthFirstSearch(TPredecessorMap & predecessor,
     // We do the DFS non-recursively using a stack. The stack holds two possible tasks:
     //   EXPLORE, which means we must follow that vertex's edges
     //   FINISH, which means the vertex just needs a finish time
-    std::vector<std::pair<TVertexDescriptor, Task> > vStack;
+    std::vector<std::pair<TVertexDescriptor, _DfsTask> > vStack;
 
     // The graph may not be connected, so start at every vertex.
     goBegin(it);
@@ -135,7 +137,7 @@ void depthFirstSearch(TPredecessorMap & predecessor,
         }
 
         vStack.clear();
-        vStack.emplace_back(v, Task::EXPLORE);
+        vStack.emplace_back(v, _DfsTask::EXPLORE);
         while (!vStack.empty())
         {
             // Get the vertex and task from the top of the stack.
@@ -143,7 +145,7 @@ void depthFirstSearch(TPredecessorMap & predecessor,
             vStack.pop_back();
             TVertexDescriptor v = stackItem.first;
 
-            if (stackItem.second == Task::FINISH)
+            if (stackItem.second == _DfsTask::FINISH)
             {
                 assignProperty(finish, v, ++time);
             }
@@ -151,7 +153,7 @@ void depthFirstSearch(TPredecessorMap & predecessor,
             {
                 assignProperty(tokenMap, v, true);    // label as visited
                 assignProperty(disc, v, ++time);      // set discovery time
-                vStack.emplace_back(v, Task::FINISH); // add a task to the stack so the vertex will get a finish time
+                vStack.emplace_back(v, _DfsTask::FINISH); // add a task to the stack so the vertex will get a finish time
 
                 // Add EXPLORE tasks to the stack for each unvisited adjacent vertex. They are added in reverse order
                 // so the first adjacent vertex will be the first to come off the stack. This is to mimic the behaviour
@@ -164,7 +166,7 @@ void depthFirstSearch(TPredecessorMap & predecessor,
                     TVertexDescriptor nextV = getValue(itad);
                     if (!getProperty(tokenMap, nextV))
                     {
-                        vStack.emplace_back(nextV, Task::EXPLORE);
+                        vStack.emplace_back(nextV, _DfsTask::EXPLORE);
                         assignProperty(predecessor, nextV, v);
                     }
                 }

--- a/include/seqan/graph_algorithms/strongly_connected_compnents.h
+++ b/include/seqan/graph_algorithms/strongly_connected_compnents.h
@@ -59,6 +59,35 @@ namespace seqan {
 // Function stronglyConnectedComponents()
 // ----------------------------------------------------------------------------
 
+template <typename TSpec, typename TVertexDescriptor, typename TTokenMap, typename TPredecessorMap, typename TDiscoveryTimeMap, typename TFinishingTimeMap, typename TVal>
+void
+_dfsVisit(Graph<TSpec> const& g,
+           TVertexDescriptor const u,
+           TTokenMap& tokenMap,
+           TPredecessorMap& predecessor,
+           TDiscoveryTimeMap& disc,
+           TFinishingTimeMap& finish,
+           TVal& time)
+{
+    typedef typename Iterator<Graph<TSpec>, AdjacencyIterator>::Type TAdjacencyIterator;
+
+    assignProperty(tokenMap, u, true);
+    ++time;
+    assignProperty(disc, u, time);
+    TAdjacencyIterator itad(g,u);
+    for(;!atEnd(itad);goNext(itad))
+    {
+        TVertexDescriptor v = getValue(itad);
+        if (getProperty(tokenMap, v) == false)
+        {
+            assignProperty(predecessor, v, u);
+            _dfsVisit(g, v, tokenMap, predecessor, disc, finish, time);
+        }
+    }
+    ++time;
+    assignProperty(finish, u, time);
+}
+
 /*!
  * @fn stronglyConnectedComponents
  * @headerfile <seqan/graph_algorithms.h>


### PR DESCRIPTION
The previous implementation of depthFirstSearch was recursive and could crash if it got too many levels deep (10s of thousands). This new implementation is iterative and can handle larger graphs.

This PR replaces https://github.com/seqan/seqan/pull/1823, which was made against master, instead of develop.