### PR TITLE
[FIX] Fix windows error with static const initialization with brace-initialization.

### DIFF
--- a/include/seqan/arg_parse/arg_parse_argument.h
+++ b/include/seqan/arg_parse/arg_parse_argument.h
@@ -197,10 +197,10 @@ public:
     {
         if (argumentType == ArgParseArgument::BOOL)
         {
-            validValues = BooleanArgumentValues_<>::LIST_TRUE;
-            validValues.insert(validValues.end(),
-                               BooleanArgumentValues_<>::LIST_FALSE.begin(),
-                               BooleanArgumentValues_<>::LIST_FALSE.end());
+            copy(BooleanArgumentValues_<>::LIST_TRUE.begin(), BooleanArgumentValues_<>::LIST_TRUE.end(),
+                 std::back_inserter(validValues));
+            copy(BooleanArgumentValues_<>::LIST_FALSE.begin(), BooleanArgumentValues_<>::LIST_FALSE.end(),
+                 std::back_inserter(validValues));
         }
     }
 };

--- a/include/seqan/arg_parse/arg_parse_type_support.h
+++ b/include/seqan/arg_parse/arg_parse_type_support.h
@@ -52,15 +52,15 @@ namespace seqan {
 template <typename TVoidSpec = void>
 struct BooleanArgumentValues_
 {
-    static const std::vector<std::string> LIST_TRUE;
-    static const std::vector<std::string> LIST_FALSE;
+    static constexpr std::array<const char *, 5> LIST_TRUE  = {"1", "ON", "TRUE", "T", "YES"};
+    static constexpr std::array<const char *, 5> LIST_FALSE = {"1", "ON", "TRUE", "T", "YES"};
 };
 
 template <typename TVoidSpec>
-const std::vector<std::string> BooleanArgumentValues_<TVoidSpec>::LIST_TRUE{"1", "ON", "TRUE", "T", "YES"};
+constexpr std::array<const char *, 5> BooleanArgumentValues_<TVoidSpec>::LIST_TRUE;
 
 template <typename TVoidSpec>
-const std::vector<std::string> BooleanArgumentValues_<TVoidSpec>::LIST_FALSE{"0", "OFF", "FALSE", "F", "NO"};
+constexpr std::array<const char *, 5> BooleanArgumentValues_<TVoidSpec>::LIST_FALSE;
 
 // ==========================================================================
 // Functions

--- a/include/seqan/arg_parse/arg_parse_type_support.h
+++ b/include/seqan/arg_parse/arg_parse_type_support.h
@@ -52,8 +52,8 @@ namespace seqan {
 template <typename TVoidSpec = void>
 struct BooleanArgumentValues_
 {
-    static constexpr std::array<const char *, 5> LIST_TRUE  = {"1", "ON", "TRUE", "T", "YES"};
-    static constexpr std::array<const char *, 5> LIST_FALSE = {"1", "ON", "TRUE", "T", "YES"};
+    static constexpr std::array<const char *, 5> LIST_TRUE{{"1", "ON", "TRUE", "T", "YES"}};
+    static constexpr std::array<const char *, 5> LIST_FALSE{{"1", "ON", "TRUE", "T", "YES"}};
 };
 
 template <typename TVoidSpec>


### PR DESCRIPTION
Uses constexpr with std::array to get rid of windows error/bug?
Seems to be a bug with brace-initilaization in static const expression?