### PR TITLE
[FEATURE] add support for lca fields and fix some stuff

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Library Features
         - supported formats: Vienna (.dbv), Dot-Bracket-Notation (.dbn), Stockholm (.sth), Connect (.ct), Bpseq (.bpseq), Extended Bpseq (.ebpseq)
         - input/output of whole files or of a single record/header
 
+- Blast I/O:
+    - added support for handling the Q_ACC, S_ACC, S_ALLACC, S_TAX_IDS fields
+    - added non standard fields LCA_ID and LCA_TAX_ID for lowest common ancestor information
+    - moved some redundant data from matches into record objects
+
 Release 2.2.0
 ~~~~~~~~~~~~~
 

--- a/demos/tutorial/blast_io/write_assignment.cpp
+++ b/demos/tutorial/blast_io/write_assignment.cpp
@@ -75,7 +75,7 @@ int main(int argc, char ** argv)
 
         for (unsigned s = 0; s < length(subjects); ++s)
         {
-            appendValue(r.matches, TBlastMatch(qIds[q], sIds[s]));
+            appendValue(r.matches, TBlastMatch(sIds[s]));
             TBlastMatch & m = back(records[q].matches);
 
             assignSource(m.alignRow0, queries[q]);

--- a/include/seqan/blast/blast_record.h
+++ b/include/seqan/blast/blast_record.h
@@ -65,9 +65,8 @@ namespace seqan
  * @tparam TPos   Position type of the sequences, defaults to <tt>uint32_t</tt>
  * @tparam TQId   Type of qId, defaults to <tt>std::string</tt>
  * @tparam TSId   Type of sId, defaults to <tt>std::string</tt>
- * @tparam TQAccs Type of qAccs, defaults to <tt>std::vector</tt> of <tt>std::string</tt>
  * @tparam TSAccs Type of sAccs, defaults to <tt>std::vector</tt> of <tt>std::string</tt>
- * @tparam TSTaxIds Type of sTaxIds, defaults to @link String @endlink of <tt>uint64_t</tt>
+ * @tparam TSTaxIds Type of sTaxIds, defaults to @link String @endlink of <tt>uint32_t</tt>
  */
 
 template <typename TAlignRow0_ = Gaps<CharString, ArrayGaps>,
@@ -75,9 +74,8 @@ template <typename TAlignRow0_ = Gaps<CharString, ArrayGaps>,
           typename TPos_ = uint32_t,
           typename TQId_ = std::string,
           typename TSId_ = std::string,
-          typename TQAccs_ = std::vector<std::string>,
           typename TSAccs_ = std::vector<std::string>,
-          typename TSTaxIds_ = String<uint64_t>>
+          typename TSTaxIds_ = String<uint32_t>>
 struct BlastMatch
 {
     typedef TAlignRow0_ TAlignRow0;
@@ -85,7 +83,6 @@ struct BlastMatch
     typedef TPos_ TPos;
     typedef TQId_ TQId;
     typedef TSId_ TSId;
-    typedef TQAccs_     TQAccs;
     typedef TSAccs_     TSAccs;
     typedef TSTaxIds_   TSTaxIds;
 
@@ -96,21 +93,18 @@ struct BlastMatch
     /*!
      * @var TQId BlastMatch::qId;
      * @brief The verbose Id of the query.
+     * @deprecated Use @link BlastRecord::qId @endlink instead.
      *
      * @var TSId BlastMatch::sId;
      * @brief The verbose Id of the subject.
      */
-    TQId            qId;
+    TQId            qId; // deprecated but can't be marked as such, since still supported/used
     TSId            sId;
 
     /*!
-     * @var TQId BlastMatch::qAccs;
-     * @brief The Accession number(s) of the query.
-     *
      * @var TSId BlastMatch::sAccs;
      * @brief The Accession number(s) of the subject.
      */
-    TQAccs          qAccs;
     TSAccs          sAccs;
 
     /*!
@@ -140,11 +134,12 @@ struct BlastMatch
     /*!
      * @var TPos BlastMatch::qLength;
      * @brief The length of the original query sequence (possibly before translation).
+     * @deprecated Use @link BlastRecord::qLength @endlink instead.
      *
      * @var TPos BlastMatch::sLength;
      * @brief The length of the original subject sequence (possibly before translation).
      */
-    TPos            qLength       = 0;
+    TPos            qLength       = 0; // deprecated but can't be marked as such, since still supported/used
     TPos            sLength       = 0;
 
     /*!
@@ -197,18 +192,29 @@ struct BlastMatch
      * @fn BlastMatch::BlastMatch()
      * @brief Constructor, can be called with arguments for qId and sId.
      * @signature BlastMatch::BlastMatch()
-     * BlastMatch::BlastMatch(qId, sId)
+     * BlastMatch::BlastMatch(sId)
+     * BlastMatch::BlastMatch(qId, sId) [deprecated]
      */
     BlastMatch() :
         qId(TQId()), sId(TSId())
     {}
 
+    [[deprecated("Only pass sId to the constructor")]]
     BlastMatch(TQId const & _qId, TSId const & _sId) :
         qId(_qId), sId(_sId)
     {}
 
+    [[deprecated("Only pass sId to the constructor")]]
     BlastMatch(TQId && _qId, TSId && _sId) :
         qId(std::move(_qId)), sId(std::move(_sId))
+    {}
+
+    BlastMatch(TSId const & _sId) :
+        sId(_sId)
+    {}
+
+    BlastMatch(TSId && _sId) :
+        sId(std::move(_sId))
     {}
 
     inline bool operator==(BlastMatch const & bm2) const
@@ -267,7 +273,6 @@ struct BlastMatch
     {
         clear(qId);
         clear(sId);
-        clear(qAccs);
         clear(sAccs);
         clear(sTaxIds);
 
@@ -291,7 +296,6 @@ struct BlastMatch
     {
         qId           = "not init";
         sId           = "not init";
-        clear(qAccs);
         clear(sAccs);
         clear(sTaxIds);
 
@@ -356,22 +360,34 @@ clear(BlastMatch<TAlignRow0, TAlignRow1, TPos, TQId, TSId> & match)
  * @class BlastRecord
  * @implements FormattedFileRecordConcept
  * @headerfile <seqan/blast.h>
- * @signature struct BlastRecord<TMatch> { ... };
+ * @signature struct BlastRecord<TMatch, ...> { ... };
  * @brief A record of blast-matches (belonging to one query).
  *
  * @tparam TMatch Specialization of @link BlastMatch @endlink
+ * @tparam TQID   Type of @link BlastRecord::qId @endlink, defaults to TMatch::TQId
+ * @tparam TQAccs Type of @link BlastRecord::qAccs @endlink, defaults to <tt>std::vector</tt> of <tt>std::string</tt>
+ * @tparam TLcaId Type of @link BlastRecord::lcaId @endlink, defaults to <tt>std::string</tt>
+ * @tparam TLcaTaxId Type of @link BlastRecord::lcaTaxId @endlink, defaults to <tt>uint32_t</tt>
  */
 
-template <typename TBlastMatch_ = BlastMatch<>>
+template <typename TBlastMatch_ = BlastMatch<>,
+          typename TQId_ = typename TBlastMatch_::TQId,
+          typename TQAccs_ = std::vector<std::string>,
+          typename TLcaId_ = std::string,
+          typename TLcaTaxId_ = uint32_t>
 struct BlastRecord
 {
+    typedef TQId_       TQId;
+    typedef TQAccs_     TQAccs;
+    typedef TLcaId_     TLcaId;
+    typedef TLcaTaxId_  TLcaTaxId;
+
     /*!
      * @typedef BlastRecord::TBlastMatch
      * @signature typedef TBlastMatch_ TBlastMatch;
      * @brief type of the contained matches
      */
     typedef TBlastMatch_                TBlastMatch;
-    typedef typename TBlastMatch::TQId  TQId;
     typedef typename TBlastMatch::TPos  TPos;
 
     /*!
@@ -384,7 +400,13 @@ struct BlastRecord
      * @var TPos BlastRecord::qLength;
      * @brief length of the query sequence
      */
-    TPos            qLength;
+    TPos            qLength = 0;
+
+    /*!
+     * @var TQId BlastRecord::qAccs;
+     * @brief The Accession number(s) of the query.
+     */
+    TQAccs          qAccs;
 
     /*!
      * @var std::list<TBlastMatch> BlastRecord::matches;
@@ -393,33 +415,48 @@ struct BlastRecord
     std::list<TBlastMatch>  matches;
 
     /*!
+     * @var TPos BlastRecord::lcaId;
+     * @brief String identifier (e.g. scientific name) of the lowest common ancestor of all matches.
+     */
+    TLcaId            lcaId;
+
+    /*!
+     * @var TPos BlastRecord::lcaTaxId;
+     * @brief Numeric taxonomic identifier of the lowest common ancestor of all matches.
+     */
+    TLcaTaxId            lcaTaxId = 0;
+
+    /*!
      * @fn BlastRecord::BlastRecord()
      * @brief constructor, can be passed the qId
      * @signature BlastRecord::BlastRecord()
      * BlastRecord::BlastRecord(qid)
      */
     BlastRecord() :
-        qId(TQId()), qLength(0), matches()
+        qId(TQId())
     {}
 
     BlastRecord(TQId const & _qId) :
-        qId(_qId), qLength(0), matches()
+        qId(_qId)
     {}
 
     BlastRecord(TQId && _qId) :
-        qId(std::move(_qId)), qLength(0), matches()
+        qId(std::move(_qId))
     {}
 
     // copy, move and assign implicitly
 };
 
-template <typename TMatch>
+template <typename ... TSpecs>
 inline void
-clear(BlastRecord<TMatch> & blastRecord)
+clear(BlastRecord<TSpecs...> & blastRecord)
 {
     clear(blastRecord.qId);
     blastRecord.qLength = 0;
+    clear(blastRecord.qAccs);
     clear(blastRecord.matches);
+    clear(blastRecord.lcaId);
+    blastRecord.lcaTaxId = 0;
 }
 
 }

--- a/include/seqan/blast/blast_report_out.h
+++ b/include/seqan/blast/blast_report_out.h
@@ -610,13 +610,13 @@ _writeMatchOneLiner(TStream & stream,
 
 template <typename TStream,
           typename TScore,
-          typename TMatch,
+          typename ... TSpecs,
           BlastProgram p,
           BlastTabularSpec h>
 inline void
 _writeRecordTop(TStream & stream,
                    BlastIOContext<TScore, p, h> &,
-                   BlastRecord<TMatch> const & record,
+                   BlastRecord<TSpecs...> const & record,
                    BlastReport const & /*tag*/)
 {
     // write query header
@@ -629,13 +629,13 @@ _writeRecordTop(TStream & stream,
 
 template <typename TStream,
           typename TScore,
-          typename TMatch,
+          typename ... TSpecs,
           BlastProgram p,
           BlastTabularSpec h>
 inline void
 _writeRecordFooter(TStream & stream,
                    BlastIOContext<TScore, p, h> & context,
-                   BlastRecord<TMatch> const & record,
+                   BlastRecord<TSpecs...> const & record,
                    BlastReport const & /*tag*/)
 {
     write(stream, "\n"
@@ -683,13 +683,13 @@ _writeRecordFooter(TStream & stream,
 
 template <typename TStream,
           typename TScore,
-          typename TMatch,
+          typename ... TSpecs,
           BlastProgram p,
           BlastTabularSpec h>
 inline void
 writeRecord(TStream & stream,
             BlastIOContext<TScore, p, h> & context,
-            BlastRecord<TMatch> const & record,
+            BlastRecord<TSpecs...> const & record,
             BlastReport const & /*tag*/)
 {
 
@@ -728,10 +728,10 @@ writeRecord(TStream & stream,
 }
 
 template <typename TContext,
-          typename TMatch>
+          typename ... TSpecs>
 inline void
 writeRecord(BlastReportFileOut<TContext> & formattedFile,
-            BlastRecord<TMatch> const & r)
+            BlastRecord<TSpecs...> const & r)
 {
     writeRecord(formattedFile.iter, context(formattedFile), r, BlastReport());
 }

--- a/include/seqan/blast/blast_tabular.h
+++ b/include/seqan/blast/blast_tabular.h
@@ -241,16 +241,16 @@ constexpr char const * FileExtensions<BlastTabular, T>::VALUE[2];
  * <tr><td>0</td><td>STD</td><td>std</td><td>query id, subject id, % identity, alignment length, mismatches, gap opens, q. start, q. end, s. start, s. end, evalue, bit score</td><td>Default 12 columns (Query Seq-id, Subject Seq-id, Percentage of identical matches, Alignment length, Number of mismatches, Number of gap openings, Start of alignment in query, End of alignment in query, Start of alignment in subject, End of alignment in subject, Expect value, Bit score)</td><td>&#9745;</td></tr>
  * <tr><td>1</td><td>Q_SEQ_ID</td><td>qseqid</td><td>query id</td><td>Query Seq-id</td><td>&#9745;</td></tr>
  * <tr><td>2</td><td>Q_GI</td><td>qgi</td><td>query gi</td><td>Query GI</td><td>&#9744;</td></tr>
- * <tr><td>3</td><td>Q_ACC</td><td>qacc</td><td>query acc.</td><td>Query accesion</td><td>&#9744;</td></tr>
+ * <tr><td>3</td><td>Q_ACC</td><td>qacc</td><td>query acc.</td><td>Query accesion</td><td>&#9745;</td></tr>
  * <tr><td>4</td><td>Q_ACCVER</td><td>qaccver</td><td>query acc.ver</td><td>Query accesion.version</td><td>&#9744;</td></tr>
  * <tr><td>5</td><td>Q_LEN</td><td>qlen</td><td>query length</td><td>Query sequence length</td><td>&#9745;</td></tr>
  * <tr><td>6</td><td>S_SEQ_ID</td><td>sseqid</td><td>subject id</td><td>Subject Seq-id</td><td>&#9745;</td></tr>
  * <tr><td>7</td><td>S_ALL_SEQ_ID</td><td>sallseqid</td><td>subject ids</td><td>All subject Seq-id(s), separated by a ';'</td><td>&#9744;</td></tr>
  * <tr><td>8</td><td>S_GI</td><td>sgi</td><td>subject gi</td><td>Subject GI</td><td>&#9744;</td></tr>
  * <tr><td>9</td><td>S_ALL_GI</td><td>sallgi</td><td>subject gis</td><td>All subject GIs</td><td>&#9744;</td></tr>
- * <tr><td>10</td><td>S_ACC</td><td>sacc</td><td>subject acc.</td><td>Subject accession</td><td>&#9744;</td></tr>
+ * <tr><td>10</td><td>S_ACC</td><td>sacc</td><td>subject acc.</td><td>Subject accession</td><td>&#9745;</td></tr>
  * <tr><td>11</td><td>S_ACCVER</td><td>saccver</td><td>subject acc.ver</td><td>Subject accession.version</td><td>&#9744;</td></tr>
- * <tr><td>12</td><td>S_ALLACC</td><td>sallacc</td><td>subject accs.</td><td>All subject accessions</td><td>&#9744;</td></tr>
+ * <tr><td>12</td><td>S_ALLACC</td><td>sallacc</td><td>subject accs.</td><td>All subject accessions</td><td>&#9745;</td></tr>
  * <tr><td>13</td><td>S_LEN</td><td>slen</td><td>subject length</td><td>Subject sequence length</td><td>&#9745;</td></tr>
  * <tr><td>14</td><td>Q_START</td><td>qstart</td><td>q. start</td><td>Start of alignment in query</td><td>&#9745;</td></tr>
  * <tr><td>15</td><td>Q_END</td><td>qend</td><td>q. end</td><td>End of alignment in query</td><td>&#9745;</td></tr>
@@ -273,7 +273,7 @@ constexpr char const * FileExtensions<BlastTabular, T>::VALUE[2];
  * <tr><td>32</td><td>Q_FRAME</td><td>qframe</td><td>query frame</td><td>Query frame</td><td>&#9745;</td></tr>
  * <tr><td>33</td><td>S_FRAME</td><td>sframe</td><td>sbjct frame</td><td>Subject frame</td><td>&#9745;</td></tr>
  * <tr><td>34</td><td>BTOP</td><td>btop</td><td>BTOP</td><td>Blast traceback operations (BTOP)</td><td>&#9744;</td></tr>
- * <tr><td>35</td><td>S_TAX_IDS</td><td>staxids</td><td>subject tax ids</td><td>unique Subject Taxonomy ID(s), separated by a ';' (in numerical order)</td><td>&#9744;</td></tr>
+ * <tr><td>35</td><td>S_TAX_IDS</td><td>staxids</td><td>subject tax ids</td><td>unique Subject Taxonomy ID(s), separated by a ';' (in numerical order)</td><td>&#9745;</td></tr>
  * <tr><td>36</td><td>S_SCI_NAMES</td><td>sscinames</td><td>subject sci names</td><td>unique Subject Scientific Name(s), separated by a ';'</td><td>&#9744;</td></tr>
  * <tr><td>37</td><td>S_COM_NAMES</td><td>scomnames</td><td>subject com names</td><td>unique Subject Common Name(s), separated by a ';'</td><td>&#9744;</td></tr>
  * <tr><td>38</td><td>S_BLAST_NAMES</td><td>sblastnames</td><td>subject blast names</td><td>unique Subject Blast Name(s), separated by a ';' (in alphabetical order)</td><td>&#9744;</td></tr>
@@ -283,10 +283,12 @@ constexpr char const * FileExtensions<BlastTabular, T>::VALUE[2];
  * <tr><td>42</td><td>S_STRAND</td><td>sstrand</td><td>subject strand</td><td>Subject Strand</td><td>&#9744;</td></tr>
  * <tr><td>43</td><td>Q_COV_S</td><td>qcovs</td><td>% subject coverage</td><td>Query Coverage Per Subject</td><td>&#9744;</td></tr>
  * <tr><td>45</td><td>Q_COV_HSP</td><td>qcovhsp</td><td>% hsp coverage</td><td>Query Coverage Per HSP</td><td>&#9744;</td></tr>
+ * <tr><td>46</td><td>LCA_ID</td><td>lcaid</td><td>lca id</td><td>String ID (e.g. scientific name) of the lowest common ancestor of all matches of a query</td><td>&#9745;</td></tr>
+ * <tr><td>47</td><td>LCA_TAX_ID</td><td>lcataxid</td><td>lca tax id</td><td>Numeric Taxonomy ID of the lowest common ancestor of all matches of a query</td><td>&#9745;</td></tr>
  * </table></span>
  * @endhtmlonly
  *
- * More fields will likely be implemented in the future.
+ * <tt>LCA_IC</tt> and <tt>LCA_TAX_ID</tt> are non available in NCBI Blast.
  */
 
 template <typename TVoidSpec = void>
@@ -346,7 +348,9 @@ struct BlastMatchField
         S_ALL_TITLES,
         S_STRAND,
         Q_COV_S,
-        Q_COV_HSP
+        Q_COV_HSP,
+        LCA_ID,
+        LCA_TAX_ID
     };
 
     /*!
@@ -393,10 +397,10 @@ struct BlastMatchField
     };
 
     /*!
-     * @var static_constexpr_const_std::array<char_const*,45> BlastMatchField::optionLabels[]
+     * @var static_constexpr_const_std::array<char_const*,47> BlastMatchField::optionLabels[]
      * @brief An array of CStrings representing the command line parameter name of each field
      */
-    static constexpr const std::array<char const *, 45> optionLabels
+    static constexpr const std::array<char const *, 47> optionLabels
     {
       {
         "std",
@@ -443,7 +447,9 @@ struct BlastMatchField
         "salltitles",
         "sstrand",
         "qcovs",
-        "qcovhsp"
+        "qcovhsp",
+        "lcaid",
+        "lcataxid"
       }
     };
 
@@ -458,11 +464,11 @@ struct BlastMatchField
     };
 
     /*!
-     * @var static_constexpr_const_std::array<char_const*,45> BlastMatchField::columnLabels[]
+     * @var static_constexpr_const_std::array<char_const*,47> BlastMatchField::columnLabels[]
      * @brief An array of CStrings representing the <b>column label</b> of each possible field; for the
      * @link BlastIOContext::legacyFormat @endlink, use @link BlastMatchField::legacyColumnLabels @endlink instead.
      */
-    static constexpr const std::array<char const *, 45> columnLabels
+    static constexpr const std::array<char const *, 47> columnLabels
     {
       {
         "query id, subject id, % identity, alignment length, mismatches, gap opens, q. start, q. end, s. start, s. "
@@ -510,15 +516,17 @@ struct BlastMatchField
         "subject titles",
         "subject strand",
         "% subject coverage",
-        "% hsp coverage"
+        "% hsp coverage",
+        "lca id",
+        "lca tax id"
       }
     };
 
     /*!
-     * @var static_constexpr_const_std::array<char_const*,45> BlastMatchField::descriptions[]
+     * @var static_constexpr_const_std::array<char_const*,47> BlastMatchField::descriptions[]
      * @brief An array of CStrings representing the human-readable descriptions of each field
      */
-    static constexpr const std::array<char const *, 45> descriptions
+    static constexpr const std::array<char const *, 47> descriptions
     {
       {
         "Default 12 columns (Query Seq-id, Subject Seq-id, Percentage of "
@@ -569,81 +577,85 @@ struct BlastMatchField
         "All Subject Title(s), separated by a '<>'",
         "Subject Strand",
         "Query Coverage Per Subject",
-        "Query Coverage Per HSP"
+        "Query Coverage Per HSP",
+        "String ID (e.g. scientific name) of the lowest common ancestor of all matches of a query",
+        "Numeric Taxonomy ID of the lowest common ancestor of all matches of a query"
       }
     };
 
     /*!
-     * @var static_constexpr_const_std::array<bool,45> BlastMatchField::implemented[]
+     * @var static_constexpr_const_std::array<bool,47> BlastMatchField::implemented[]
      * @brief An array of bools revealing whether the Blast I/O module supports printing this field
      */
     //TODO(c++14): change to std::bitset that is initialized with binary literal
-    static constexpr const std::array<bool, 45> implemented
+    static constexpr const std::array<bool, 47> implemented
     {
       {
-        true,
-        true,
-        false,
-        false,
-        false,
-        true,
-        true,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        true,
-        true,
-        true,
-        true,
-        true,
-        false,
-        false,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false
+        true,         // STD,
+        true,         // Q_SEQ_ID,
+        false,        // Q_GI,
+        true,         // Q_ACC,
+        false,        // Q_ACCVER,
+        true,         // Q_LEN,
+        true,         // S_SEQ_ID,
+        false,        // S_ALL_SEQ_ID,
+        false,        // S_GI,
+        false,        // S_ALL_GI,
+        true,         // S_ACC,
+        false,        // S_ACCVER,
+        true,         // S_ALLACC,
+        true,         // S_LEN,
+        true,         // Q_START,
+        true,         // Q_END,
+        true,         // S_START,
+        true,         // S_END,
+        false,        // Q_SEQ,
+        false,        // S_SEQ,
+        true,         // E_VALUE,
+        true,         // BIT_SCORE,
+        true,         // SCORE,
+        true,         // LENGTH,
+        true,         // P_IDENT,
+        true,         // N_IDENT,
+        true,         // MISMATCH,
+        true,         // POSITIVE,
+        true,         // GAP_OPEN,
+        true,         // GAPS,
+        true,         // P_POS,
+        true,         // FRAMES,
+        true,         // Q_FRAME,
+        true,         // S_FRAME,
+        false,        // BTOP,
+        true,         // S_TAX_IDS,
+        false,        // S_SCI_NAMES,
+        false,        // S_COM_NAMES,
+        false,        // S_BLAST_NAMES,
+        false,        // S_S_KINGDOMS,
+        false,        // S_TITLE,
+        false,        // S_ALL_TITLES,
+        false,        // S_STRAND,
+        false,        // Q_COV_S,
+        false,        // Q_COV_HSP,
+        true,         // LCA_ID,
+        true          // LCA_TAX_ID
       }
     };
 };
 
 template <typename TVoidSpec>
-constexpr const std::array<char const *, 45> BlastMatchField<TVoidSpec>::optionLabels;
+constexpr const std::array<char const *, 47> BlastMatchField<TVoidSpec>::optionLabels;
 
 template <typename TVoidSpec>
 constexpr char const * const BlastMatchField<TVoidSpec>::legacyColumnLabels;
 
 template <typename TVoidSpec>
-constexpr const std::array<char const *, 45> BlastMatchField<TVoidSpec>::columnLabels;
+constexpr const std::array<char const *, 47> BlastMatchField<TVoidSpec>::columnLabels;
 
 template <typename TVoidSpec>
-constexpr const std::array<char const *, 45> BlastMatchField<TVoidSpec>::descriptions;
+constexpr const std::array<char const *, 47> BlastMatchField<TVoidSpec>::descriptions;
 
 template <typename TVoidSpec>
-constexpr const std::array<bool, 45> BlastMatchField<TVoidSpec>::implemented;
+constexpr const std::array<bool, 47> BlastMatchField<TVoidSpec>::implemented;
 
 template <typename TVoidSpec>
 constexpr const std::array<typename BlastMatchField<TVoidSpec>::Enum const, 12> BlastMatchField<TVoidSpec>::defaults;

--- a/include/seqan/blast/blast_tabular_in.h
+++ b/include/seqan/blast/blast_tabular_in.h
@@ -246,13 +246,13 @@ _goNextLine(BlastIOContext<TScore, p, h> & context,
 // Function _readCommentLines()
 // ----------------------------------------------------------------------------
 
-template <typename TMatch,
+template <typename ... TSpecs,
           typename TFwdIterator,
           typename TScore,
           BlastProgram p,
           BlastTabularSpec h>
 inline void
-_readCommentLinesImpl(BlastRecord<TMatch> & r,
+_readCommentLinesImpl(BlastRecord<TSpecs...> & r,
                       TFwdIterator & iter,
                       BlastIOContext<TScore, p, h> & context,
                       BlastTabular const &)
@@ -431,13 +431,13 @@ _readCommentLinesImpl(BlastRecord<TMatch> & r,
         appendValue(context.conformancyErrors, "Unexpected lines present, see context.otherLines.");
 }
 
-template <typename TMatch,
+template <typename ... TSpecs,
           typename TFwdIterator,
           typename TScore,
           BlastProgram p,
           BlastTabularSpec h>
 inline void
-_readCommentLines(BlastRecord<TMatch> & r,
+_readCommentLines(BlastRecord<TSpecs...> & r,
                   TFwdIterator & iter,
                   BlastIOContext<TScore, p, h> & context,
                   BlastTabular const &)
@@ -470,10 +470,12 @@ template <typename TAlignRow0,
           typename TQId,
           typename TSId,
           typename TScore,
+          typename ... TSpecs,
           BlastProgram p,
           BlastTabularSpec h>
 inline void
 _readField(BlastMatch<TAlignRow0, TAlignRow1, TPos, TQId, TSId> & match,
+           BlastRecord<TSpecs...> & record,
            BlastIOContext<TScore, p, h> & context,
            typename BlastMatchField<>::Enum const fieldId)
 {
@@ -486,11 +488,12 @@ _readField(BlastMatch<TAlignRow0, TAlignRow1, TPos, TQId, TSId> & match,
             break;
 //         case ENUM::Q_GI: write(s,  * ); break;
         case BlastMatchField<>::Enum::Q_ACC:
-            appendValue(match.qAccs, context._stringBuffer);
+            appendValue(record.qAccs, context._stringBuffer);
             break;
 //         case ENUM::Q_ACCVER: write(s,  * ); break;
         case BlastMatchField<>::Enum::Q_LEN:
             match.qLength = lexicalCast<TPos>(context._stringBuffer);
+            record.qLength = match.qLength;
             break;
         case BlastMatchField<>::Enum::S_SEQ_ID:
             match.sId = context._stringBuffer;
@@ -587,6 +590,12 @@ _readField(BlastMatch<TAlignRow0, TAlignRow1, TPos, TQId, TSId> & match,
 //         case ENUM::S_STRAND: write( * ); break;
 //         case ENUM::Q_COV_S: write( * ); break;
 //         case ENUM::Q_COV_HSP:
+        case BlastMatchField<>::Enum::LCA_ID:
+            record.lcaId = context._stringBuffer;
+            break;
+        case BlastMatchField<>::Enum::LCA_TAX_ID:
+            record.lcaTaxId = lexicalCast<uint32_t>(context._stringBuffer);
+            break;
         default:
             SEQAN_THROW(ParseError("The requested column type is not yet "
                                    "implemented."));
@@ -604,10 +613,12 @@ template <typename TAlignRow0,
           typename TSId,
           typename TFwdIterator,
           typename TScore,
+          typename ... TSpecs,
           BlastProgram p,
           BlastTabularSpec h>
 inline void
 _readMatch(BlastMatch<TAlignRow0, TAlignRow1, TPos, TQId, TSId> & match,
+           BlastRecord<TSpecs...> & record,
            TFwdIterator & iter,
            BlastIOContext<TScore, p, h> & context,
            BlastTabular const &)
@@ -649,7 +660,7 @@ _readMatch(BlastMatch<TAlignRow0, TAlignRow1, TPos, TQId, TSId> & match,
                     SEQAN_THROW(ParseError("More columns expected than were present in file."));
 
                 context._stringBuffer = static_cast<decltype(context._stringBuffer)>(fields[n++]);
-                _readField(match, context, f2);
+                _readField(match, record, context, f2);
             }
         } else
         {
@@ -657,7 +668,7 @@ _readMatch(BlastMatch<TAlignRow0, TAlignRow1, TPos, TQId, TSId> & match,
                 SEQAN_THROW(ParseError("More columns expected than were present in file."));
 
             context._stringBuffer = static_cast<decltype(context._stringBuffer)>(fields[n++]);
-            _readField(match, context, f);
+            _readField(match, record, context, f);
         }
     }
 
@@ -692,12 +703,12 @@ _readMatch(BlastMatch<TAlignRow0, TAlignRow1, TPos, TQId, TSId> & match,
 // ----------------------------------------------------------------------------
 
 template <typename TFwdIterator,
-          typename TMatch,
+          typename ... TSpecs,
           typename TScore,
           BlastProgram p,
           BlastTabularSpec h>
 inline void
-_readRecordWithCommentLines(BlastRecord<TMatch> & blastRecord,
+_readRecordWithCommentLines(BlastRecord<TSpecs...> & blastRecord,
                             TFwdIterator & iter,
                             BlastIOContext<TScore, p, h> & context,
                             BlastTabular const &)
@@ -716,7 +727,7 @@ _readRecordWithCommentLines(BlastRecord<TMatch> & blastRecord,
                 break;
             }
 
-            _readMatch(m, iter, context, BlastTabular());
+            _readMatch(m, blastRecord, iter, context, BlastTabular());
         }
 
         if ((!atEnd(context, iter, BlastTabular())) && _onMatch(context, BlastTabular()))
@@ -726,25 +737,25 @@ _readRecordWithCommentLines(BlastRecord<TMatch> & blastRecord,
         while ((!atEnd(context, iter, BlastTabular())) && _onMatch(context, BlastTabular()))
         {
             blastRecord.matches.emplace_back();
-            _readMatch(back(blastRecord.matches), iter, context, BlastTabular());
+            _readMatch(back(blastRecord.matches), blastRecord, iter, context, BlastTabular());
         }
     } else
     {
         while ((!atEnd(context, iter, BlastTabular())) && _onMatch(context, BlastTabular()))
         {
             blastRecord.matches.emplace_back();
-            _readMatch(back(blastRecord.matches), iter, context, BlastTabular());
+            _readMatch(back(blastRecord.matches), blastRecord, iter, context, BlastTabular());
         }
     }
 }
 
-template <typename TMatch,
+template <typename ... TSpecs,
           typename TFwdIterator,
           typename TScore,
           BlastProgram p,
           BlastTabularSpec h>
 inline void
-_readRecordWithoutCommentLines(BlastRecord<TMatch> & blastRecord,
+_readRecordWithoutCommentLines(BlastRecord<TSpecs...> & blastRecord,
                                TFwdIterator & iter,
                                BlastIOContext<TScore, p, h> & context,
                                BlastTabular const &)
@@ -771,7 +782,7 @@ _readRecordWithoutCommentLines(BlastRecord<TMatch> & blastRecord,
     {
         blastRecord.matches.emplace_back();
         // read remainder of line
-        _readMatch(back(blastRecord.matches), iter, context, BlastTabular());
+        _readMatch(back(blastRecord.matches), blastRecord, iter, context, BlastTabular());
 
         if (!startsWith(context._lineBuffer, curIdPlusTab)) // next record reached
             break;
@@ -861,13 +872,13 @@ _readRecordWithoutCommentLines(BlastRecord<TMatch> & blastRecord,
  * @throw ParseError On high-level file format errors.
  */
 
-template <typename TMatch,
+template <typename ... TSpecs,
           typename TFwdIterator,
           typename TScore,
           BlastProgram p,
           BlastTabularSpec h>
 inline void
-readRecord(BlastRecord<TMatch> & blastRecord,
+readRecord(BlastRecord<TSpecs...> & blastRecord,
            TFwdIterator & iter,
            BlastIOContext<TScore, p, h> & context,
            BlastTabular const &)
@@ -878,10 +889,10 @@ readRecord(BlastRecord<TMatch> & blastRecord,
         _readRecordWithCommentLines(blastRecord, iter, context, BlastTabular());
 }
 
-template <typename TMatch,
+template <typename ... TSpecs,
           typename TContext>
 inline void
-readRecord(BlastRecord<TMatch> & blastRecord,
+readRecord(BlastRecord<TSpecs...> & blastRecord,
            BlastTabularFileIn<TContext> & formattedFile)
 {
     readRecord(blastRecord, formattedFile.iter, context(formattedFile), BlastTabular());

--- a/include/seqan/blast/blast_tabular_out.h
+++ b/include/seqan/blast/blast_tabular_out.h
@@ -155,13 +155,13 @@ _writeFieldLabels(TFwdIterator & stream,
 
 template <typename TFwdIterator,
           typename TScore,
-          typename TMatch,
+          typename ... TSpecs,
           BlastProgram p,
           BlastTabularSpec h>
 inline void
 _writeCommentLinesWithoutColumnLabels(TFwdIterator & stream,
                                       BlastIOContext<TScore, p, h> & context,
-                                      BlastRecord<TMatch> const & r,
+                                      BlastRecord<TSpecs...> const & r,
                                       BlastTabular const & /*tag*/)
 {
     write(stream, "# ");
@@ -178,13 +178,13 @@ _writeCommentLinesWithoutColumnLabels(TFwdIterator & stream,
 
 template <typename TFwdIterator,
           typename TScore,
-          typename TMatch,
+          typename ... TSpecs,
           BlastProgram p,
           BlastTabularSpec h>
 inline void
 _writeCommentLines(TFwdIterator & stream,
                   BlastIOContext<TScore, p, h> & context,
-                  BlastRecord<TMatch> const & r,
+                  BlastRecord<TSpecs...> const & r,
                   BlastTabular const & /*tag*/)
 {
     ++context._numberOfRecords;
@@ -224,6 +224,20 @@ _writeCommentLines(TFwdIterator & stream,
 // Function _writeField() [match object given]
 // ----------------------------------------------------------------------------
 
+template <typename TSequence>
+inline SEQAN_FUNC_ENABLE_IF(Is<StringConcept<TSequence>>, bool)
+_isEmpty(TSequence const & s)
+{
+    return length(s);
+}
+
+template <typename TSequence>
+inline SEQAN_FUNC_DISABLE_IF(Is<StringConcept<TSequence>>, bool)
+_isEmpty(TSequence const &)
+{
+    return true;
+}
+
 template <typename TFwdIterator,
           typename TScore,
           typename TQId,
@@ -231,12 +245,14 @@ template <typename TFwdIterator,
           typename TPos,
           typename TAlignRow0,
           typename TAlignRow1,
+          typename ... TSpecs,
           BlastProgram p,
           BlastTabularSpec h>
 inline void
 _writeField(TFwdIterator & s,
             BlastIOContext<TScore, p, h> & context,
             BlastMatch<TAlignRow0, TAlignRow1, TPos, TQId, TSId> const & match,
+            BlastRecord<TSpecs...> const & record,
             typename BlastMatchField<>::Enum const fieldId,
             BlastTabular const &)
 {
@@ -246,20 +262,28 @@ _writeField(TFwdIterator & s,
              // STD is handled from the calling function
             break;
         case BlastMatchField<>::Enum::Q_SEQ_ID:
-            write(s, prefix(match.qId,
-                            std::find(begin(match.qId, Standard()), end(match.qId, Standard()), ' ')
-                            - begin(match.qId, Standard()))); // truncate at first ' '
+            if (_isEmpty(match.qId)) // new behaviour
+                write(s, prefix(record.qId,
+                                std::find(begin(record.qId, Standard()), end(record.qId, Standard()), ' ')
+                                - begin(record.qId, Standard()))); // truncate at first ' '
+            else // deprecated behaviour
+                write(s, prefix(match.qId,
+                                std::find(begin(match.qId, Standard()), end(match.qId, Standard()), ' ')
+                                - begin(match.qId, Standard()))); // truncate at first ' '
             break;
 //         case ENUM::Q_GI: write(s,  * ); break;
         case BlastMatchField<>::Enum::Q_ACC:
-            if (length(match.qAccs))
-                write(s, match.qAccs[0]);
+            if (length(record.qAccs))
+                write(s, record.qAccs[0]);
             else
                 write(s, "n/a");
             break;
 //         case ENUM::Q_ACCVER: write(s,  * ); break;
         case BlastMatchField<>::Enum::Q_LEN:
-            write(s, match.qLength);
+            if ((match.qLength != 0) && (match.qLength != record.qLength)) // deprecated behaviour
+                write(s, match.qLength);
+            else // new behaviour
+                write(s, record.qLength);
             break;
         case BlastMatchField<>::Enum::S_SEQ_ID:
             write(s, prefix(match.sId,
@@ -298,7 +322,10 @@ _writeField(TFwdIterator & s,
         {
             TPos effectiveQStart    = match.qStart;
             TPos effectiveQEnd      = match.qEnd;
-            _untranslateQPositions(effectiveQStart, effectiveQEnd, match.qFrameShift, match.qLength,
+            auto length             = record.qLength;
+            if ((match.qLength != 0) && (match.qLength != record.qLength))
+                length = match.qLength;
+            _untranslateQPositions(effectiveQStart, effectiveQEnd, match.qFrameShift, length,
                                    context.blastProgram);
             write(s, effectiveQStart);
         } break;
@@ -306,7 +333,10 @@ _writeField(TFwdIterator & s,
         {
             TPos effectiveQStart    = match.qStart;
             TPos effectiveQEnd      = match.qEnd;
-            _untranslateQPositions(effectiveQStart, effectiveQEnd, match.qFrameShift, match.qLength,
+            auto length             = record.qLength;
+            if ((match.qLength != 0) && (match.qLength != record.qLength))
+                length = match.qLength;
+            _untranslateQPositions(effectiveQStart, effectiveQEnd, match.qFrameShift, length,
                                    context.blastProgram);
             write(s, effectiveQEnd);
         } break;
@@ -449,6 +479,26 @@ _writeField(TFwdIterator & s,
 //         case ENUM::S_STRAND: write( * ); break;
 //         case ENUM::Q_COV_S: write( * ); break;
 //         case ENUM::Q_COV_HSP:
+        case BlastMatchField<>::Enum::LCA_ID:
+            if (length(record.lcaId))
+            {
+                // replace whitespace with _
+                std::string buf;
+                resize(buf, length(record.lcaId));
+                std::transform(seqan::begin(record.lcaId), seqan::end(record.lcaId), std::begin(buf), [] (auto const c)
+                {
+                    return ((c == ' ') || (c == '\t')) ? '_' : c;
+                });
+                write(s, buf);
+            }
+            else
+            {
+                write(s, "n/a");
+            }
+            break;
+        case BlastMatchField<>::Enum::LCA_TAX_ID:
+            write(s, record.lcaTaxId);
+            break;
         default:
             write(s, "n/i"); // not implemented
     };
@@ -465,12 +515,14 @@ template <typename TQId,
           typename TPos,
           typename TAlignRow0,
           typename TAlignRow1,
+          typename ... TSpecs,
           BlastProgram p,
           BlastTabularSpec h>
 inline void
 _writeMatch(TFwdIterator & stream,
            BlastIOContext<TScore, p, h> & context,
            BlastMatch<TAlignRow0, TAlignRow1, TPos, TQId, TSId> const & match,
+           BlastRecord<TSpecs...> const & record,
            BlastTabular const & /*tag*/)
 {
     if (SEQAN_LIKELY(!context.legacyFormat))
@@ -482,7 +534,7 @@ _writeMatch(TFwdIterator & stream,
 
             if (*it != BlastMatchField<>::Enum::STD)
             {
-                _writeField(stream, context, match, *it, BlastTabular());
+                _writeField(stream, context, match, record, *it, BlastTabular());
             }
             else // STD is placeholder for multiple fields
             {
@@ -492,7 +544,7 @@ _writeMatch(TFwdIterator & stream,
                     if (it2 != it2B)
                         write(stream, '\t');
 
-                    _writeField(stream, context, match, *it2, BlastTabular());
+                    _writeField(stream, context, match, record, *it2, BlastTabular());
                 }
             }
         }
@@ -505,7 +557,7 @@ _writeMatch(TFwdIterator & stream,
             if (it != itB)
                 write(stream, '\t');
 
-            _writeField(stream, context, match, *it, BlastTabular());
+            _writeField(stream, context, match, record, *it, BlastTabular());
         }
 
         #if SEQAN_ENABLE_DEBUG
@@ -581,13 +633,13 @@ _writeMatch(TFwdIterator & stream,
 
 template <typename TFwdIterator,
           typename TScore,
-          typename TMatch,
+          typename ... TSpecs,
           BlastProgram p,
           BlastTabularSpec h>
 inline void
 writeRecord(TFwdIterator & stream,
             BlastIOContext<TScore, p, h> & context,
-            BlastRecord<TMatch> const & r,
+            BlastRecord<TSpecs...> const & r,
             BlastTabular const & /*tag*/)
 {
     //TODO if debug, do lots of sanity checks on record
@@ -599,15 +651,15 @@ writeRecord(TFwdIterator & stream,
         //SOME SANITY CHECKS
         SEQAN_ASSERT(startsWith(r.qId, it->qId));
 
-        _writeMatch(stream, context, *it, BlastTabular());
+        _writeMatch(stream, context, *it, r, BlastTabular());
     }
 }
 
 template <typename TContext,
-          typename TMatch>
+          typename ... TSpecs>
 inline void
 writeRecord(BlastTabularFileOut<TContext> & formattedFile,
-            BlastRecord<TMatch> const & r)
+            BlastRecord<TSpecs...> const & r)
 {
     writeRecord(formattedFile.iter, context(formattedFile), r, BlastTabular());
 }


### PR DESCRIPTION
This adds LCA fields to blast output and fixes some things. 

Information that was redundantly saved in each match is now accessed through the record. The previous interface is preserved for compatibility. Those parts that could be marked deprecated in the code, where. Other parts are marked deprecated through the documentation.

This is a PR I need for the next Lambda release.