### PR TITLE
[FIX] Windows warning: EPR-dictionary: shift negative or too big

### DIFF
--- a/include/seqan/index/index_fm_rank_dictionary_levels.h
+++ b/include/seqan/index/index_fm_rank_dictionary_levels.h
@@ -507,8 +507,8 @@ struct RankDictionary<TValue, Levels<TSpec, TConfig> >
         // TODO(cpockrandt): make all bitmasks a const-expr
         constexpr unsigned maxValue = (1 << _BITS_PER_VALUE) - 1;
         constexpr unsigned padding = _BITS_PER_WORD % _BITS_PER_VALUE;
-	    // max() workaround for windows C4293 warning
-        constexpr TWordType paddingWord = (padding > 0) ? (1ull << (_BITS_PER_WORD - std::max(padding, 1u))) : 0ull;
+        // max() workaround for windows C4293 warning
+        TWordType paddingWord = (padding > 0) ? (1ull << (_BITS_PER_WORD - std::max(padding, 1u))) : 0ull;
         if (isLevelsPrefixRD<Levels<TSpec, TConfig> >::VALUE && !std::is_same<TValue, bool>::value)
         {
             if (padding > 0)

--- a/include/seqan/index/index_fm_rank_dictionary_levels.h
+++ b/include/seqan/index/index_fm_rank_dictionary_levels.h
@@ -36,6 +36,8 @@
 #ifndef INDEX_FM_RANK_DICTIONARY_LEVELS_H_
 #define INDEX_FM_RANK_DICTIONARY_LEVELS_H_
 
+#include <algorithm>
+
 #define TPREFIXLEVELS Levels<TSpec, LevelsPrefixRDConfig<TSize, TFibre, LEVELS, WPB> >
 
 namespace seqan {
@@ -503,10 +505,10 @@ struct RankDictionary<TValue, Levels<TSpec, TConfig> >
     void _populateBitmasks()
     {
         // TODO(cpockrandt): make all bitmasks a const-expr
-        const unsigned maxValue = (1 << _BITS_PER_VALUE) - 1;
-        const unsigned padding = _BITS_PER_WORD % _BITS_PER_VALUE;
-	// Max<> workaround for windows C4293 warning
-        const TWordType paddingWord = (padding > 0) ? (1ull << (_BITS_PER_WORD - Max<padding, 1>::VALUE)) : 0ull;
+        constexpr unsigned maxValue = (1 << _BITS_PER_VALUE) - 1;
+        constexpr unsigned padding = _BITS_PER_WORD % _BITS_PER_VALUE;
+	    // max() workaround for windows C4293 warning
+        constexpr TWordType paddingWord = (padding > 0) ? (1ull << (_BITS_PER_WORD - std::max(padding, 1u))) : 0ull;
         if (isLevelsPrefixRD<Levels<TSpec, TConfig> >::VALUE && !std::is_same<TValue, bool>::value)
         {
             if (padding > 0)

--- a/include/seqan/index/index_fm_rank_dictionary_levels.h
+++ b/include/seqan/index/index_fm_rank_dictionary_levels.h
@@ -505,7 +505,8 @@ struct RankDictionary<TValue, Levels<TSpec, TConfig> >
         // TODO(cpockrandt): make all bitmasks a const-expr
         const unsigned maxValue = (1 << _BITS_PER_VALUE) - 1;
         const unsigned padding = _BITS_PER_WORD % _BITS_PER_VALUE;
-        const TWordType paddingWord = (padding > 0) ? (1ull << (_BITS_PER_WORD - padding)) : 0ull;
+	// Max<> workaround for windows C4293 warning
+        const TWordType paddingWord = (padding > 0) ? (1ull << (_BITS_PER_WORD - Max<padding, 1>::VALUE)) : 0ull;
         if (isLevelsPrefixRD<Levels<TSpec, TConfig> >::VALUE && !std::is_same<TValue, bool>::value)
         {
             if (padding > 0)


### PR DESCRIPTION
(hopefully) resolves #1908 

Thanks for hinting at it, h-2!