### PR TITLE
[FIX] BiFM: Reversed StringSet had wrong limits

### DIFF
--- a/include/seqan/index/index_bidirectional.h
+++ b/include/seqan/index/index_bidirectional.h
@@ -66,19 +66,7 @@ class BidirectionalIndex;
 template <typename TText>
 struct RevTextFibre
 {
-    typedef ModifiedString<TText, ModReverse> Type;
-};
-
-template <typename TText>
-struct RevTextFibre<ModifiedString<TText, ModReverse> >
-{
     typedef TText Type;
-};
-
-template <typename TText, typename TTextConfig>
-struct RevTextFibre<StringSet<TText, TTextConfig> >
-{
-    typedef StringSet<typename RevTextFibre<TText>::Type, TTextConfig> Type;
 };
 
 // ----------------------------------------------------------------------------
@@ -120,7 +108,9 @@ class Index<TText, BidirectionalIndex<TIndexSpec> >
         revText(text),
         rev(revText),
         fwd(text)
-    {}
+    {
+        reverse(revText);
+    }
 };
 
 // ============================================================================

--- a/include/seqan/index/index_bidirectional.h
+++ b/include/seqan/index/index_bidirectional.h
@@ -148,7 +148,7 @@ inline void clear(Index<TText, BidirectionalIndex<TIndexSpec> > & index)
 template <typename TText, typename TIndexSpec>
 inline bool empty(Index<TText, BidirectionalIndex<TIndexSpec> > const & index)
 {
-    return empty(index.fwd) || empty(index.rev);
+    return empty(index.fwd) && empty(index.rev);
 }
 
 // This function can be used to open a previously saved index.
@@ -191,6 +191,7 @@ inline typename Fibre<Index<TText, TSpec>, FibreText>::Type &
 getFibre(Index<TText, BidirectionalIndex<TSpec> > &index, FibreText) {
     return value(index.fwd.text);
 }
+
 template <typename TText, typename TSpec>
 inline typename Fibre<Index<TText, TSpec>, const FibreText>::Type &
 getFibre(Index<TText, BidirectionalIndex<TSpec> > const &index, FibreText) {

--- a/include/seqan/index/index_bidirectional_stree.h
+++ b/include/seqan/index/index_bidirectional_stree.h
@@ -61,13 +61,11 @@ class Iter<Index<TText, BidirectionalIndex<TIndexSpec> >, VSTree<TopDown<TSpec> 
 public:
     typedef Index<TText, BidirectionalIndex<TIndexSpec> > TBiIndex;
 
-    typedef typename RevTextFibre<TText>::Type                                                      TRevText;
-
-    typedef Index<TText, TIndexSpec>     TFwdIndex;
-    typedef Index<TRevText, TIndexSpec>  TRevIndex;
-
-    typedef Iter<TFwdIndex, VSTree<TopDown<TSpec> > >                                                   TFwdIndexIter;
-    typedef Iter<TRevIndex, VSTree<TopDown<TSpec> > >                                                   TRevIndexIter;
+    typedef typename RevTextFibre<TText>::Type          TRevText;
+    typedef Index<TText, TIndexSpec>                    TFwdIndex;
+    typedef Index<TRevText, TIndexSpec>                 TRevIndex;
+    typedef Iter<TFwdIndex, VSTree<TopDown<TSpec> > >   TFwdIndexIter;
+    typedef Iter<TRevIndex, VSTree<TopDown<TSpec> > >   TRevIndexIter;
 
     TFwdIndexIter    fwdIter;
     TRevIndexIter    revIter;
@@ -97,13 +95,11 @@ class Iter<Index<TText, BidirectionalIndex<TIndexSpec> >, VSTree<TopDown<ParentL
 public:
     typedef Index<TText, BidirectionalIndex<TIndexSpec> >  TBiIndex;
 
-    typedef typename RevTextFibre<TText>::Type                                                            TRevText;
-
-    typedef Index<TText, TIndexSpec>           TFwdIndex;
-    typedef Index<TRevText, TIndexSpec>        TRevIndex;
-
-    typedef Iter<TFwdIndex, VSTree<TopDown<ParentLinks<TSpec> > > >                                           TFwdIndexIter;
-    typedef Iter<TRevIndex, VSTree<TopDown<ParentLinks<TSpec> > > >                                           TRevIndexIter;
+    typedef typename RevTextFibre<TText>::Type                      TRevText;
+    typedef Index<TText, TIndexSpec>                                TFwdIndex;
+    typedef Index<TRevText, TIndexSpec>                             TRevIndex;
+    typedef Iter<TFwdIndex, VSTree<TopDown<ParentLinks<TSpec> > > > TFwdIndexIter;
+    typedef Iter<TRevIndex, VSTree<TopDown<ParentLinks<TSpec> > > > TRevIndexIter;
 
     TFwdIndexIter    fwdIter;
     TRevIndexIter    revIter;

--- a/include/seqan/index/index_bifm.h
+++ b/include/seqan/index/index_bifm.h
@@ -56,6 +56,8 @@ SEQAN_CONCEPT_IMPL((Index<TText, BidirectionalIndex<FMIndex<TSpec, TConfig> > > 
 template <typename TText, typename TSpec, typename TConfig>
 inline bool indexCreate(Index<TText, BidirectionalIndex<FMIndex<TSpec, TConfig> > > & index)
 {
+    indexText(index.rev) = indexText(index.fwd);
+    reverse(indexText(index.rev));
     return indexCreate(index.fwd, FibreSALF()) && indexCreate(index.rev, FibreSALF());
 }
 

--- a/tests/index/test_index_bifm.cpp
+++ b/tests/index/test_index_bifm.cpp
@@ -189,19 +189,15 @@ SEQAN_TYPED_TEST(BidirectionalFMIndexTest, SearchInStringSet)
     unsigned textLength = 3947;
 
     TStringSet stringSet;
+    TStringSet revStringSet;
     for (unsigned stringSetSize = 1; stringSetSize <= 3; ++stringSetSize)
     {
         TText text;
         generateText(rng, text, textLength);
-        appendValue(stringSet, text);
+        ModifiedString<TText, ModReverse> revText(text);
 
-        TStringSet revStringSet;
-        for (unsigned i = 0; i < stringSetSize; ++i)
-        {
-            TText revText(stringSet[stringSetSize - i - 1]);
-            reverse(revText);
-            appendValue(revStringSet, revText);
-        }
+        appendValue(stringSet, text);
+        appendValue(revStringSet, revText);
 
         TStringSetIndex index(stringSet);
         for (unsigned patternLength = 1; patternLength <= 10; ++patternLength)


### PR DESCRIPTION
I kept the RevTextFibre for now in case we want to switch back to a ModifiedString.