### PR TITLE
[FIX,INTERNAL] Work around GNU Hurd's TANDEM constant

### DIFF
--- a/apps/gustaf/msplazer.h
+++ b/apps/gustaf/msplazer.h
@@ -134,7 +134,7 @@ struct Breakpoint
         INSERTION,          // 1
         DELETION,           // 2
         INVERSION,          // 3
-        TANDEM,             // 4
+        SEQAN_TANDEM,       // 4  TANDEM is an IOCTL numeric constant in Hurd
         DISPDUPLICATION,    // 5
         INTERTRANSLOCATION, // 6
         TRANSLOCATION,      // 7
@@ -696,7 +696,7 @@ TStream & operator<<(TStream & out, Breakpoint<TSequence, TId> const & value)
         case TBreakpoint::INVERSION:
         out << "SVType: inversion";
         break;
-        case TBreakpoint::TANDEM:
+        case TBreakpoint::SEQAN_TANDEM:
         out << "SVType: tandem";
         break;
         case TBreakpoint::DISPDUPLICATION:

--- a/apps/gustaf/msplazer_algorithms.h
+++ b/apps/gustaf/msplazer_algorithms.h
@@ -493,7 +493,7 @@ void _chainMatches(QueryMatches<StellarMatch<TSequence, TId> > & queryMatches,
                     // Double overlap check (not handled jet)
                     // std::cerr << "double overlap in reference and read called from read overlap" << std::endl;
                     // std::cout << "Translocation double overlap" << std::endl;
-                    bp.svtype = TBreakpoint::TANDEM;
+                    bp.svtype = TBreakpoint::SEQAN_TANDEM;
                 }
 
                 //std::cout << "Breakpoint " << bp << std::endl;

--- a/apps/gustaf/msplazer_out.h
+++ b/apps/gustaf/msplazer_out.h
@@ -196,7 +196,7 @@ void _setGffRecordType(GffRecord & record, TBreakpoint & bp)
         case TBreakpoint::INVERSION:
         record.type = "inversion";
         break;
-        case TBreakpoint::TANDEM:
+        case TBreakpoint::SEQAN_TANDEM:
         record.type = "tandem";
         break;
         case TBreakpoint::DISPDUPLICATION:
@@ -647,7 +647,7 @@ inline bool _fillVcfRecord(VcfRecord & record, TBreakpoint & bp, TSequence & ref
         case TBreakpoint::INVERSION:
         _fillVcfRecordInversion(record, bp, ref, id);
         return 1;
-        case TBreakpoint::TANDEM:
+        case TBreakpoint::SEQAN_TANDEM:
         _fillVcfRecordTandem(record, bp, ref, id);
         return 1;
         case TBreakpoint::DISPDUPLICATION:


### PR DESCRIPTION
Partial fix for https://github.com/seqan/seqan/issues/1861 
See also https://fossies.org/dox/glibc-2.24/sysdeps_2mach_2hurd_2bits_2ioctls_8h.html#aea2b0b2a11b94d258198cd2104bc79a4
