### PR TITLE
[FEATURE, INTERNAL] Altered Display of ArgParseOption in help page 

### DIFF
--- a/include/seqan/arg_parse/arg_parse_argument.h
+++ b/include/seqan/arg_parse/arg_parse_argument.h
@@ -495,41 +495,7 @@ inline std::string getArgumentType(ArgParseArgument const & me)
 
 inline std::string getArgumentLabel(ArgParseArgument const & me)
 {
-    if (me._argumentLabel != "")
-    {
-        return me._argumentLabel;
-    }
-    else
-    {
-        // infer from argument type
-        std::string baseLabel = "";
-        if (isInputFileArgument(me) || isOutputFileArgument(me))
-            baseLabel = "FILE";
-        else if (isInputPrefixArgument(me) || isOutputPrefixArgument(me))
-            baseLabel = "PREFIX";
-        else if (isStringArgument(me))
-            baseLabel = "STR";
-        else if (isIntegerArgument(me) || isDoubleArgument(me))
-            baseLabel = "NUM";
-
-        std::string finalLabel;
-
-        if (me._numberOfValues != 1)
-        {
-            for (unsigned i = 0; i < me._numberOfValues; ++i)
-            {
-                if (i != 0)
-                    append(finalLabel, " ");
-                append(finalLabel, baseLabel);
-            }
-        }
-        else if (isListArgument(me))
-            finalLabel = baseLabel;                         // maybe we want to customize list labels
-        else
-            finalLabel = baseLabel;
-
-        return finalLabel;
-    }
+    return me._argumentLabel;
 }
 
 // ----------------------------------------------------------------------------

--- a/include/seqan/arg_parse/arg_parse_argument.h
+++ b/include/seqan/arg_parse/arg_parse_argument.h
@@ -483,10 +483,41 @@ inline std::string const _getArgumentType(ArgParseArgument const & me)
 
 inline std::string const getArgumentLabel(ArgParseArgument const & me)
 {
-    if (me._argumentLabel.empty())
+    if (me._argumentLabel != "")
+    {
         return me._argumentLabel;
+    }
     else
-        return _getArgumentType(me);
+    {
+        // infer from argument type
+        std::string baseLabel = "";
+        if (isInputFileArgument(me) || isOutputFileArgument(me))
+            baseLabel = "FILE";
+        else if (isInputPrefixArgument(me) || isOutputPrefixArgument(me))
+            baseLabel = "PREFIX";
+        else if (isStringArgument(me))
+            baseLabel = "STR";
+        else if (isIntegerArgument(me) || isDoubleArgument(me))
+            baseLabel = "NUM";
+
+        std::string finalLabel;
+
+        if (me._numberOfValues != 1)
+        {
+            for (unsigned i = 0; i < me._numberOfValues; ++i)
+            {
+                if (i != 0)
+                    append(finalLabel, " ");
+                append(finalLabel, baseLabel);
+            }
+        }
+        else if (isListArgument(me))
+            finalLabel = baseLabel;                         // maybe we want to customize list labels
+        else
+            finalLabel = baseLabel;
+
+        return finalLabel;
+    }
 }
 
 // ----------------------------------------------------------------------------

--- a/include/seqan/arg_parse/arg_parse_argument.h
+++ b/include/seqan/arg_parse/arg_parse_argument.h
@@ -230,19 +230,19 @@ inline std::string _typeToString(ArgParseArgument const & me)
         break;
 
     case ArgParseArgument::INPUT_FILE:
-        typeName = "inputfile";
+        typeName = "input_file";
         break;
 
     case ArgParseArgument::OUTPUT_FILE:
-        typeName = "outputfile";
+        typeName = "output_file";
         break;
 
     case ArgParseArgument::INPUT_PREFIX:
-        typeName = "inputprefix";
+        typeName = "input_prefix";
         break;
 
     case ArgParseArgument::OUTPUT_PREFIX:
-        typeName = "outputprefix";
+        typeName = "output_prefix";
         break;
 
     default:
@@ -476,7 +476,7 @@ inline ArgParseArgument::ArgumentType getArgumentType(ArgParseArgument const & m
 /*!
  * @fn ArgParseArgument#getArgumentTypeAsString
  * @headerfile <seqan/arg_parse.h>
- * @brief Return argument type. The type is either FILE, FILENAME_PREFIX, STRING, NUMBER or UNKOWN_TYPE.
+ * @brief Return argument type As a string.
  *
  * @signature std::string getArgumentTypeAsString(arg);
  *
@@ -487,15 +487,7 @@ inline ArgParseArgument::ArgumentType getArgumentType(ArgParseArgument const & m
 
 inline std::string getArgumentTypeAsString(ArgParseArgument const & me)
 {
-    if (isInputFileArgument(me) || isOutputFileArgument(me))
-        return "FILE";
-    else if (isInputPrefixArgument(me) || isOutputPrefixArgument(me))
-        return "FILENAME_PREFIX";
-    else if (isStringArgument(me))
-        return "STRING";
-    else if (isIntegerArgument(me) || isDoubleArgument(me))
-        return "NUMBER";
-    return "UNKOWN_TYPE";
+    return _typeToString(me._argumentType);
 }
 
 // ----------------------------------------------------------------------------

--- a/include/seqan/arg_parse/arg_parse_argument.h
+++ b/include/seqan/arg_parse/arg_parse_argument.h
@@ -455,16 +455,37 @@ inline bool isInputPrefixArgument(ArgParseArgument const & me)
 /*!
  * @fn ArgParseArgument#getArgumentType
  * @headerfile <seqan/arg_parse.h>
- * @brief Return argument type. The type is either FILE, FILENAME_PREFIX, STRING, NUMBER or UNKOWN_TYPE.
+ * @brief Return the <tt>ArgParseArgument::ArgumentType</tt>.
  *
  * @signature std::string getArgumentType(arg);
+ *
+ * @param[in] arg The ArgParseArgument to query.
+ *
+ * @return ArgumentType The argument type.
+ */
+
+inline ArgParseArgument::ArgumentType getArgumentType(ArgParseArgument const & me)
+{
+    return me._argumentType;
+}
+
+// ----------------------------------------------------------------------------
+// Function getArgumentTypeAsString()
+// ----------------------------------------------------------------------------
+
+/*!
+ * @fn ArgParseArgument#getArgumentTypeAsString
+ * @headerfile <seqan/arg_parse.h>
+ * @brief Return argument type. The type is either FILE, FILENAME_PREFIX, STRING, NUMBER or UNKOWN_TYPE.
+ *
+ * @signature std::string getArgumentTypeAsString(arg);
  *
  * @param[in] arg The ArgParseArgument to query.
  *
  * @return std::string The argument type as a STL string.
  */
 
-inline std::string getArgumentType(ArgParseArgument const & me)
+inline std::string getArgumentTypeAsString(ArgParseArgument const & me)
 {
     if (isInputFileArgument(me) || isOutputFileArgument(me))
         return "FILE";

--- a/include/seqan/arg_parse/arg_parse_argument.h
+++ b/include/seqan/arg_parse/arg_parse_argument.h
@@ -457,7 +457,7 @@ inline std::string _getArgumentType(ArgParseArgument const & me)
     if (isInputFileArgument(me) || isOutputFileArgument(me))
         return "FILE";
     else if (isInputPrefixArgument(me) || isOutputPrefixArgument(me))
-        return "PREFIX";
+        return "FILENAME_PREFIX";
     else if (isStringArgument(me))
         return "STRING";
     else if (isIntegerArgument(me) || isDoubleArgument(me))

--- a/include/seqan/arg_parse/arg_parse_argument.h
+++ b/include/seqan/arg_parse/arg_parse_argument.h
@@ -451,7 +451,7 @@ inline bool isInputPrefixArgument(ArgParseArgument const & me)
 // ----------------------------------------------------------------------------
 // Function _getArgumentType()
 // ----------------------------------------------------------------------------
-inline std::string const _getArgumentType(ArgParseArgument const & me)
+inline std::string _getArgumentType(ArgParseArgument const & me)
 {
     // infer from argument type
     if (isInputFileArgument(me) || isOutputFileArgument(me))
@@ -481,7 +481,7 @@ inline std::string const _getArgumentType(ArgParseArgument const & me)
  * @return std::string The argument label as a STL string.
  */
 
-inline std::string const getArgumentLabel(ArgParseArgument const & me)
+inline std::string getArgumentLabel(ArgParseArgument const & me)
 {
     if (me._argumentLabel != "")
     {

--- a/include/seqan/arg_parse/arg_parse_argument.h
+++ b/include/seqan/arg_parse/arg_parse_argument.h
@@ -449,6 +449,23 @@ inline bool isInputPrefixArgument(ArgParseArgument const & me)
 }
 
 // ----------------------------------------------------------------------------
+// Function _getArgumentType()
+// ----------------------------------------------------------------------------
+inline std::string const _getArgumentType(ArgParseArgument const & me)
+{
+    // infer from argument type
+    if (isInputFileArgument(me) || isOutputFileArgument(me))
+        return "FILE";
+    else if (isInputPrefixArgument(me) || isOutputPrefixArgument(me))
+        return "PREFIX";
+    else if (isStringArgument(me))
+        return "STRING";
+    else if (isIntegerArgument(me) || isDoubleArgument(me))
+        return "NUMBER";
+    return "";
+}
+
+// ----------------------------------------------------------------------------
 // Function getArgumentLabel()
 // ----------------------------------------------------------------------------
 
@@ -466,41 +483,10 @@ inline bool isInputPrefixArgument(ArgParseArgument const & me)
 
 inline std::string const getArgumentLabel(ArgParseArgument const & me)
 {
-    if (me._argumentLabel != "")
-    {
+    if (me._argumentLabel.empty())
         return me._argumentLabel;
-    }
     else
-    {
-        // infer from argument type
-        std::string baseLabel = "";
-        if (isInputFileArgument(me) || isOutputFileArgument(me))
-            baseLabel = "FILE";
-        else if (isInputPrefixArgument(me) || isOutputPrefixArgument(me))
-            baseLabel = "PREFIX";
-        else if (isStringArgument(me))
-            baseLabel = "STR";
-        else if (isIntegerArgument(me) || isDoubleArgument(me))
-            baseLabel = "NUM";
-
-        std::string finalLabel;
-
-        if (me._numberOfValues != 1)
-        {
-            for (unsigned i = 0; i < me._numberOfValues; ++i)
-            {
-                if (i != 0)
-                    append(finalLabel, " ");
-                append(finalLabel, baseLabel);
-            }
-        }
-        else if (isListArgument(me))
-            finalLabel = baseLabel;                         // maybe we want to customize list labels
-        else
-            finalLabel = baseLabel;
-
-        return finalLabel;
-    }
+        return _getArgumentType(me);
 }
 
 // ----------------------------------------------------------------------------
@@ -1084,6 +1070,16 @@ inline std::string getFileExtension(ArgParseArgument const & me, unsigned pos = 
     if (dotPos == std::string::npos)
         return "";
     return value.substr(dotPos + 1);
+}
+
+// ----------------------------------------------------------------------------
+// Function isBooleanOption()
+// ----------------------------------------------------------------------------
+
+// needed for easy printing of the help page
+constexpr bool isBooleanOption(ArgParseArgument const & /*me*/)
+{
+    return false;
 }
 
 } // namespace seqan

--- a/include/seqan/arg_parse/arg_parse_argument.h
+++ b/include/seqan/arg_parse/arg_parse_argument.h
@@ -449,11 +449,23 @@ inline bool isInputPrefixArgument(ArgParseArgument const & me)
 }
 
 // ----------------------------------------------------------------------------
-// Function _getArgumentType()
+// Function getArgumentType()
 // ----------------------------------------------------------------------------
-inline std::string _getArgumentType(ArgParseArgument const & me)
+
+/*!
+ * @fn ArgParseArgument#getArgumentType
+ * @headerfile <seqan/arg_parse.h>
+ * @brief Return argument type. The type is either FILE, FILENAME_PREFIX, STRING, NUMBER or UNKOWN_TYPE.
+ *
+ * @signature std::string getArgumentType(arg);
+ *
+ * @param[in] arg The ArgParseArgument to query.
+ *
+ * @return std::string The argument type as a STL string.
+ */
+
+inline std::string getArgumentType(ArgParseArgument const & me)
 {
-    // infer from argument type
     if (isInputFileArgument(me) || isOutputFileArgument(me))
         return "FILE";
     else if (isInputPrefixArgument(me) || isOutputPrefixArgument(me))
@@ -462,7 +474,7 @@ inline std::string _getArgumentType(ArgParseArgument const & me)
         return "STRING";
     else if (isIntegerArgument(me) || isDoubleArgument(me))
         return "NUMBER";
-    return "";
+    return "UNKOWN_TYPE";
 }
 
 // ----------------------------------------------------------------------------

--- a/include/seqan/arg_parse/arg_parse_argument.h
+++ b/include/seqan/arg_parse/arg_parse_argument.h
@@ -1094,16 +1094,6 @@ inline std::string getFileExtension(ArgParseArgument const & me, unsigned pos = 
     return value.substr(dotPos + 1);
 }
 
-// ----------------------------------------------------------------------------
-// Function isBooleanOption()
-// ----------------------------------------------------------------------------
-
-// needed for easy printing of the help page
-constexpr bool isBooleanOption(ArgParseArgument const & /*me*/)
-{
-    return false;
-}
-
 } // namespace seqan
 
 #endif // SEQAN_INCLUDE_SEQAN_ARG_PARSE_ARG_PARSE_ARGUMENT_H_

--- a/include/seqan/arg_parse/arg_parse_doc.h
+++ b/include/seqan/arg_parse/arg_parse_doc.h
@@ -813,7 +813,7 @@ inline void _addValidValuesRestrictions(std::string & text, ArgParseArgument con
 
 inline void _addTypeAndListInfo(std::string & text, ArgParseArgument const & arg)
 {
-    std::string type = _getArgumentType(arg);
+    std::string type = getArgumentType(arg);
 
     // Write arguments to term line -> only exception, boolean flags
     if (!empty(type))

--- a/include/seqan/arg_parse/arg_parse_doc.h
+++ b/include/seqan/arg_parse/arg_parse_doc.h
@@ -667,22 +667,22 @@ inline void printLongCopyright(ArgumentParser const & me)
 // Function _addNumericalRestriction()
 // ----------------------------------------------------------------------------
 
-inline void _addNumericalRestriction(std::string & text, ArgParseOption const & opt)
+inline void _addNumericalRestriction(std::string & text, ArgParseArgument const & arg)
 {
     // expand min/max restrictions
-    if (!empty(opt.minValue) || !empty(opt.maxValue))
+    if (!empty(arg.minValue) || !empty(arg.maxValue))
     {
         append(text, " In range [");
 
-        if (!empty(opt.minValue))
-            append(text, opt.minValue);
+        if (!empty(arg.minValue))
+            append(text, arg.minValue);
         else
             append(text, "-inf");
 
         append(text, "..");
 
-        if (!empty(opt.maxValue))
-            append(text, opt.maxValue);
+        if (!empty(arg.maxValue))
+            append(text, arg.maxValue);
         else
             append(text, "inf");
 
@@ -718,12 +718,12 @@ inline void _expandList(std::string & text, std::vector<std::string> const & lis
 // Function _addDefaultValues()
 // ----------------------------------------------------------------------------
 
-inline void _addDefaultValues(std::string & text, ArgParseOption const & opt)
+inline void _addDefaultValues(std::string & text, ArgParseArgument const & arg)
 {
-    if (!empty(opt.defaultValue) && !isBooleanOption(opt))
+    if (!empty(arg.defaultValue) && !isBooleanOption(arg))
     {
         append(text, " Default: ");
-        _expandList(text, opt.defaultValue);
+        _expandList(text, arg.defaultValue);
         append(text, ".");
     }
 }
@@ -770,16 +770,16 @@ inline void _seperateExtensionsForPrettyPrinting(std::vector<std::string> & file
 // Function _addValidValuesRestrictions()
 // ----------------------------------------------------------------------------
 
-inline void _addValidValuesRestrictions(std::string & text, ArgParseOption const & opt)
+inline void _addValidValuesRestrictions(std::string & text, ArgParseArgument const & arg)
 {
-    if (!empty(opt.validValues) && !isBooleanOption(opt))
+    if (!empty(arg.validValues) && !isBooleanOption(arg))
     {
-        if (isInputFileArgument(opt) || isOutputFileArgument(opt))
+        if (isInputFileArgument(arg) || isOutputFileArgument(arg))
         {
             std::vector<std::string> file_extensions;
             std::vector<std::string> compresssion_extensions;
 
-            _seperateExtensionsForPrettyPrinting(file_extensions, compresssion_extensions, opt.validValues);
+            _seperateExtensionsForPrettyPrinting(file_extensions, compresssion_extensions, arg.validValues);
 
             append(text, " Valid filetype");
 
@@ -800,10 +800,38 @@ inline void _addValidValuesRestrictions(std::string & text, ArgParseOption const
         else
         {
             append(text, " One of ");
-            _expandList(text, opt.validValues);
+            _expandList(text, arg.validValues);
         }
 
         append(text, ".");
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Function _addTypeAndListInfo()
+// ----------------------------------------------------------------------------
+
+inline void _addTypeAndListInfo(std::string & text, ArgParseArgument const & arg)
+{
+    std::string type = _getArgumentType(arg);
+
+    // Write arguments to term line -> only exception, boolean flags
+    if (!empty(type))
+    {
+        append(text, " ");
+
+        if (isListArgument(arg))
+            append(text, "List of ");
+
+        if (arg._numberOfValues != 1)
+            append(text,  std::to_string(arg._numberOfValues) + " ");
+
+        append(text, "\\fI");
+        append(text, type);
+        append(text, "\\fP");
+
+        if (isListArgument(arg))
+            append(text, "'s");
     }
 }
 
@@ -842,7 +870,49 @@ inline void printHelp(ArgumentParser const & me,
     for (unsigned i = 0; i < me._description.size(); ++i)
         addText(toolDoc, me._description[i]);
 
-    // Add options to description section.
+    // Add arguments to arguments section
+    if (length(me.argumentList) != 0)
+        addSection(toolDoc, "Arguments");
+    for (unsigned i = 0; i < length(me.argumentList); ++i)
+    {
+        ArgParseArgument const & arg = me.argumentList[i];
+
+        // Build list item term.
+        std::string term;
+        if (!empty(arg._argumentLabel))
+        {
+            term = "\\fB-";
+            append(term, arg._argumentLabel);
+            append(term, "\\fP");
+        }
+        else
+        {
+            term = "\\fB-ARGUMENT ";
+            append(term, std::to_string(i));
+            append(term, "\\fP");
+        }
+
+        // expand type, list and numValues information
+        _addTypeAndListInfo(term, arg);
+
+        std::string helpText = arg._helpText;
+
+        // expand min/max restrictions
+        _addNumericalRestriction(helpText, arg);
+
+        // expand validValues restrictions
+        _addValidValuesRestrictions(helpText, arg);
+
+        // expand defaultValue
+        _addDefaultValues(helpText, arg);
+
+        // Add list item.
+        addListItem(toolDoc, term, helpText);
+    }
+
+    // Add options to options section.
+    if (length(me.optionMap) != 0)
+        addSection(toolDoc, "Options");
     for (unsigned i = 0; i < length(me.optionMap); ++i)
     {
         ArgParseOption const & opt = me.optionMap[i];
@@ -885,25 +955,9 @@ inline void printHelp(ArgumentParser const & me,
                 append(term, opt.longName);
                 append(term, "\\fP");
             }
-            // Get arguments, autogenerate if necessary.
-            std::string arguments = getArgumentLabel(opt);
 
-            // Write arguments to term line -> only exception, boolean flags
-            if (!empty(arguments))
-            {
-                // Tokenize argument names.
-                std::istringstream iss(toCString(arguments));
-                std::vector<std::string> tokens;
-                std::copy(std::istream_iterator<std::string>(iss), std::istream_iterator<std::string>(),
-                          std::back_inserter<std::vector<std::string> >(tokens));
-                // Append them, formatted in italic.
-                for (unsigned i = 0; i < length(tokens); ++i)
-                {
-                    append(term, " \\fI");
-                    append(term, tokens[i]);
-                    append(term, "\\fP");
-                }
-            }
+            // expand type, list and numValues information
+            _addTypeAndListInfo(term, opt);
 
             std::string helpText = opt._helpText;
 

--- a/include/seqan/arg_parse/arg_parse_doc.h
+++ b/include/seqan/arg_parse/arg_parse_doc.h
@@ -865,7 +865,8 @@ inline void _addValidValuesRestrictions(std::string & text, ArgParseOption const
 inline void _addTypeAndListInfo(std::string & text, ArgParseArgument const & arg)
 {
     std::string type = getArgumentTypeAsString(arg);
-    for (auto & c: type) c = toupper(c);
+    for (auto & c: type)
+         c = toupper(c);
 
     // Write arguments to term line -> only exception, boolean flags
     if (!empty(type))

--- a/include/seqan/arg_parse/arg_parse_doc.h
+++ b/include/seqan/arg_parse/arg_parse_doc.h
@@ -813,7 +813,7 @@ inline void _addValidValuesRestrictions(std::string & text, ArgParseArgument con
 
 inline void _addTypeAndListInfo(std::string & text, ArgParseArgument const & arg)
 {
-    std::string type = getArgumentType(arg);
+    std::string type = getArgumentTypeAsString(arg);
 
     // Write arguments to term line -> only exception, boolean flags
     if (!empty(type))

--- a/include/seqan/arg_parse/arg_parse_doc.h
+++ b/include/seqan/arg_parse/arg_parse_doc.h
@@ -759,12 +759,18 @@ inline void _expandList(std::string & text, std::vector<std::string> const & lis
 
 inline void _addDefaultValues(std::string & text, ArgParseArgument const & arg)
 {
-    if (!empty(arg.defaultValue) && !isBooleanOption(arg))
+    if (!empty(arg.defaultValue))
     {
         append(text, " Default: ");
         _expandList(text, arg.defaultValue);
         append(text, ".");
     }
+}
+
+inline void _addDefaultValues(std::string & text, ArgParseOption const & arg)
+{
+    if (!isBooleanOption(arg))
+        _addDefaultValues(text, static_cast<ArgParseArgument>(arg));
 }
 
 // ----------------------------------------------------------------------------
@@ -811,7 +817,7 @@ inline void _seperateExtensionsForPrettyPrinting(std::vector<std::string> & file
 
 inline void _addValidValuesRestrictions(std::string & text, ArgParseArgument const & arg)
 {
-    if (!empty(arg.validValues) && !isBooleanOption(arg))
+    if (!empty(arg.validValues))
     {
         if (isInputFileArgument(arg) || isOutputFileArgument(arg))
         {
@@ -846,6 +852,12 @@ inline void _addValidValuesRestrictions(std::string & text, ArgParseArgument con
     }
 }
 
+inline void _addValidValuesRestrictions(std::string & text, ArgParseOption const & opt)
+{
+    if (!isBooleanOption(opt))
+        _addValidValuesRestrictions(text, static_cast<ArgParseArgument>(opt));
+}
+
 // ----------------------------------------------------------------------------
 // Function _addTypeAndListInfo()
 // ----------------------------------------------------------------------------
@@ -870,7 +882,7 @@ inline void _addTypeAndListInfo(std::string & text, ArgParseArgument const & arg
         append(text, type);
         append(text, "\\fP");
 
-        if (isListArgument(arg))
+        if (isListArgument(arg) || arg._numberOfValues != 1)
             append(text, "'s");
     }
 }
@@ -1000,7 +1012,8 @@ inline void printHelp(ArgumentParser const & me,
             }
 
             // expand type, list and numValues information
-            _addTypeAndListInfo(term, opt);
+            if (!opt._isFlag)
+                _addTypeAndListInfo(term, opt);
 
             std::string helpText = opt._helpText;
 

--- a/include/seqan/arg_parse/arg_parse_doc.h
+++ b/include/seqan/arg_parse/arg_parse_doc.h
@@ -959,25 +959,8 @@ inline void printHelp(ArgumentParser const & me,
                 append(term, "\\fP");
             }
 
-            // Get arguments, autogenerate if necessary.
-            std::string arguments = getArgumentLabel(opt);
-
-            // Write arguments to term line -> only exception, boolean flags
-            if (!empty(arguments))
-            {
-                // Tokenize argument names.
-                std::istringstream iss(toCString(arguments));
-                std::vector<std::string> tokens;
-                std::copy(std::istream_iterator<std::string>(iss), std::istream_iterator<std::string>(),
-                          std::back_inserter<std::vector<std::string> >(tokens));
-                // Append them, formatted in italic.
-                for (unsigned i = 0; i < length(tokens); ++i)
-                {
-                    append(term, " \\fI");
-                    append(term, tokens[i]);
-                    append(term, "\\fP");
-                }
-            }
+            // expand type, list and numValues information
+            _addTypeAndListInfo(term, opt);
 
             std::string helpText = opt._helpText;
 

--- a/include/seqan/arg_parse/arg_parse_doc.h
+++ b/include/seqan/arg_parse/arg_parse_doc.h
@@ -873,6 +873,7 @@ inline void printHelp(ArgumentParser const & me,
     // Add arguments to arguments section
     if (length(me.argumentList) != 0)
         addSection(toolDoc, "Arguments");
+
     for (unsigned i = 0; i < length(me.argumentList); ++i)
     {
         ArgParseArgument const & arg = me.argumentList[i];
@@ -913,6 +914,7 @@ inline void printHelp(ArgumentParser const & me,
     // Add options to options section.
     if (length(me.optionMap) != 0)
         addSection(toolDoc, "Options");
+
     for (unsigned i = 0; i < length(me.optionMap); ++i)
     {
         ArgParseOption const & opt = me.optionMap[i];

--- a/include/seqan/arg_parse/arg_parse_doc.h
+++ b/include/seqan/arg_parse/arg_parse_doc.h
@@ -814,6 +814,7 @@ inline void _addValidValuesRestrictions(std::string & text, ArgParseArgument con
 inline void _addTypeAndListInfo(std::string & text, ArgParseArgument const & arg)
 {
     std::string type = getArgumentTypeAsString(arg);
+    for (auto & c: type) c = toupper(c);
 
     // Write arguments to term line -> only exception, boolean flags
     if (!empty(type))

--- a/include/seqan/arg_parse/arg_parse_doc.h
+++ b/include/seqan/arg_parse/arg_parse_doc.h
@@ -872,7 +872,7 @@ inline void printHelp(ArgumentParser const & me,
 
     // Add arguments to arguments section
     if (length(me.argumentList) != 0)
-        addSection(toolDoc, "Arguments");
+        addSection(toolDoc, "Required Arguments");
 
     for (unsigned i = 0; i < length(me.argumentList); ++i)
     {
@@ -882,13 +882,14 @@ inline void printHelp(ArgumentParser const & me,
         std::string term;
         if (!empty(arg._argumentLabel))
         {
-            term = "\\fB-";
-            append(term, arg._argumentLabel);
+            std::regex space(" ");
+            term = "\\fB";
+            append(term, std::regex_replace(arg._argumentLabel, space,"_"));
             append(term, "\\fP");
         }
         else
         {
-            term = "\\fB-ARGUMENT ";
+            term = "\\fBARGUMENT ";
             append(term, std::to_string(i));
             append(term, "\\fP");
         }

--- a/include/seqan/arg_parse/arg_parse_doc.h
+++ b/include/seqan/arg_parse/arg_parse_doc.h
@@ -956,8 +956,25 @@ inline void printHelp(ArgumentParser const & me,
                 append(term, "\\fP");
             }
 
-            // expand type, list and numValues information
-            _addTypeAndListInfo(term, opt);
+            // Get arguments, autogenerate if necessary.
+            std::string arguments = getArgumentLabel(opt);
+
+            // Write arguments to term line -> only exception, boolean flags
+            if (!empty(arguments))
+            {
+                // Tokenize argument names.
+                std::istringstream iss(toCString(arguments));
+                std::vector<std::string> tokens;
+                std::copy(std::istream_iterator<std::string>(iss), std::istream_iterator<std::string>(),
+                          std::back_inserter<std::vector<std::string> >(tokens));
+                // Append them, formatted in italic.
+                for (unsigned i = 0; i < length(tokens); ++i)
+                {
+                    append(term, " \\fI");
+                    append(term, tokens[i]);
+                    append(term, "\\fP");
+                }
+            }
 
             std::string helpText = opt._helpText;
 

--- a/tests/arg_parse/test_arg_parse.cpp
+++ b/tests/arg_parse/test_arg_parse.cpp
@@ -130,12 +130,15 @@ SEQAN_BEGIN_TESTSUITE(test_arg_parse)
     SEQAN_CALL_TEST(test_long_short_flag_name);
 
     // cmd argument tests
-    SEQAN_CALL_TEST(test_argument_string_label);
-    SEQAN_CALL_TEST(test_argument_int_label);
-    SEQAN_CALL_TEST(test_argument_double_label);
-    SEQAN_CALL_TEST(test_argument_inputfile_label);
-    SEQAN_CALL_TEST(test_argument_outputfile_label);
-    SEQAN_CALL_TEST(test_argument_user_defined_label);
+    SEQAN_CALL_TEST(test_argument_string_type);
+    SEQAN_CALL_TEST(test_argument_int_type);
+    SEQAN_CALL_TEST(test_argument_int64_type);
+    SEQAN_CALL_TEST(test_argument_double_type);
+    SEQAN_CALL_TEST(test_argument_inputfile_type);
+    SEQAN_CALL_TEST(test_argument_outputfile_type);
+    SEQAN_CALL_TEST(test_argument_inputprefix_type);
+    SEQAN_CALL_TEST(test_argument_outputprefix_type);
+    SEQAN_CALL_TEST(test_argument_label);
     SEQAN_CALL_TEST(test_argument_invalid_cast);
     SEQAN_CALL_TEST(test_argument_min_max_boundaries);
     SEQAN_CALL_TEST(test_argument_valid_values);

--- a/tests/arg_parse/test_arg_parse_argument.h
+++ b/tests/arg_parse/test_arg_parse_argument.h
@@ -44,73 +44,58 @@
 
 using namespace seqan;
 
-SEQAN_DEFINE_TEST(test_argument_string_label)
+SEQAN_DEFINE_TEST(test_argument_string_type)
 {
-    ArgParseArgument arg1(ArgParseArgument::STRING);
-    SEQAN_ASSERT_EQ(getArgumentLabel(arg1), "STR");
-
-    arg1._numberOfValues = 2;
-    SEQAN_ASSERT_EQ(getArgumentLabel(arg1), "STR STR");
-
-    ArgParseArgument arg2(ArgParseArgument::STRING);
-    SEQAN_ASSERT_EQ(getArgumentLabel(arg2), "STR");
+    ArgParseArgument arg(ArgParseArgument::STRING);
+    SEQAN_ASSERT_EQ(getArgumentType(arg), ArgParseArgument::STRING);
 }
 
-SEQAN_DEFINE_TEST(test_argument_int_label)
+SEQAN_DEFINE_TEST(test_argument_int_type)
 {
-    ArgParseArgument arg1(ArgParseArgument::INTEGER);
-    SEQAN_ASSERT_EQ(getArgumentLabel(arg1), "NUM");
-
-    arg1._numberOfValues = 2;
-    SEQAN_ASSERT_EQ(getArgumentLabel(arg1), "NUM NUM");
-
-    ArgParseArgument arg2(ArgParseArgument::INTEGER);
-    SEQAN_ASSERT_EQ(getArgumentLabel(arg2), "NUM");
+    ArgParseArgument arg(ArgParseArgument::INTEGER);
+    SEQAN_ASSERT_EQ(getArgumentType(arg), ArgParseArgument::INTEGER);
 }
 
-SEQAN_DEFINE_TEST(test_argument_double_label)
+SEQAN_DEFINE_TEST(test_argument_int64_type)
 {
-    ArgParseArgument arg1(ArgParseArgument::DOUBLE);
-    SEQAN_ASSERT_EQ(getArgumentLabel(arg1), "NUM");
-
-    arg1._numberOfValues = 2;
-    SEQAN_ASSERT_EQ(getArgumentLabel(arg1), "NUM NUM");
-
-    ArgParseArgument arg2(ArgParseArgument::DOUBLE);
-    SEQAN_ASSERT_EQ(getArgumentLabel(arg2), "NUM");
+    ArgParseArgument arg(ArgParseArgument::INT64);
+    SEQAN_ASSERT_EQ(getArgumentType(arg), ArgParseArgument::INT64);
 }
 
-SEQAN_DEFINE_TEST(test_argument_inputfile_label)
+SEQAN_DEFINE_TEST(test_argument_double_type)
 {
-    ArgParseArgument arg1(ArgParseArgument::INPUT_FILE);
-    SEQAN_ASSERT_EQ(getArgumentLabel(arg1), "FILE");
-
-    arg1._numberOfValues = 2;
-    SEQAN_ASSERT_EQ(getArgumentLabel(arg1), "FILE FILE");
-
-    ArgParseArgument arg2(ArgParseArgument::INPUT_FILE);
-    SEQAN_ASSERT_EQ(getArgumentLabel(arg2), "FILE");
+    ArgParseArgument arg(ArgParseArgument::DOUBLE);
+    SEQAN_ASSERT_EQ(getArgumentType(arg), ArgParseArgument::DOUBLE);
 }
 
-SEQAN_DEFINE_TEST(test_argument_outputfile_label)
+SEQAN_DEFINE_TEST(test_argument_inputfile_type)
 {
-    ArgParseArgument arg1(ArgParseArgument::OUTPUT_FILE);
-    SEQAN_ASSERT_EQ(getArgumentLabel(arg1), "FILE");
-
-    arg1._numberOfValues = 2;
-    SEQAN_ASSERT_EQ(getArgumentLabel(arg1), "FILE FILE");
-
-    ArgParseArgument arg2(ArgParseArgument::OUTPUT_FILE);
-    SEQAN_ASSERT_EQ(getArgumentLabel(arg2), "FILE");
+    ArgParseArgument arg(ArgParseArgument::INPUT_FILE);
+    SEQAN_ASSERT_EQ(getArgumentType(arg), ArgParseArgument::INPUT_FILE);
 }
 
-SEQAN_DEFINE_TEST(test_argument_user_defined_label)
+SEQAN_DEFINE_TEST(test_argument_outputfile_type)
 {
-    ArgParseArgument arg1(ArgParseArgument::STRING, "my_label");
-    SEQAN_ASSERT_EQ(getArgumentLabel(arg1), "my_label");
+    ArgParseArgument arg(ArgParseArgument::OUTPUT_FILE);
+    SEQAN_ASSERT_EQ(getArgumentType(arg), ArgParseArgument::OUTPUT_FILE);
+}
 
-    arg1._numberOfValues = 2;
-    SEQAN_ASSERT_EQ(getArgumentLabel(arg1), "my_label");
+SEQAN_DEFINE_TEST(test_argument_inputprefix_type)
+{
+    ArgParseArgument arg(ArgParseArgument::INPUT_PREFIX);
+    SEQAN_ASSERT_EQ(getArgumentType(arg), ArgParseArgument::INPUT_PREFIX);
+}
+
+SEQAN_DEFINE_TEST(test_argument_outputprefix_type)
+{
+    ArgParseArgument arg(ArgParseArgument::OUTPUT_PREFIX);
+    SEQAN_ASSERT_EQ(getArgumentType(arg), ArgParseArgument::OUTPUT_PREFIX);
+}
+
+SEQAN_DEFINE_TEST(test_argument_label)
+{
+    ArgParseArgument arg(ArgParseArgument::STRING, "my_label");
+    SEQAN_ASSERT_EQ(getArgumentLabel(arg), "my_label");
 }
 
 SEQAN_DEFINE_TEST(test_argument_invalid_cast)


### PR DESCRIPTION
- corrected behaviour of getArgumentLabel()
- added function getArgumentType()
- added function getArgumentTypeAsString()
- Altered display of an ArgParseOption on the help page: 
... - the type of the option is displayed instead of the argumentLabel
... - instead of ```NUM NUM NUM``` the help page displays ```List of 3 NUMBER's``` 