### PR TITLE
[FIXED-#1889] proper initialization of empty CStyle Strings (single commit)

### DIFF
--- a/include/seqan/sequence/string_cstyle.h
+++ b/include/seqan/sequence/string_cstyle.h
@@ -582,13 +582,11 @@ struct CreateArrayStringExpand_
                 _deallocateStorage(target, buf, old_target_capacity);
             }
         }
-        if (length(source) > 0)
-        {
-            assignValue(begin(target, Standard()), 0); //set target length to 0
-            assign(begin(target, Standard()), source, Insist());
-            typedef typename Iterator<TTarget>::Type TTargetIterator;
-            _setEnd(target, TTargetIterator( begin(target) + source_length));
-        }
+        assignValue(begin(target, Standard()), 0); //set target length to 0
+        assign(begin(target, Standard()), source, Insist());
+        typedef typename Iterator<TTarget>::Type TTargetIterator;
+        _setEnd(target, TTargetIterator( begin(target) + source_length));
+
     }
 
     template <typename TTarget, typename TSource, typename TLimit>


### PR DESCRIPTION
`if (length(source) > 0)` in CreateArrayStringExpand_ (string_cstyle.h line 585) removed because it results in incomplete initialization of a CStyle string with an empty string.
