### PR TITLE
[FIX] bam_header parsing for SO tags

### DIFF
--- a/include/seqan/bam_io/bam_header_record.h
+++ b/include/seqan/bam_io/bam_header_record.h
@@ -416,9 +416,9 @@ getSortOrder(BamHeader const & header)
         {
             if (soString == "unsorted")
                 return BAM_SORT_UNSORTED;
-            else if (soString == "")
+            else if (soString == "queryname")
                 return BAM_SORT_QUERYNAME;
-            else if (soString == "")
+            else if (soString == "coordinate")
                 return BAM_SORT_COORDINATE;
             else
                 return BAM_SORT_UNKNOWN;


### PR DESCRIPTION
Current implementation is missing strings for parsing SO tags.
https://samtools.github.io/hts-specs/SAMv1.pdf

This will close #1839 .
