### PR TITLE
Fixed warning “misleadingly indented”

### DIFF
--- a/include/seqan/seq_io/bam_sam.h
+++ b/include/seqan/seq_io/bam_sam.h
@@ -264,11 +264,12 @@ inline void _readRecord(TIdString & meta,
         resize(qual, l_qseq, Exact());
         TQualIter qitEnd = end(qual, Standard());
         for (TQualIter qit = begin(qual, Standard()); qit != qitEnd; )
+        {
             *qit++ = '!' + *it++;
-
-            clear(file.context.prevId);
-            file.context.prevId = meta;
-            }
+        }
+        clear(file.context.prevId);
+        file.context.prevId = meta;
+    }
     else
     {
         clear(file.context.prevId);


### PR DESCRIPTION
Fixes warning  due to PR #1920