### PR TITLE
Fixed reading/writing of contig names in VCF header

### DIFF
--- a/include/seqan/vcf_io/write_vcf.h
+++ b/include/seqan/vcf_io/write_vcf.h
@@ -61,6 +61,15 @@ writeHeader(TTarget & target,
         writeValue(target, '\n');
     }
 
+    for (unsigned i = 0; i < length(contigNames(context)); ++i)
+    {
+        write(target, "##");
+        write(target, "contig=<ID=");
+        write(target, contigNames(context)[i]);
+        writeValue(target, '>');
+        writeValue(target, '\n');
+    }
+
     write(target, "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT");
     for (unsigned i = 0; i < length(sampleNames(context)); ++i)
     {


### PR DESCRIPTION
Note that parsing could be smarter: now it expects ID as first field. Contig lengths could also be parsed.