### PR TITLE
Fix FTBFS with Boost 1.62

### DIFF
--- a/apps/bs_tools/casbar.cpp
+++ b/apps/bs_tools/casbar.cpp
@@ -64,6 +64,7 @@
 #include <seqan/vcf_io.h>
 #include <seqan/bed_io.h>
 
+#include <boost/detail/workaround.hpp>
 #include <boost/math/tools/tuple.hpp>
 #include <boost/math/tools/roots.hpp>
 


### PR DESCRIPTION
Add missing include so that BOOST_WORKAROUND is defined.

Import [downstream patch](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=846617) of debian into upstream