### PR TITLE
Add check before dereferencing iterator

### DIFF
--- a/include/seqan/graph_msa/graph_align_tcoffee_library.h
+++ b/include/seqan/graph_msa/graph_align_tcoffee_library.h
@@ -543,7 +543,7 @@ getAlignmentStatistics(String<TFragment, TSpec1> const& matches,
     if (length(matches) > 0)
     {
         TFragIter itFrag = begin(matches, Standard()) + from;
-        TFragIter itFragEnd = itFrag + to;
+        TFragIter itFragEnd = begin(matches, Standard()) + to;
 
         TId id1 = sequenceId(*itFrag, 0);
         TId id2 = sequenceId(*itFrag, 1);

--- a/include/seqan/graph_msa/graph_align_tcoffee_library.h
+++ b/include/seqan/graph_msa/graph_align_tcoffee_library.h
@@ -541,33 +541,36 @@ getAlignmentStatistics(String<TFragment, TSpec1> const& matches,
     TSize maxId2 = 0;
     TSize matchMismatch_length = 0;
 
-    TFragIter itFrag = begin(matches, Standard());
-    TFragIter itFragEnd = itFrag;
-    itFrag += from;
-    itFragEnd += to;
-    TId id1 = sequenceId(*itFrag, 0);
-    TId id2 = sequenceId(*itFrag, 1);
-    TSize fragLen = 0;
-    TSize beginI = 0;
-    TSize beginJ = 0;
-    for(;itFrag != itFragEnd; ++itFrag) {
-        fragLen = fragmentLength(*itFrag, id1);
-        beginI = fragmentBegin(*itFrag, id1);
-        beginJ = fragmentBegin(*itFrag, id2);
-        if (beginI < minId1) minId1 = beginI;
-        if (beginJ < minId2) minId2 = beginJ;
-        if (beginI + fragLen > maxId1) maxId1 = beginI + fragLen;
-        if (beginJ + fragLen > maxId2) maxId2 = beginJ + fragLen;
-        typedef typename Infix<TString>::Type TInfix;
-        typedef typename Iterator<TInfix, Standard>::Type TInfixIter;
-        TInfix inf1 = label(*itFrag, str, id1);
-        TInfix inf2 = label(*itFrag, str, id2);
-        TInfixIter sIt1 = begin(inf1, Standard());
-        TInfixIter sIt2 = begin(inf2, Standard());
-        TInfixIter sIt1End = end(inf1, Standard());
-        matchMismatch_length += fragLen;
-        for(;sIt1 != sIt1End; ++sIt1, ++sIt2)
-            if ( (TAlphabet) *sIt1  == (TAlphabet) *sIt2) ++matchLength;
+    if (length(matches) > 0)
+    {
+        TFragIter itFrag = begin(matches, Standard());
+        TFragIter itFragEnd = itFrag;
+        itFrag += from;
+        itFragEnd += to;
+        TId id1 = sequenceId(*itFrag, 0);
+        TId id2 = sequenceId(*itFrag, 1);
+        TSize fragLen = 0;
+        TSize beginI = 0;
+        TSize beginJ = 0;
+        for(;itFrag != itFragEnd; ++itFrag) {
+            fragLen = fragmentLength(*itFrag, id1);
+            beginI = fragmentBegin(*itFrag, id1);
+            beginJ = fragmentBegin(*itFrag, id2);
+            if (beginI < minId1) minId1 = beginI;
+            if (beginJ < minId2) minId2 = beginJ;
+            if (beginI + fragLen > maxId1) maxId1 = beginI + fragLen;
+            if (beginJ + fragLen > maxId2) maxId2 = beginJ + fragLen;
+            typedef typename Infix<TString>::Type TInfix;
+            typedef typename Iterator<TInfix, Standard>::Type TInfixIter;
+            TInfix inf1 = label(*itFrag, str, id1);
+            TInfix inf2 = label(*itFrag, str, id2);
+            TInfixIter sIt1 = begin(inf1, Standard());
+            TInfixIter sIt2 = begin(inf2, Standard());
+            TInfixIter sIt1End = end(inf1, Standard());
+            matchMismatch_length += fragLen;
+            for(;sIt1 != sIt1End; ++sIt1, ++sIt2)
+                if ( (TAlphabet) *sIt1  == (TAlphabet) *sIt2) ++matchLength;
+        }
     }
     alignLength = static_cast<TSize1>(matchMismatch_length + (len1 - matchMismatch_length) + (len2 - matchMismatch_length));
     overlapLength = alignLength -  minId1 - minId2 - (len1 + len2 - maxId1 - maxId2);

--- a/include/seqan/graph_msa/graph_align_tcoffee_library.h
+++ b/include/seqan/graph_msa/graph_align_tcoffee_library.h
@@ -521,7 +521,7 @@ getAlignmentStatistics(String<TFragment, TSpec1> const& matches,
                        TPos const from,
                        TPos const to,
                        TSize1& matchLength,    // Number of identical characters
-                       TSize1& overlapLength,    // Number of character in overlapping segments (with mismatches and gaps)
+                       TSize1& overlapLength,  // Number of character in overlapping segments (with mismatches and gaps)
                        TSize1& alignLength)    // Length of the alignment
 {
     typedef String<TFragment, TSpec1> const TFragmentMatches;
@@ -534,7 +534,6 @@ getAlignmentStatistics(String<TFragment, TSpec1> const& matches,
     TSize len1 = length(str[0]);
     TSize len2 = length(str[1]);
 
-
     TSize minId1 = len1 + len2;
     TSize minId2 = len1 + len2;
     TSize maxId1 = 0;
@@ -543,23 +542,29 @@ getAlignmentStatistics(String<TFragment, TSpec1> const& matches,
 
     if (length(matches) > 0)
     {
-        TFragIter itFrag = begin(matches, Standard());
-        TFragIter itFragEnd = itFrag;
-        itFrag += from;
-        itFragEnd += to;
+        TFragIter itFrag = begin(matches, Standard()) + from;
+        TFragIter itFragEnd = itFrag + to;
+
         TId id1 = sequenceId(*itFrag, 0);
         TId id2 = sequenceId(*itFrag, 1);
         TSize fragLen = 0;
         TSize beginI = 0;
         TSize beginJ = 0;
-        for(;itFrag != itFragEnd; ++itFrag) {
+
+        for(; itFrag != itFragEnd; ++itFrag)
+        {
             fragLen = fragmentLength(*itFrag, id1);
             beginI = fragmentBegin(*itFrag, id1);
             beginJ = fragmentBegin(*itFrag, id2);
-            if (beginI < minId1) minId1 = beginI;
-            if (beginJ < minId2) minId2 = beginJ;
-            if (beginI + fragLen > maxId1) maxId1 = beginI + fragLen;
-            if (beginJ + fragLen > maxId2) maxId2 = beginJ + fragLen;
+            if (beginI < minId1)
+                minId1 = beginI;
+            if (beginJ < minId2)
+                minId2 = beginJ;
+            if (beginI + fragLen > maxId1)
+                maxId1 = beginI + fragLen;
+            if (beginJ + fragLen > maxId2)
+                maxId2 = beginJ + fragLen;
+
             typedef typename Infix<TString>::Type TInfix;
             typedef typename Iterator<TInfix, Standard>::Type TInfixIter;
             TInfix inf1 = label(*itFrag, str, id1);
@@ -568,12 +573,15 @@ getAlignmentStatistics(String<TFragment, TSpec1> const& matches,
             TInfixIter sIt2 = begin(inf2, Standard());
             TInfixIter sIt1End = end(inf1, Standard());
             matchMismatch_length += fragLen;
-            for(;sIt1 != sIt1End; ++sIt1, ++sIt2)
-                if ( (TAlphabet) *sIt1  == (TAlphabet) *sIt2) ++matchLength;
+            for(; sIt1 != sIt1End; ++sIt1, ++sIt2)
+            {
+                if ( (TAlphabet) *sIt1 == (TAlphabet) *sIt2)
+                    ++matchLength;
+            }
         }
     }
     alignLength = static_cast<TSize1>(matchMismatch_length + (len1 - matchMismatch_length) + (len2 - matchMismatch_length));
-    overlapLength = alignLength -  minId1 - minId2 - (len1 + len2 - maxId1 - maxId2);
+    overlapLength = alignLength - minId1 - minId2 - (len1 + len2 - maxId1 - maxId2);
 }
 
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
I ran into a crash that I traced to the `getAlignmentStatistics` function in the `graph_align_tcoffee_library.h` file. This function was being called with an empty `matches` string and crashing when this line tried to dereference the iterator:
`TId id1 = sequenceId(*itFrag, 0);`

I should mention that I ran into this bug after making a number of modifications to SeqAn, so perhaps it can never happen in actual, unmodified SeqAn. But it seems like a safe change, so I thought I'll make this PR, in case you'd like to use it!