### PR TITLE
[INTERNAL, FIX-#699] Add check for possible score overflow in banded chain alignment

### DIFF
--- a/include/seqan/journaled_set/score_biaffine.h
+++ b/include/seqan/journaled_set/score_biaffine.h
@@ -52,51 +52,44 @@ template <typename TScoreValue>
 class Score<TScoreValue, BiAffine>
 {
     public:
-    TScoreValue _match;
-    TScoreValue _mismatch;
+    TScoreValue data_match;
+    TScoreValue data_mismatch;
     TScoreValue _gapExtendHorizontal;
     TScoreValue _gapOpenHorizontal;
     TScoreValue _gapExtendVertical;
     TScoreValue _gapOpenVertical;
 
 
-    Score() : _match(0),
-              _mismatch(0),
+    Score() : data_match(0),
+              data_mismatch(0),
               _gapExtendHorizontal(0),
               _gapOpenHorizontal(0),
               _gapExtendVertical(0),
               _gapOpenVertical(0) {}
 
     Score(TScoreValue match, TScoreValue mismatch, TScoreValue gap) :
-                                    _match(match),
-                                    _mismatch(mismatch),
+                                    data_match(match),
+                                    data_mismatch(mismatch),
                                     _gapExtendHorizontal(gap),
                                     _gapOpenHorizontal(gap),
                                     _gapExtendVertical(gap),
                                     _gapOpenVertical(gap) {}
 
     Score(TScoreValue match, TScoreValue mismatch, TScoreValue gapExtend, TScoreValue gapOpen) :
-                                    _match(match),
-                                    _mismatch(mismatch),
+                                    data_match(match),
+                                    data_mismatch(mismatch),
                                     _gapExtendHorizontal(gapExtend),
                                     _gapOpenHorizontal(gapOpen),
                                     _gapExtendVertical(gapExtend),
                                     _gapOpenVertical(gapOpen) {}
 
     Score(TScoreValue match, TScoreValue mismatch, TScoreValue gapExtendHorizontal, TScoreValue gapOpenHorizontal,
-          TScoreValue gapExtendVertical, TScoreValue gapOpenVertical) : _match(match),
-                                                                        _mismatch(mismatch),
+          TScoreValue gapExtendVertical, TScoreValue gapOpenVertical) : data_match(match),
+                                                                        data_mismatch(mismatch),
                                                                         _gapExtendHorizontal(gapExtendHorizontal),
                                                                         _gapOpenHorizontal(gapOpenHorizontal),
                                                                         _gapExtendVertical(gapExtendVertical),
                                                                         _gapOpenVertical(gapOpenVertical) {}
-
-    Score(Score const & other) : _match(other._match),
-                                 _mismatch(other._mismatch),
-                                 _gapExtendHorizontal(other._gapExtendHorizontal),
-                                 _gapOpenHorizontal(other._gapOpenHorizontal),
-                                 _gapExtendVertical(other._gapExtendVertical),
-                                 _gapOpenVertical(other._gapOpenVertical) {}
 };
 
 // ============================================================================
@@ -119,8 +112,8 @@ score(Score<TScoreValue, BiAffine> const & me,
       TSeqEntry2 const & seqEntry2)
 {
     if (seqEntry1 == static_cast<TSeqEntry1>(seqEntry2))
-        return me._match;
-    return me._mismatch;
+        return me.data_match;
+    return me.data_mismatch;
 }
 
 // ----------------------------------------------------------------------------
@@ -183,7 +176,7 @@ template <typename TScoreValue>
 inline void
 setScoreMatch(Score<TScoreValue, BiAffine> & scoringScheme, TScoreValue const & score)
 {
-    scoringScheme._match = score;
+    scoringScheme.data_match = score;
 }
 
 // ----------------------------------------------------------------------------
@@ -194,7 +187,7 @@ template <typename TScoreValue>
 inline void
 setScoreMismatch(Score<TScoreValue, BiAffine>  & scoringScheme, TScoreValue const & score)
 {
-    scoringScheme._mismatch = score;
+    scoringScheme.data_mismatch = score;
 }
 
 // ----------------------------------------------------------------------------

--- a/include/seqan/journaled_set/score_biaffine.h
+++ b/include/seqan/journaled_set/score_biaffine.h
@@ -52,40 +52,40 @@ template <typename TScoreValue>
 class Score<TScoreValue, BiAffine>
 {
     public:
-    TScoreValue data_match;
-    TScoreValue data_mismatch;
+    TScoreValue _match;
+    TScoreValue _mismatch;
     TScoreValue _gapExtendHorizontal;
     TScoreValue _gapOpenHorizontal;
     TScoreValue _gapExtendVertical;
     TScoreValue _gapOpenVertical;
 
 
-    Score() : data_match(0),
-              data_mismatch(0),
+    Score() : _match(0),
+              _mismatch(0),
               _gapExtendHorizontal(0),
               _gapOpenHorizontal(0),
               _gapExtendVertical(0),
               _gapOpenVertical(0) {}
 
     Score(TScoreValue match, TScoreValue mismatch, TScoreValue gap) :
-                                    data_match(match),
-                                    data_mismatch(mismatch),
+                                    _match(match),
+                                    _mismatch(mismatch),
                                     _gapExtendHorizontal(gap),
                                     _gapOpenHorizontal(gap),
                                     _gapExtendVertical(gap),
                                     _gapOpenVertical(gap) {}
 
     Score(TScoreValue match, TScoreValue mismatch, TScoreValue gapExtend, TScoreValue gapOpen) :
-                                    data_match(match),
-                                    data_mismatch(mismatch),
+                                    _match(match),
+                                    _mismatch(mismatch),
                                     _gapExtendHorizontal(gapExtend),
                                     _gapOpenHorizontal(gapOpen),
                                     _gapExtendVertical(gapExtend),
                                     _gapOpenVertical(gapOpen) {}
 
     Score(TScoreValue match, TScoreValue mismatch, TScoreValue gapExtendHorizontal, TScoreValue gapOpenHorizontal,
-          TScoreValue gapExtendVertical, TScoreValue gapOpenVertical) : data_match(match),
-                                                                        data_mismatch(mismatch),
+          TScoreValue gapExtendVertical, TScoreValue gapOpenVertical) : _match(match),
+                                                                        _mismatch(mismatch),
                                                                         _gapExtendHorizontal(gapExtendHorizontal),
                                                                         _gapOpenHorizontal(gapOpenHorizontal),
                                                                         _gapExtendVertical(gapExtendVertical),
@@ -112,8 +112,8 @@ score(Score<TScoreValue, BiAffine> const & me,
       TSeqEntry2 const & seqEntry2)
 {
     if (seqEntry1 == static_cast<TSeqEntry1>(seqEntry2))
-        return me.data_match;
-    return me.data_mismatch;
+        return me._match;
+    return me._mismatch;
 }
 
 // ----------------------------------------------------------------------------
@@ -176,7 +176,18 @@ template <typename TScoreValue>
 inline void
 setScoreMatch(Score<TScoreValue, BiAffine> & scoringScheme, TScoreValue const & score)
 {
-    scoringScheme.data_match = score;
+    scoringScheme._match = score;
+}
+
+// ----------------------------------------------------------------------------
+// Function scoreMatch()
+// ----------------------------------------------------------------------------
+
+template <typename TScoreValue>
+inline TScoreValue
+scoreMatch(Score<TScoreValue, BiAffine> const & scoringScheme)
+{
+    return scoringScheme._match;
 }
 
 // ----------------------------------------------------------------------------
@@ -185,9 +196,20 @@ setScoreMatch(Score<TScoreValue, BiAffine> & scoringScheme, TScoreValue const & 
 
 template <typename TScoreValue>
 inline void
-setScoreMismatch(Score<TScoreValue, BiAffine>  & scoringScheme, TScoreValue const & score)
+setScoreMismatch(Score<TScoreValue, BiAffine> & scoringScheme, TScoreValue const & score)
 {
-    scoringScheme.data_mismatch = score;
+    scoringScheme._mismatch = score;
+}
+
+// ----------------------------------------------------------------------------
+// Function scoreMismatch()
+// ----------------------------------------------------------------------------
+
+template <typename TScoreValue>
+inline TScoreValue
+scoreMismatch(Score<TScoreValue, BiAffine> const & scoringScheme)
+{
+    return scoringScheme._mismatch;
 }
 
 // ----------------------------------------------------------------------------

--- a/tests/seeds/test_align_banded_chain_impl.cpp
+++ b/tests/seeds/test_align_banded_chain_impl.cpp
@@ -1075,6 +1075,23 @@ SEQAN_DEFINE_TEST(test_banded_chain_alignment_band_extensions_affine)
     testBandedChainAlignmentBandExtension(seqan::AffineGaps());
 }
 
+SEQAN_DEFINE_TEST(test_banded_chain_score_overflow_detection)
+{
+    using namespace seqan;
+    Score<int8_t> score(2, -5, -2);
+    SEQAN_ASSERT(!_checkScoreOverflow(127, score));
+    SEQAN_ASSERT(_checkScoreOverflow(50, score));
+    SEQAN_ASSERT(_checkScoreOverflow(24, score));
+    SEQAN_ASSERT(_checkScoreOverflow(15, score));
+
+    Score<int32_t> score2(2, -5, -2);
+    SEQAN_ASSERT(_checkScoreOverflow(655536, score2));
+    SEQAN_ASSERT(_checkScoreOverflow(127, score2));
+    SEQAN_ASSERT(_checkScoreOverflow(50, score2));
+    SEQAN_ASSERT(_checkScoreOverflow(24, score2));
+    SEQAN_ASSERT(_checkScoreOverflow(15, score2));
+}
+
 SEQAN_BEGIN_TESTSUITE(test_banded_chain_impl)
 {
     SEQAN_CALL_TEST(test_banded_chain_alignment_empty_set_linear);
@@ -1090,5 +1107,6 @@ SEQAN_BEGIN_TESTSUITE(test_banded_chain_impl)
     SEQAN_CALL_TEST(test_banded_chain_alignment_band_extensions_linear);
     SEQAN_CALL_TEST(test_banded_chain_alignment_band_extensions_affine);
     SEQAN_CALL_TEST(test_banded_chain_alignment_issue_1020);
+    SEQAN_CALL_TEST(test_banded_chain_score_overflow_detection);
 }
 SEQAN_END_TESTSUITE


### PR DESCRIPTION
Checks if a score overflow is likely for a given alignment sub matrix in the banded chain alignment procedure.

Fixes #699.