### PR TITLE
[FEATURE] Added macros for disabling, opt-in or opt-out version update check

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,12 @@ Release 2.3.0
 Library Features
 ^^^^^^^^^^^^^^^^
 
+- Argument Parser:
+    - Adds version check support to the argument parser.
+        - Check for new updates of a specific application.
+        - Check for new versions of the library.
+        - This option is opt-out by default but can be switched to opt-in or completely disabled via compiler flags and the SeqAn build system.
+
 - Sequence I/O:
     - new support for RNA structure files
         - supported formats: Vienna (.dbv), Dot-Bracket-Notation (.dbn), Stockholm (.sth), Connect (.ct), Bpseq (.bpseq), Extended Bpseq (.ebpseq)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,8 @@ option (SEQAN_ARCH_NATIVE "Build natively optimized binaries." OFF)
 # Version Check Variable.
 # ===========================================================================
 
-option (SEQAN_VERSION_CHECK "SeqAn version check." ON)
+# Possible values: "opt-out" (default), "opt-in", "disable"
+set(SEQAN_VERSION_CHECK "opt-out" CACHE STRING "Option to choose how version update information should be integrated into the apps.")
 
 # ===========================================================================
 # Setup Modules and Find Packages.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,11 +79,11 @@ option (SEQAN_ARCH_AVX2 "Build AVX optimized binaries." OFF)
 option (SEQAN_ARCH_NATIVE "Build natively optimized binaries." OFF)
 
 # ===========================================================================
-# Version Check Variable.
+# Version Check Variables.
 # ===========================================================================
 
-# Possible values: "opt-out" (default), "opt-in", "disable"
-set(SEQAN_VERSION_CHECK "opt-out" CACHE STRING "Option to choose how version update information should be integrated into the apps.")
+option (SEQAN_VERSION_CHECK_OPT_IN "Enable version check but activate as opt-in." OFF)
+option (SEQAN_DISABLE_VERSION_CHECK "Disable version check." OFF) 
 
 # ===========================================================================
 # Setup Modules and Find Packages.

--- a/include/seqan/arg_parse/arg_parse_parse.h
+++ b/include/seqan/arg_parse/arg_parse_parse.h
@@ -308,6 +308,7 @@ ArgumentParser::ParseResult parse(ArgumentParser & me,
         return ArgumentParser::PARSE_ERROR;
     }
 
+#ifndef SEQAN_DISABLE_VERSION_CHECK
     // do version check if not turned off by the user
     std::string version_option;
     getOptionValue(version_option, me, "version-check");
@@ -332,6 +333,7 @@ ArgumentParser::ParseResult parse(ArgumentParser & me,
             seqan_version(std::move(seqanVersionProm));
         }
     }
+#endif  // !SEQAN_DISABLE_VERSION_CHECK
 
     // Handle the special options.
     if (hasOption(me, "version") && isSet(me, "version"))

--- a/include/seqan/arg_parse/arg_parse_version_check.h
+++ b/include/seqan/arg_parse/arg_parse_version_check.h
@@ -139,7 +139,7 @@ struct VersionCheck
         {
             _version = versionMatch.str(1); // in case the git revision number is given take only version number
         }
-        _url = static_cast<std::string>("http://www.seqan.de/version_check/SeqAn_") + _getOS() + _getBitSys() + _name + "_" + _version;
+        _url = static_cast<std::string>("http://seqan-update.informatik.uni-tuebingen.de/check/SeqAn_") + _getOS() + _getBitSys() + _name + "_" + _version;
         _getProgram();
         _updateCommand();
     }

--- a/include/seqan/arg_parse/argument_parser.h
+++ b/include/seqan/arg_parse/argument_parser.h
@@ -268,7 +268,7 @@ public:
             appVersionCheckFuture.wait_for(std::chrono::seconds(3));
                 
         if (seqanVersionCheckFuture.valid()) 
-            seqanVersionCheckFuture.wait_for(std::chrono::seconds(2));
+            seqanVersionCheckFuture.wait_for(std::chrono::seconds(3));
     }
     
 };

--- a/include/seqan/arg_parse/argument_parser.h
+++ b/include/seqan/arg_parse/argument_parser.h
@@ -264,8 +264,11 @@ public:
     ~ArgumentParser()
     {
         // wait for another 3 seconds
-        if(appVersionCheckFuture.valid())
+        if (appVersionCheckFuture.valid())
             appVersionCheckFuture.wait_for(std::chrono::seconds(3));
+                
+        if (seqanVersionCheckFuture.valid()) 
+            seqanVersionCheckFuture.wait_for(std::chrono::seconds(2));
     }
     
 };

--- a/include/seqan/arg_parse/argument_parser.h
+++ b/include/seqan/arg_parse/argument_parser.h
@@ -228,6 +228,7 @@ public:
         hideOption(*this, "export-help", true);
         setValidValues(*this, "export-help", "html man txt");
 
+#ifndef SEQAN_DISABLE_VERSION_CHECK
         addOption(*this, ArgParseOption("",
                                         "version-check",
                                         "Choose OFF to disable any update notifications. "
@@ -237,12 +238,12 @@ public:
                                         ArgParseArgument::STRING,
                                         "OPTION"));
         setValidValues(*this, "version-check", VersionControlTags_<>::OPTIONS);
-#ifdef SEQAN_DISABLE_VERSION_CHECK
+#ifdef SEQAN_VERSION_CHECK_OPT_IN
         setDefaultValue(*this, "version-check", VersionControlTags_<>::OPTION_OFF);
-        hideOption(*this, "version-check", true);
-#else
-        setDefaultValue(*this, "version-check", VersionControlTags_<>::OPTION_OFF);  // TODO(rrahn): Set to "DEV" after proper testing.
-#endif  // SEQAN_DISABLE_VERSION_CHECK
+#else  // Make version update opt out.
+        setDefaultValue(*this, "version-check", VersionControlTags_<>::OPTION_DEV);
+#endif  // SEQAN_VERSION_CHECK_OPT_IN
+#endif  // !SEQAN_DISABLE_VERSION_CHECK
     }
 
     // ----------------------------------------------------------------------------

--- a/manual/source/Infrastructure/Use/CustomBuildSystem.rst
+++ b/manual/source/Infrastructure/Use/CustomBuildSystem.rst
@@ -192,17 +192,24 @@ meaning
  If set to 1 then OpenMP is expected to be available.
  You might have to add ``-fopenmp`` and possibly ``-lgomp`` to your build. And OpenMP needs to be supported by your compiler.
 
-SEQAN_DISABLE_VERSION_VCHECK
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+SEQAN_VERSION_CHECK_OPT_IN
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-possible value
-  0, 1
+meaning 
+ If set then the version update feature is enabled but deactivated in the argument parser options and must be explicitly activated by the user.
+ If not specified the update feature is enabled and activated by default.
 
-default
-  0 (from release 2.4.0 onwards)
+usage
+ Add compiler flag: ``-DSEQAN_VERSION_CHCK_OPT_IN``
+
+SEQAN_DISABLE_VERSION_CHECK
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 meaning
-  Starting from the release 2.4.0 every application or script that uses the SeqAn argument parser (and only those) will have a new feature to check whether your SeqAn version is outdated. This feature can be disabled by setting this flag to 1. Note: You can also disble this feature at runtime by specifying the command line option ``--version-check OFF``.
+ If set the version update feature is disabled in the argument parser.
+
+usage
+ add compiler flag: ``-DSEQAN_DISABLE_VERSION_CHEK`` 
 
 Settings Projects Using Seqan
 -----------------------------

--- a/manual/source/Infrastructure/Use/CustomBuildSystem.rst
+++ b/manual/source/Infrastructure/Use/CustomBuildSystem.rst
@@ -200,7 +200,7 @@ meaning
  If not specified the update feature is enabled and activated by default.
 
 usage
- Add compiler flag: ``-DSEQAN_VERSION_CHCK_OPT_IN``
+ Add compiler flag: ``-DSEQAN_VERSION_CHECK_OPT_IN``
 
 SEQAN_DISABLE_VERSION_CHECK
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -209,7 +209,7 @@ meaning
  If set the version update feature is disabled in the argument parser.
 
 usage
- add compiler flag: ``-DSEQAN_DISABLE_VERSION_CHEK`` 
+ add compiler flag: ``-DSEQAN_DISABLE_VERSION_CHECK`` 
 
 Settings Projects Using Seqan
 -----------------------------

--- a/manual/source/Infrastructure/Use/FindSeqAnCMake.rst
+++ b/manual/source/Infrastructure/Use/FindSeqAnCMake.rst
@@ -145,11 +145,21 @@ See :ref:`this page <infra-use-cmake-build-dirs>` for more details.
 Checking for newer Versions of SeqAn (optional)
 -----------------------------------------------
 
-Starting from the release 2.4.0 the argument parser will have a new feature to check whether your SeqAn version is outdated. This can be a very helpful reminder to stay up to date since SeqAn evolves rapidly to resolve issues or to supply new functionality. We are aware that this might be unwanted by some of you so we provide several ways of disabling this feature:
+The argument parser has a new feature to check for updates for the SeqAn library or for an application.
+This can be a very helpful reminder to stay up to date since SeqAn evolves rapidly to resolve issues or to supply new functionality.
+The following options are possible:
 
-  #. You can disable the feature globally at compile time using the compiler flag ``-DSEQAN_DISABLE_VERSION_CHECK=1``
+  ===================================  ============================================
+            Cmake Option                                Description
+  ===================================  ============================================
+  ``-DSEQAN_VERSION_CHECK="opt-out"``  The update feature is enabled and switched
+                                       on in the argument parser options. (default)
 
-  #. You can disable the feature locally for every command line application by specifying ``--version-check OFF``
+  ``-DSEQAN_VERSION_CHECK="opt-in"``   The update feature is enabled but switched
+                                       off in the argument parser options.
+
+  ``-DSEQAN_VERSION_CHECK="disable"``  The update feature is disabled.
+  ===================================  ============================================
 
 .. note::
 

--- a/manual/source/Infrastructure/Use/FindSeqAnCMake.rst
+++ b/manual/source/Infrastructure/Use/FindSeqAnCMake.rst
@@ -147,19 +147,15 @@ Checking for newer Versions of SeqAn (optional)
 
 The argument parser has a new feature to check for updates for the SeqAn library or for an application.
 This can be a very helpful reminder to stay up to date since SeqAn evolves rapidly to resolve issues or to supply new functionality.
-The following options are possible:
+If none of the following options are selected the version update feature is activated by default.
 
-  ===================================  ============================================
+  =================================  ==========================================
             Cmake Option                                Description
-  ===================================  ============================================
-  ``-DSEQAN_VERSION_CHECK="opt-out"``  The update feature is enabled and switched
-                                       on in the argument parser options. (default)
+  =================================  ==========================================
+  ``-DSEQAN_VERSION_CHECK_OPT_IN``   Turn update feature on but make it opt-in.
 
-  ``-DSEQAN_VERSION_CHECK="opt-in"``   The update feature is enabled but switched
-                                       off in the argument parser options.
-
-  ``-DSEQAN_VERSION_CHECK="disable"``  The update feature is disabled.
-  ===================================  ============================================
+  ``-DSEQAN_DISABLE_VERSION_CHECK``  Turn update feature off.
+  =================================  ==========================================
 
 .. note::
 

--- a/tests/arg_parse/CMakeLists.txt
+++ b/tests/arg_parse/CMakeLists.txt
@@ -39,11 +39,9 @@ add_executable (test_arg_parse
                 test_argument_parser.h
                 test_arg_parse_ctd_support.h)
 
-set (SEQAN_VERSION_CHECK ON FORCE)
 add_executable (test_arg_parse_version_check
                test_arg_parse_version_check.cpp
                test_arg_parse_version_check.h)
-set (SEQAN_VERSION_CHECK OFF FORCE)
 
 # Add dependencies found by find_package (SeqAn).
 target_link_libraries (test_arg_parse ${SEQAN_LIBRARIES})

--- a/tests/arg_parse/test_app.ctd
+++ b/tests/arg_parse/test_app.ctd
@@ -9,9 +9,6 @@ The second one contains formating &lt;bla&gt;.
 		<clielement optionIdentifier="--full-help" isList="false">
 			<mapping referenceName="test_app.full-help" />
 		</clielement>
-		<clielement optionIdentifier="--version-check" isList="false">
-			<mapping referenceName="test_app.version-check" />
-		</clielement>
 		<clielement optionIdentifier="--double" isList="false">
 			<mapping referenceName="test_app.double" />
 		</clielement>
@@ -56,7 +53,6 @@ The second one contains formating &lt;bla&gt;.
 	<PARAMETERS version="1.6.2" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/Param_1_6_2.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 		<NODE name="test_app" description="This is a test-app.">
 			<ITEM name="full-help" value="false" type="string" description="Display the help message with advanced options." restrictions="true,false" required="false" advanced="false" />
-			<ITEM name="version-check" value="OFF" type="string" description="Choose OFF to disable any update notifications. With APP_ONLY you&apos;ll receive update notifications about new versions of your app. In DEV mode you&apos;ll receive update notifications regarding new versions of your app and new versions of the SeqAn library." restrictions="DEV,APP_ONLY,OFF" required="false" advanced="false" />
 			<ITEM name="double" value="" type="double" description="set a double option" required="false" advanced="false" />
 			<ITEM name="integer" value="" type="int" description="set an integer option" restrictions="1:10" required="false" advanced="false" />
 			<ITEM name="int64" value="" type="int" description="set a 64 bit integer option" required="false" advanced="false" />

--- a/tests/arg_parse/test_arg_parse_version_check.cpp
+++ b/tests/arg_parse/test_arg_parse_version_check.cpp
@@ -32,6 +32,14 @@
 // Author: Svenja Mehringer <svenja.mehringer@fu-berlin.de>
 // ==========================================================================
 
+// Locally enable version check for this test.
+#if defined(SEQAN_DISABLE_VERSION_CHECK)
+#undef SEQAN_DISABLE_VERSION_CHECK
+#endif
+#if defined(SEQAN_VERSION_CHECK_OPT_IN)
+#undef SEQAN_VERSION_CHECK_OPT_IN
+#endif
+
 #define SEQAN_DEBUG
 
 #include "test_arg_parse_version_check.h"

--- a/util/cmake/SeqAnBuildSystem.cmake
+++ b/util/cmake/SeqAnBuildSystem.cmake
@@ -219,9 +219,9 @@ macro (seqan_build_system_init)
     ## options
 
     # SeqAn Version Check
-    if ("${SEQAN_VERSION_CHECK}" STREQUAL "disable")  # Disable completely
+    if (SEQAN_DISABLE_VERSION_CHECK)  # Disable completely
         set (SEQAN_DEFINITIONS ${SEQAN_DEFINITIONS} -DSEQAN_DISABLE_VERSION_CHECK)
-    elseif ("${SEQAN_VERSION_CHECK}" STREQUAL "opt-in")  # Build it but make it opt-in
+    elseif (SEQAN_VERSION_CHECK_OPT_IN)  # Build it but make it opt-in
         set (SEQAN_DEFINITIONS ${SEQAN_DEFINITIONS} -DSEQAN_VERSION_CHECK_OPT_IN)
     endif ()
 

--- a/util/cmake/SeqAnBuildSystem.cmake
+++ b/util/cmake/SeqAnBuildSystem.cmake
@@ -221,7 +221,7 @@ macro (seqan_build_system_init)
     # SeqAn Version Check
     if (SEQAN_DISABLE_VERSION_CHECK)  # Disable completely
         set (SEQAN_DEFINITIONS ${SEQAN_DEFINITIONS} -DSEQAN_DISABLE_VERSION_CHECK)
-    elseif (SEQAN_VERSION_CHECK_OPT_IN)  # Build it but make it opt-in
+    elseif (SEQAN_VERSION_CHECK_OPT_IN OR ("${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP"))  # Build it but make it opt-in, also when building in develop mode.
         set (SEQAN_DEFINITIONS ${SEQAN_DEFINITIONS} -DSEQAN_VERSION_CHECK_OPT_IN)
     endif ()
 

--- a/util/cmake/SeqAnBuildSystem.cmake
+++ b/util/cmake/SeqAnBuildSystem.cmake
@@ -219,8 +219,10 @@ macro (seqan_build_system_init)
     ## options
 
     # SeqAn Version Check
-    if (NOT SEQAN_VERSION_CHECK)
-        set (SEQAN_DEFINITIONS "${SEQAN_DEFINITIONS};-DSEQAN_DISABLE_VERSION_CHECK")
+    if ("${SEQAN_VERSION_CHECK}" STREQUAL "disable")  # Disable completely
+        set (SEQAN_DEFINITIONS ${SEQAN_DEFINITIONS} -DSEQAN_DISABLE_VERSION_CHECK)
+    elseif ("${SEQAN_VERSION_CHECK}" STREQUAL "opt-in")  # Build it but make it opt-in
+        set (SEQAN_DEFINITIONS ${SEQAN_DEFINITIONS} -DSEQAN_VERSION_CHECK_OPT_IN)
     endif ()
 
     # Architecture.
@@ -748,11 +750,11 @@ function (seqan_register_demos PREFIX)
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SEQAN_CXX_FLAGS}" PARENT_SCOPE)
     # Setup include directories and definitions for SeqAn; flags follow below.
     include_directories (${SEQAN_INCLUDE_DIRS})
+    # Disable version check for demos.
+    set (SEQAN_DEFINITIONS ${SEQAN_DEFINITIONS} -DSEQAN_DISABLE_VERSION_CHECK)
     add_definitions (${SEQAN_DEFINITIONS})
 
     # Disable the version check for all demos.
-    set (SEQAN_VERSION_CHECK_TMP_ ${SEQAN_VERSION_CHECK} CACHE INTERNAL "Disable version check in demos.")
-    set (SEQAN_VERSION_CHECK OFF CACHE BOOL "SeqAn version check." FORCE)
 
     # Add all demos with found flags in SeqAn.
     foreach (ENTRY ${ENTRIES})
@@ -783,8 +785,6 @@ function (seqan_register_demos PREFIX)
             _seqan_setup_demo_test (${ENTRY} ${PREFIX}${BIN_NAME})
         endif (SKIP)
     endforeach (ENTRY ${ENTRIES})
-    # Reset SEQAN_VERSION_CHECK to user set value.
-    set (SEQAN_VERSION_CHECK ${SEQAN_VERSION_CHECK_TMP_} CACHE BOOL "SeqAn version check." FORCE)
 endfunction (seqan_register_demos)
 
 # ---------------------------------------------------------------------------
@@ -804,11 +804,7 @@ endfunction (seqan_register_demos)
 
 macro (seqan_register_tests)
     # Setup flags for tests.
-    set (SEQAN_DEFINITIONS ${SEQAN_DEFINITIONS} -DSEQAN_ENABLE_TESTING=1)
-
-    # Disable the version check for all tests.
-    set (SEQAN_VERSION_CHECK_TMP_ ${SEQAN_VERSION_CHECK} CACHE INTERNAL "Disable version check in tests.")
-    set (SEQAN_VERSION_CHECK OFF CACHE BOOL "SeqAn version check." FORCE)
+    set (SEQAN_DEFINITIONS ${SEQAN_DEFINITIONS} -DSEQAN_ENABLE_TESTING=1 -DSEQAN_DISABLE_VERSION_CHECK)
 
     # Remove NDEBUG definition for tests.
     string (REGEX REPLACE "-DNDEBUG" ""
@@ -841,6 +837,4 @@ macro (seqan_register_tests)
             endif (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${ENTRY}/CMakeLists.txt)
         endif (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${ENTRY})
     endforeach (ENTRY ${ENTRIES})
-    # Reset value of SEQAN_VERSION variable.
-    set (SEQAN_VERSION_CHECK ${SEQAN_VERSION_CHECK_TMP_} CACHE BOOL "SeqAn version check." FORCE)
 endmacro (seqan_register_tests)


### PR DESCRIPTION
Introduces 2 new macros/definition flags to select the behavior for the version update checker:

- ```SEQAN_VERSION_CHECK_OPT_IN```: enables version check but leaves it as opt-in option.
- ```SEQAN_DISABLE_VERSION_CHECK```: disables version check completely.

If non is specified the default will be enabled and fully activated.

Revises the cmake option ```SEQAN_VERSION_CHECK = disable|opt-in|opt-out```
```opt-out``` is the default.

The update version is disabled for all tests and demos but ```test_arg_parse_version_check``` which is explicitly enabled locally in the cpp.
I tested all different behaviors and adapted the tests accordingly.
@smehringer can you verify, that the test behavior matches the expected one?