### PR TITLE
Extending stream_base.h to allow bgzf compression for BED files

### DIFF
--- a/include/seqan/stream/stream_base.h
+++ b/include/seqan/stream/stream_base.h
@@ -134,18 +134,17 @@ char const * FileExtensions<GZFile, T>::VALUE[1] =
 template <typename T>
 struct FileExtensions<BgzfFile, T>
 {
-    static char const * VALUE[4];
+    static char const * VALUE[5];
 };
 
 template <typename T>
-char const * FileExtensions<BgzfFile, T>::VALUE[4] =
+char const * FileExtensions<BgzfFile, T>::VALUE[5] =
 {
     ".bgzf",      // default output extension
     ".bam",       // BAM files are bgzf compressed
-    ".vcf.gz",    // Compressed and indexed VCF files are actually bgzf compressed
+    ".vcf.gz",    // Compressed and indexed VCF files are bgzf compressed
+    ".bed.gz",    // Compressed and indexed BED files are bgzf compressed
     ".tbi"        // Tabix index files are bgzf compressed
-
-    // if you add extensions here, extend getBasename() below
 };
 
 

--- a/include/seqan/tabix_io/tabix_index_tbi.h
+++ b/include/seqan/tabix_io/tabix_index_tbi.h
@@ -469,6 +469,9 @@ open(TabixIndex & index, char const * filename)
     CharString tmp;
     readRawPod(lNm, iter);
     read(tmp, iter, lNm);
+    // Trim last terminating '\0's as they confuse strSplit() below
+    while (!empty(tmp) && back(tmp) == '\0')
+        resize(tmp, length(tmp) - 1);
 
     // Split concatenated names at \0's.
     clear(index._nameStore);


### PR DESCRIPTION
Otherwise, jumpToRegion() with tabix indices fails silently, leading to
no jumping at all and weird errors.

This does not fix #1835, though.