### PR TITLE
[HOTFIX] Fix several issues with cmake build system

### DIFF
--- a/apps/alf/CMakeLists.txt
+++ b/apps/alf/CMakeLists.txt
@@ -18,7 +18,7 @@ set (SEQAN_APP_VERSION "1.1.7")
 
 # Search SeqAn and select dependencies.
 if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
-    find_package (SeqAn REQUIRED)
+    find_package (SeqAn CONFIG REQUIRED)
 endif ()
 
 # ----------------------------------------------------------------------------

--- a/apps/bs_tools/CMakeLists.txt
+++ b/apps/bs_tools/CMakeLists.txt
@@ -25,7 +25,7 @@ endif ()
 if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
     find_package (ZLIB)
     find_package (Boost)
-    find_package (SeqAn REQUIRED)
+    find_package (SeqAn CONFIG REQUIRED)
 endif ()
 
 if (NOT Boost_FOUND OR NOT ZLIB_FOUND)

--- a/apps/dfi/CMakeLists.txt
+++ b/apps/dfi/CMakeLists.txt
@@ -18,7 +18,7 @@ set (SEQAN_APP_VERSION "2.1.7")
 
 # Search SeqAn and select dependencies.
 if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
-    find_package (SeqAn REQUIRED)
+    find_package (SeqAn CONFIG REQUIRED)
 endif ()
 
 # ----------------------------------------------------------------------------

--- a/apps/fiona/CMakeLists.txt
+++ b/apps/fiona/CMakeLists.txt
@@ -21,7 +21,7 @@ if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
     find_package (OpenMP)
     find_package (ZLIB)
     find_package (Boost)
-    find_package (SeqAn REQUIRED)
+    find_package (SeqAn CONFIG REQUIRED)
 endif ()
 
 # Stop here if we cannot find Boost or OpenMP.

--- a/apps/fx_tools/CMakeLists.txt
+++ b/apps/fx_tools/CMakeLists.txt
@@ -18,7 +18,7 @@ set (SEQAN_APP_VERSION "0.2.7")
 
 # Search SeqAn and select dependencies.
 if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
-    find_package (SeqAn REQUIRED)
+    find_package (SeqAn CONFIG REQUIRED)
 endif ()
 
 # ----------------------------------------------------------------------------

--- a/apps/gustaf/CMakeLists.txt
+++ b/apps/gustaf/CMakeLists.txt
@@ -18,7 +18,7 @@ set (SEQAN_APP_VERSION "1.0.7")
 
 # Search SeqAn and select dependencies.
 if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
-    find_package (SeqAn REQUIRED)
+    find_package (SeqAn CONFIG REQUIRED)
 endif ()
 
 # ----------------------------------------------------------------------------

--- a/apps/insegt/CMakeLists.txt
+++ b/apps/insegt/CMakeLists.txt
@@ -18,7 +18,7 @@ set (SEQAN_APP_VERSION "1.1.7")
 
 # Search SeqAn and select dependencies.
 if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
-    find_package (SeqAn REQUIRED)
+    find_package (SeqAn CONFIG REQUIRED)
 endif ()
 
 # ----------------------------------------------------------------------------

--- a/apps/mason2/CMakeLists.txt
+++ b/apps/mason2/CMakeLists.txt
@@ -20,7 +20,7 @@ set (SEQAN_APP_VERSION "2.0.6")
 if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
     find_package (OpenMP)
     find_package (ZLIB)
-    find_package (SeqAn REQUIRED)
+    find_package (SeqAn CONFIG REQUIRED)
 endif ()
 
 if (NOT ZLIB_FOUND)

--- a/apps/micro_razers/CMakeLists.txt
+++ b/apps/micro_razers/CMakeLists.txt
@@ -18,7 +18,7 @@ set (SEQAN_APP_VERSION "1.0.8")
 
 # Search SeqAn and select dependencies.
 if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
-    find_package (SeqAn REQUIRED)
+    find_package (SeqAn CONFIG REQUIRED)
 endif ()
 
 # ----------------------------------------------------------------------------

--- a/apps/ngs_roi/CMakeLists.txt
+++ b/apps/ngs_roi/CMakeLists.txt
@@ -20,7 +20,7 @@ set (SEQAN_APP_VERSION "0.2.9")
 
 if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
     find_package (ZLIB)
-    find_package (SeqAn REQUIRED)
+    find_package (SeqAn CONFIG REQUIRED)
 endif ()
 
 # ----------------------------------------------------------------------------

--- a/apps/pair_align/CMakeLists.txt
+++ b/apps/pair_align/CMakeLists.txt
@@ -18,7 +18,7 @@ set (SEQAN_APP_VERSION "1.3.5")
 
 # Search SeqAn and select dependencies.
 if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
-    find_package (SeqAn REQUIRED)
+    find_package (SeqAn CONFIG REQUIRED)
 endif ()
 
 # ----------------------------------------------------------------------------

--- a/apps/param_chooser/CMakeLists.txt
+++ b/apps/param_chooser/CMakeLists.txt
@@ -18,7 +18,7 @@ set (SEQAN_APP_VERSION "0.0.6")
 
 # Search SeqAn and select dependencies.
 if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
-    find_package (SeqAn REQUIRED)
+    find_package (SeqAn CONFIG REQUIRED)
 endif ()
 
 # ----------------------------------------------------------------------------

--- a/apps/rabema/CMakeLists.txt
+++ b/apps/rabema/CMakeLists.txt
@@ -19,7 +19,7 @@ set (SEQAN_APP_VERSION "1.2.7")
 # Search SeqAn and select dependencies.
 if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
     find_package (ZLIB)
-    find_package (SeqAn REQUIRED)
+    find_package (SeqAn CONFIG REQUIRED)
 endif ()
 
 if (NOT ZLIB_FOUND)

--- a/apps/razers/CMakeLists.txt
+++ b/apps/razers/CMakeLists.txt
@@ -18,7 +18,7 @@ set (SEQAN_APP_VERSION "1.5.5")
 
 # Search SeqAn and select dependencies.
 if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
-    find_package (SeqAn REQUIRED)
+    find_package (SeqAn CONFIG REQUIRED)
 endif ()
 
 # ----------------------------------------------------------------------------

--- a/apps/razers3/CMakeLists.txt
+++ b/apps/razers3/CMakeLists.txt
@@ -27,7 +27,7 @@ if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
     find_package (OpenMP)
     find_package (ZLIB)
     find_package (BZip2)
-    find_package (SeqAn REQUIRED)
+    find_package (SeqAn CONFIG REQUIRED)
 endif ()
 
 # ----------------------------------------------------------------------------

--- a/apps/rep_sep/CMakeLists.txt
+++ b/apps/rep_sep/CMakeLists.txt
@@ -18,7 +18,7 @@ set (SEQAN_APP_VERSION "0.1.8")
 
 # Search SeqAn and select dependencies.
 if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
-    find_package (SeqAn REQUIRED)
+    find_package (SeqAn CONFIG REQUIRED)
 endif ()
 
 # ----------------------------------------------------------------------------

--- a/apps/sak/CMakeLists.txt
+++ b/apps/sak/CMakeLists.txt
@@ -18,7 +18,7 @@ set (SEQAN_APP_VERSION "0.4.5")
 
 # Search SeqAn and select dependencies.
 if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
-    find_package (SeqAn REQUIRED)
+    find_package (SeqAn CONFIG REQUIRED)
 endif ()
 
 # ----------------------------------------------------------------------------

--- a/apps/sam2matrix/CMakeLists.txt
+++ b/apps/sam2matrix/CMakeLists.txt
@@ -18,7 +18,7 @@ set (SEQAN_APP_VERSION "0.3.5")
 
 # Search SeqAn and select dependencies.
 if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
-    find_package (SeqAn REQUIRED)
+    find_package (SeqAn CONFIG REQUIRED)
 endif ()
 
 # ----------------------------------------------------------------------------

--- a/apps/samcat/CMakeLists.txt
+++ b/apps/samcat/CMakeLists.txt
@@ -20,7 +20,7 @@ set (SEQAN_APP_VERSION "0.3.5")
 if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
     find_package (OpenMP)
     find_package (ZLIB)
-    find_package (SeqAn REQUIRED)
+    find_package (SeqAn CONFIG REQUIRED)
 endif ()
 
 # ----------------------------------------------------------------------------

--- a/apps/searchjoin/CMakeLists.txt
+++ b/apps/searchjoin/CMakeLists.txt
@@ -19,7 +19,7 @@ set (SEQAN_APP_VERSION "0.5.5")
 # Search SeqAn and select dependencies.
 if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
     find_package (OpenMP)
-    find_package (SeqAn REQUIRED)
+    find_package (SeqAn CONFIG REQUIRED)
 endif ()
 
 # ----------------------------------------------------------------------------

--- a/apps/seqan_tcoffee/CMakeLists.txt
+++ b/apps/seqan_tcoffee/CMakeLists.txt
@@ -18,7 +18,7 @@ set (SEQAN_APP_VERSION "1.13.5")
 
 # Search SeqAn and select dependencies.
 if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
-    find_package (SeqAn REQUIRED)
+    find_package (SeqAn CONFIG REQUIRED)
 endif ()
 
 # ----------------------------------------------------------------------------

--- a/apps/seqcons2/CMakeLists.txt
+++ b/apps/seqcons2/CMakeLists.txt
@@ -19,7 +19,7 @@ set (SEQAN_APP_VERSION "2.0.6")
 # Search SeqAn and select dependencies.
 if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
     find_package (ZLIB)
-    find_package (SeqAn REQUIRED)
+    find_package (SeqAn CONFIG REQUIRED)
 endif ()
 
 # ----------------------------------------------------------------------------

--- a/apps/sgip/CMakeLists.txt
+++ b/apps/sgip/CMakeLists.txt
@@ -18,7 +18,7 @@ set (SEQAN_APP_VERSION "1.4.5")
 
 # Search SeqAn and select dependencies.
 if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
-    find_package (SeqAn REQUIRED)
+    find_package (SeqAn CONFIG REQUIRED)
 endif ()
 
 # ----------------------------------------------------------------------------

--- a/apps/snp_store/CMakeLists.txt
+++ b/apps/snp_store/CMakeLists.txt
@@ -20,7 +20,7 @@ set (SEQAN_APP_VERSION "1.3.5")
 if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
     find_package (ZLIB)
     find_package (Boost)
-    find_package (SeqAn REQUIRED)
+    find_package (SeqAn CONFIG REQUIRED)
 endif ()
 
 if (NOT Boost_FOUND OR NOT ZLIB_FOUND)

--- a/apps/splazers/CMakeLists.txt
+++ b/apps/splazers/CMakeLists.txt
@@ -18,7 +18,7 @@ set (SEQAN_APP_VERSION "1.3.5")
 
 # Search SeqAn and select dependencies.
 if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
-    find_package (SeqAn REQUIRED)
+    find_package (SeqAn CONFIG REQUIRED)
 endif ()
 
 if (NOT CMAKE_SIZEOF_VOID_P EQUAL 8)

--- a/apps/stellar/CMakeLists.txt
+++ b/apps/stellar/CMakeLists.txt
@@ -18,7 +18,7 @@ set (SEQAN_APP_VERSION "1.4.8")
 
 # Search SeqAn and select dependencies.
 if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
-    find_package (SeqAn REQUIRED)
+    find_package (SeqAn CONFIG REQUIRED)
 endif ()
 
 # ----------------------------------------------------------------------------

--- a/apps/tree_recon/CMakeLists.txt
+++ b/apps/tree_recon/CMakeLists.txt
@@ -18,7 +18,7 @@ set (SEQAN_APP_VERSION "1.4.5")
 
 # Search SeqAn and select dependencies.
 if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
-    find_package (SeqAn REQUIRED)
+    find_package (SeqAn CONFIG REQUIRED)
 endif ()
 
 # ----------------------------------------------------------------------------

--- a/apps/yara/CMakeLists.txt
+++ b/apps/yara/CMakeLists.txt
@@ -24,7 +24,7 @@ if (NOT "${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
     find_package (OpenMP)
     find_package (ZLIB)
     find_package (BZip2)
-    find_package (SeqAn REQUIRED)
+    find_package (SeqAn CONFIG REQUIRED)
 endif ()
 
 # Warn if OpenMP was not found.

--- a/util/cmake/SeqAnBuildSystem.cmake
+++ b/util/cmake/SeqAnBuildSystem.cmake
@@ -324,7 +324,7 @@ macro (seqan_build_system_init)
         find_package(ZLIB)
         find_package(BZip2)
         find_package(Boost)
-        find_package(SeqAn REQUIRED)
+        find_package(SeqAn CONFIG REQUIRED)
     endif ()
 
 endmacro (seqan_build_system_init)

--- a/util/cmake/SeqAnBuildSystem.cmake
+++ b/util/cmake/SeqAnBuildSystem.cmake
@@ -313,6 +313,7 @@ macro (seqan_build_system_init)
     # strip binaries when packaging
     if ((CMAKE_BUILD_TYPE STREQUAL "Release") AND
         (NOT SEQAN_BUILD_SYSTEM STREQUAL "DEVELOP") AND
+        (NOT APPLE) AND
         (COMPILER_CLANG OR COMPILER_GCC))
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -s")
     endif ()


### PR DESCRIPTION
- Forces cmake to use CONFIG based detection instead of module based.
- Excludes stripped binaries for builds on apple.