### PR TITLE
Fixed reading of contig names in VCF header

### DIFF
--- a/include/seqan/vcf_io/read_vcf.h
+++ b/include/seqan/vcf_io/read_vcf.h
@@ -74,33 +74,28 @@ _readVcfContig(VcfIOContext<TNameStore, TNameStoreCache, TStorageSpec> & context
     TIter headerIter = directionIterator(headerValue, Input());
     CharString &buffer = context.buffer;
 
-    // Seek ID key.
-    clear(buffer);
-    skipOne(headerIter);
-    readUntil(buffer, headerIter, EqualsChar<'='>());
-    if (buffer != "ID")
-        SEQAN_THROW(ParseError("Contig ID key not found in header."));
-    skipOne(headerIter);
+    skipOne(headerIter, EqualsChar<'<'>());
 
-    // Read ID value.
+    // Seek contig ID key.
+    while (!atEnd(headerIter))
+    {
+        clear(buffer);
+        readUntil(buffer, headerIter, EqualsChar<'='>());
+        if (buffer == "ID") break;
+        skipUntil(headerIter, IsCommaOrGt());
+        skipOne(headerIter);
+    }
+
+    if (atEnd(headerIter))
+        SEQAN_THROW(ParseError("Contig ID key not found in header."));
+
+    // Read contig ID value.
     clear(buffer);
+    skipOne(headerIter, EqualsChar<'='>());
     readUntil(buffer, headerIter, IsCommaOrGt());
     if (empty(buffer))
-        SEQAN_THROW(ParseError("Contig ID key is empty."));
+        SEQAN_THROW(ParseError("Contig ID value not found in header."));
     appendName(contigNamesCache(context), buffer);
-
-    // Seek length key.
-//    clear(buffer);
-//    skipOne(headerIter);
-//    readUntil(buffer, headerIter, EqualsChar<'='>());
-//    if (buffer != "length")
-//        return;
-//    skipOne(headerIter);
-
-    // Read length value.
-//    clear(buffer);
-//    readUntil(buffer, headerIter, IsCommaOrGt());
-//    appendValue(contigLengths(context), lexicalCast<int32_t>(buffer));
 }
 
 template <typename TForwardIter, typename TNameStore, typename TNameStoreCache, typename TStorageSpec>


### PR DESCRIPTION
Was PR #1932.

I removed contig names writing as it requires heavier changes. It would be cool if somebody implements that feature though.

Notes:
* VcfIOContext lacks contig lengths. I added code to parse that field as soon as VcfIOContext has contig lengths.
* VcfIOContext and BamIOContext would share enough functionality to have a common super context.
* Right now contig header line is stored as an unparsed header record. If we store contig names/lengths in the context and write those instead, other keys [like these](https://github.com/seqan/seqan/blob/master/tests/vcf_io/example.vcf#L5) will be lost.