### PR TITLE
[HOTFIX] Change Version Check Option to bool and manage messages via macros.

### DIFF
--- a/include/seqan/arg_parse/arg_parse_parse.h
+++ b/include/seqan/arg_parse/arg_parse_parse.h
@@ -310,10 +310,10 @@ ArgumentParser::ParseResult parse(ArgumentParser & me,
 
 #ifndef SEQAN_DISABLE_VERSION_CHECK
     // do version check if not turned off by the user
-    std::string version_option;
-    getOptionValue(version_option, me, "version-check");
+    bool check_version;
+    getOptionValue(check_version, me, "version-check");
 
-    if (version_option != VersionControlTags_<>::OPTION_OFF)
+    if (check_version)
     {
         VersionCheck app_version(toCString(me._toolDoc._name),
                                  toCString(me._toolDoc._version),
@@ -321,17 +321,6 @@ ArgumentParser::ParseResult parse(ArgumentParser & me,
         std::promise<bool> appVersionProm;
         me.appVersionCheckFuture = appVersionProm.get_future();
         app_version(std::move(appVersionProm));
-
-        if (version_option != VersionControlTags_<>::OPTION_APP_ONLY)
-        {
-            std::string seqan_ver_string = std::to_string(SEQAN_VERSION_MAJOR) + "." + 
-                                           std::to_string(SEQAN_VERSION_MINOR) + "." +
-                                           std::to_string(SEQAN_VERSION_PATCH);
-            VersionCheck seqan_version("seqan", seqan_ver_string, errorStream);
-            std::promise<bool> seqanVersionProm;
-            me.seqanVersionCheckFuture = seqanVersionProm.get_future();
-            seqan_version(std::move(seqanVersionProm));
-        }
     }
 #endif  // !SEQAN_DISABLE_VERSION_CHECK
 

--- a/include/seqan/arg_parse/arg_parse_parse.h
+++ b/include/seqan/arg_parse/arg_parse_parse.h
@@ -310,7 +310,7 @@ ArgumentParser::ParseResult parse(ArgumentParser & me,
 
 #ifndef SEQAN_DISABLE_VERSION_CHECK
     // do version check if not turned off by the user
-    bool check_version;
+    bool check_version = false;
     getOptionValue(check_version, me, "version-check");
 
     if (check_version)

--- a/include/seqan/arg_parse/arg_parse_version_check.h
+++ b/include/seqan/arg_parse/arg_parse_version_check.h
@@ -127,7 +127,7 @@ struct VersionCheck
         {
             _version = versionMatch.str(1); // in case the git revision number is given take only version number
         }
-        _url = static_cast<std::string>("http://www.seqan.de/version_check/SeqAn_") + _getOS() + _getBitSys() + _name + "_" + _version;
+        _url = static_cast<std::string>("http://seqan-update.informatik.uni-tuebingen.de/check/SeqAn_") + _getOS() + _getBitSys() + _name + "_" + _version;
         _getProgram();
         _updateCommand();
     }

--- a/include/seqan/arg_parse/arg_parse_version_check.h
+++ b/include/seqan/arg_parse/arg_parse_version_check.h
@@ -66,24 +66,20 @@ struct VersionControlTags_
 {
     static constexpr char const * const SEQAN_NAME         = "seqan";
     static constexpr char const * const UNREGISTERED_APP   = "UNREGISTERED_APP";
-    static constexpr char const * const OPTION_OFF         = "OFF";
-    static constexpr char const * const OPTION_DEV         = "DEV";
-    static constexpr char const * const OPTION_APP_ONLY    = "APP_ONLY";
-    static constexpr char const * const OPTIONS            = "DEV APP_ONLY OFF";
 
     static constexpr char const * const MESSAGE_SEQAN_UPDATE =
         "[SEQAN INFO] :: There is a newer SeqAn version available!\n"
         "[SEQAN INFO] :: Please visit www.seqan.de for an update or inform the developer of this app.\n"
-        "[SEQAN INFO] :: If you don't want to recieve this message again set --version-check APP_ONLY\n\n";
+        "[SEQAN INFO] :: If you don't want to recieve this message again set --version-check OFF\n\n";
     static constexpr char const * const MESSAGE_APP_UPDATE =
         "[APP INFO] :: There is a newer version of this application available.\n"
         "[APP INFO] :: If this app is developed by SeqAn, visit www.seqan.de for updates.\n"
         "[APP INFO] :: If you don't want to recieve this message again set --version_check OFF\n\n";
     static constexpr char const * const MESSAGE_UNREGISTERED_APP =
         "[SEQAN INFO] :: Thank you for using SeqAn!\n"
-        "[SEQAN INFO] :: You might want to regsiter you app for support and version check features?!\n"
+        "[SEQAN INFO] :: You might want to regsiter you app for support and version check features?\n"
         "[SEQAN INFO] :: Just send us an email to seqan@team.fu-berlin.de with your app name and version number.\n"
-        "[SEQAN INFO] :: If you don't want to recieve this message anymore set --version_check 2\n\n";
+        "[SEQAN INFO] :: If you don't want to recieve this message anymore set --version_check OFF\n\n";
     static constexpr char const * const MESSAGE_REGISTERED_APP_UPDATE =
         "[APP INFO] :: We noticed the app version you use is newer than the one registered with us.\n"
         "[APP INFO] :: Please send us an email with the new version so we can correct it (support@seqan.de)\n\n";
@@ -93,14 +89,6 @@ template <typename TVoidSpec>
 constexpr char const * const VersionControlTags_<TVoidSpec>::SEQAN_NAME;
 template <typename TVoidSpec>
 constexpr char const * const VersionControlTags_<TVoidSpec>::UNREGISTERED_APP;
-template <typename TVoidSpec>
-constexpr char const * const VersionControlTags_<TVoidSpec>::OPTION_OFF;
-template <typename TVoidSpec>
-constexpr char const * const VersionControlTags_<TVoidSpec>::OPTION_DEV;
-template <typename TVoidSpec>
-constexpr char const * const VersionControlTags_<TVoidSpec>::OPTION_APP_ONLY;
-template <typename TVoidSpec>
-constexpr char const * const VersionControlTags_<TVoidSpec>::OPTIONS;
 template <typename TVoidSpec>
 constexpr char const * const VersionControlTags_<TVoidSpec>::MESSAGE_SEQAN_UPDATE;
 template <typename TVoidSpec>
@@ -139,7 +127,7 @@ struct VersionCheck
         {
             _version = versionMatch.str(1); // in case the git revision number is given take only version number
         }
-        _url = static_cast<std::string>("http://seqan-update.informatik.uni-tuebingen.de/check/SeqAn_") + _getOS() + _getBitSys() + _name + "_" + _version;
+        _url = static_cast<std::string>("http://www.seqan.de/version_check/SeqAn_") + _getOS() + _getBitSys() + _name + "_" + _version;
         _getProgram();
         _updateCommand();
     }
@@ -368,26 +356,31 @@ inline String<int> _getNumbersFromString(std::string const & str)
 // Function _readVersionString()
 // ----------------------------------------------------------------------------
 
-inline std::string _readVersionString(VersionCheck & me, std::string const & version_file)
+inline void _readVersionStrings(std::vector<std::string> & versions, std::string const & version_file)
 {
     std::ifstream myfile;
     myfile.open(version_file.c_str());
-    std::string line;
+    std::string app_version;
+    std::string seqan_version;
     if (myfile.is_open())
     {
-        std::getline(myfile,line); // get first line which should only contain the version number
-        if (!(std::regex_match(line, std::regex("^[[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+$"))))
-        {
-            line.clear();
-        }
-        if (line == VersionControlTags_<>::UNREGISTERED_APP)
-        {
-            me.errorStream << VersionControlTags_<>::MESSAGE_UNREGISTERED_APP;
-            line.clear();
-        }
+        std::getline(myfile, app_version); // get first line which should only contain the version number of the app
+
+#if !defined(NDEBUG) || defined(SEQAN_TEST_VERSION_CHECK_)
+        if (app_version == VersionControlTags_<>::UNREGISTERED_APP)
+            versions[0] = app_version;
+#endif // !defined(NDEBUG) || defined(SEQAN_TEST_VERSION_CHECK_)
+
+        if (std::regex_match(app_version, std::regex("^[[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+$")))
+            versions[0] = app_version;
+
+        std::getline(myfile, seqan_version); // get second line which should only contain the version number of seqan
+
+        if (std::regex_match(seqan_version, std::regex("^[[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+$")))
+            versions[1] = seqan_version;
+
         myfile.close();
     }
-    return line; // line is an empty string on failure
 }
 
 // ----------------------------------------------------------------------------
@@ -436,24 +429,36 @@ inline void _checkForNewerVersion(VersionCheck & me, std::promise<bool> prom)
         return;
     }
 
-    std::string str_server_version(_readVersionString(me, version_filename));
-    if (!str_server_version.empty())
+    std::vector<std::string> str_server_versions{"", ""};
+    _readVersionStrings(str_server_versions, version_filename);
+
+#if !defined(NDEBUG) || defined(SEQAN_TEST_VERSION_CHECK_) // only check seqan version in debug or testing mode
+    if (!str_server_versions[1].empty()) // seqan version
     {
-        String<int> server_version(_getNumbersFromString(str_server_version));
-        String<int> current_version(_getNumbersFromString(me._version));
-        Lexical<> version_comp(current_version, server_version);
+        std::string seqan_version = std::to_string(SEQAN_VERSION_MAJOR) + "." +
+                                    std::to_string(SEQAN_VERSION_MINOR) + "." +
+                                    std::to_string(SEQAN_VERSION_PATCH);
+        Lexical<> version_comp(_getNumbersFromString(seqan_version), _getNumbersFromString(str_server_versions[1]));
+
         if (isLess(version_comp))
-        {
-            if (me._name == VersionControlTags_<>::SEQAN_NAME)
-                me.errorStream << VersionControlTags_<>::MESSAGE_SEQAN_UPDATE;
-            else
-                me.errorStream << VersionControlTags_<>::MESSAGE_APP_UPDATE;
-        }
-        else if (isGreater(version_comp))
-        {
-            me.errorStream << VersionControlTags_<>::MESSAGE_REGISTERED_APP_UPDATE;
-        }
+            me.errorStream << VersionControlTags_<>::MESSAGE_SEQAN_UPDATE;
     }
+    if (str_server_versions[0] == VersionControlTags_<>::UNREGISTERED_APP)
+        me.errorStream << VersionControlTags_<>::MESSAGE_UNREGISTERED_APP;
+#endif
+
+#if defined(NDEBUG) || defined(SEQAN_TEST_VERSION_CHECK_) // only check app version in release or testing mode
+    if (!str_server_versions[0].empty() & !(str_server_versions[0] == VersionControlTags_<>::UNREGISTERED_APP)) // app version
+    {
+        Lexical<> version_comp(_getNumbersFromString(me._version), _getNumbersFromString(str_server_versions[0]));
+
+        if (isLess(version_comp))
+            me.errorStream << VersionControlTags_<>::MESSAGE_APP_UPDATE;
+
+        else if (isGreater(version_comp))
+            me.errorStream << VersionControlTags_<>::MESSAGE_REGISTERED_APP_UPDATE;
+    }
+#endif // defined(NDEBUG) || defined(SEQAN_TEST_VERSION_CHECK_)
 
     if (me._program.empty())
     {

--- a/include/seqan/arg_parse/argument_parser.h
+++ b/include/seqan/arg_parse/argument_parser.h
@@ -202,7 +202,6 @@ public:
                                             // interference with the rest of the doc
 
     std::future<bool> appVersionCheckFuture;
-    std::future<bool> seqanVersionCheckFuture;
     // ----------------------------------------------------------------------------
     // Function init()
     // ----------------------------------------------------------------------------
@@ -231,17 +230,12 @@ public:
 #ifndef SEQAN_DISABLE_VERSION_CHECK
         addOption(*this, ArgParseOption("",
                                         "version-check",
-                                        "Choose OFF to disable any update notifications. "
-                                        "With APP_ONLY you'll receive update notifications about new versions of your app. "
-                                        "In DEV mode you'll receive update notifications regarding new versions of your app "
-                                        "and new versions of the SeqAn library.",
-                                        ArgParseArgument::STRING,
-                                        "OPTION"));
-        setValidValues(*this, "version-check", VersionControlTags_<>::OPTIONS);
+                                        "Turn this option off to disable version update notifications of the application. ",
+                                        ArgParseArgument::BOOL));
 #ifdef SEQAN_VERSION_CHECK_OPT_IN
-        setDefaultValue(*this, "version-check", VersionControlTags_<>::OPTION_OFF);
+        setDefaultValue(*this, "version-check", false);
 #else  // Make version update opt out.
-        setDefaultValue(*this, "version-check", VersionControlTags_<>::OPTION_DEV);
+        setDefaultValue(*this, "version-check", true);
 #endif  // SEQAN_VERSION_CHECK_OPT_IN
 #endif  // !SEQAN_DISABLE_VERSION_CHECK
     }
@@ -266,9 +260,6 @@ public:
         // wait for another 3 seconds
         if (appVersionCheckFuture.valid())
             appVersionCheckFuture.wait_for(std::chrono::seconds(3));
-                
-        if (seqanVersionCheckFuture.valid()) 
-            seqanVersionCheckFuture.wait_for(std::chrono::seconds(3));
     }
     
 };

--- a/tests/arg_parse/test_arg_parse_version_check.cpp
+++ b/tests/arg_parse/test_arg_parse_version_check.cpp
@@ -41,6 +41,7 @@
 #endif
 
 #define SEQAN_DEBUG
+#define SEQAN_TEST_VERSION_CHECK_
 
 #include "test_arg_parse_version_check.h"
 
@@ -57,15 +58,12 @@ SEQAN_BEGIN_TESTSUITE(test_arg_parse)
     // IMPORTANT: there always needs to be the test 'test_delete_version_files'
     //            in between tests to ensure that no former files interfere with
     //            the test results.
-    SEQAN_CALL_TEST(test_option_dev);
-    SEQAN_CALL_TEST(test_delete_version_files);
-    SEQAN_CALL_TEST(test_option_app_only);
+    SEQAN_CALL_TEST(test_option_on);
     SEQAN_CALL_TEST(test_delete_version_files);
     SEQAN_CALL_TEST(test_option_off);
     SEQAN_CALL_TEST(test_delete_version_files);
     SEQAN_CALL_TEST(test_smaller_seqan_version);
     SEQAN_CALL_TEST(test_delete_version_files);
-    SEQAN_CALL_TEST(test_smaller_seqan_version_app_only);
     SEQAN_CALL_TEST(test_delete_version_files);
     SEQAN_CALL_TEST(test_smaller_app_version);
     SEQAN_CALL_TEST(test_delete_version_files);

--- a/tests/arg_parse/test_arg_parse_version_check.h
+++ b/tests/arg_parse/test_arg_parse_version_check.h
@@ -46,42 +46,34 @@ struct TestVersionCheck_
     static const std::chrono::duration<long int>::rep TIME_NOW;
 
     static const std::string PATH; // See arg_parse_version_check.h for _getPath()
-    static const std::string SEQAN_VERSION_FILENAME;
-    static const std::string SEQAN_TIMESTAMP_FILENAME;
+    static const std::string APP_NAME;
     static const std::string APP_VERSION_FILENAME;
     static const std::string APP_TIMESTAMP_FILENAME;
 
-    static constexpr const char * const PARSER_NAME = "test_app_version_check";
-    static constexpr const char * const APP_NAME = "test";
     static constexpr const char * const OPTION_VERSION_CHECK = "--version-check";
     static constexpr const char * const OPTION_OFF = "OFF";
-    static constexpr const char * const OPTION_APP_ONLY = "APP_ONLY";
-    static constexpr const char * const OPTION_DEV = "DEV";
+    static constexpr const char * const OPTION_ON = "ON";
 };
 
 const std::chrono::duration<long int>::rep TestVersionCheck_::TIME_NOW = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 const std::string TestVersionCheck_::PATH = seqan::_getPath();
-const std::string TestVersionCheck_::SEQAN_VERSION_FILENAME   = TestVersionCheck_::PATH +
-                                                                static_cast<std::string>("/seqan.version");
-const std::string TestVersionCheck_::SEQAN_TIMESTAMP_FILENAME = TestVersionCheck_::PATH +
-                                                                static_cast<std::string>("/seqan.timestamp");
+const std::string TestVersionCheck_::APP_NAME = "test_version_check_" + std::to_string(TIME_NOW); // avoid name conflicts
 const std::string TestVersionCheck_::APP_VERSION_FILENAME     = TestVersionCheck_::PATH + "/" +
-                                                                TestVersionCheck_::PARSER_NAME +
+                                                                TestVersionCheck_::APP_NAME +
                                                                 static_cast<std::string>(".version");
 const std::string TestVersionCheck_::APP_TIMESTAMP_FILENAME   = TestVersionCheck_::PATH + "/" +
-                                                                TestVersionCheck_::PARSER_NAME +
+                                                                TestVersionCheck_::APP_NAME +
                                                                 static_cast<std::string>(".timestamp");
 
 namespace seqan {
 
 inline ArgumentParser::ParseResult _simulateArgumentParser(String<CharString> & stream_result,
                                                            bool & app_call_succeeded,
-                                                           bool & seqan_call_succeeded,
                                                            int argc,
                                                            const char ** argv)
 {
     ArgumentParser parser;
-    setAppName(parser, TestVersionCheck_::PARSER_NAME);
+    setAppName(parser, TestVersionCheck_::APP_NAME);
     setVersion(parser, "2.3.4");
 
     std::stringstream err_stream;
@@ -96,16 +88,12 @@ inline ArgumentParser::ParseResult _simulateArgumentParser(String<CharString> & 
     // any interference with following tests
     if(parser.appVersionCheckFuture.valid())
             app_call_succeeded = parser.appVersionCheckFuture.get();
-    if(parser.seqanVersionCheckFuture.valid())
-            seqan_call_succeeded = parser.seqanVersionCheckFuture.get();
 
     return res;
 }
 
 inline void _removeFilesFromPath()
 {
-    std::remove(TestVersionCheck_::SEQAN_VERSION_FILENAME.c_str());
-    std::remove(TestVersionCheck_::SEQAN_TIMESTAMP_FILENAME.c_str());
     std::remove(TestVersionCheck_::APP_VERSION_FILENAME.c_str());
     std::remove(TestVersionCheck_::APP_TIMESTAMP_FILENAME.c_str());
 }
@@ -131,42 +119,32 @@ SEQAN_DEFINE_TEST(test_path_availability)
 SEQAN_DEFINE_TEST(test_delete_version_files)
 {
     _removeFilesFromPath();
-    SEQAN_ASSERT(!fileExists(TestVersionCheck_::SEQAN_VERSION_FILENAME.c_str()));
-    SEQAN_ASSERT(!fileExists(TestVersionCheck_::SEQAN_TIMESTAMP_FILENAME.c_str()));
     SEQAN_ASSERT(!fileExists(TestVersionCheck_::APP_VERSION_FILENAME.c_str()));
     SEQAN_ASSERT(!fileExists(TestVersionCheck_::APP_TIMESTAMP_FILENAME.c_str()));
 }
 
 SEQAN_DEFINE_TEST(test_create_files)
 {
-    _createFile(TestVersionCheck_::SEQAN_VERSION_FILENAME.c_str(), "20.5.9");
-    _createFile(TestVersionCheck_::SEQAN_TIMESTAMP_FILENAME.c_str(), TestVersionCheck_::TIME_NOW);
     _createFile(TestVersionCheck_::APP_VERSION_FILENAME.c_str(), "20.5.9");
     _createFile(TestVersionCheck_::APP_TIMESTAMP_FILENAME.c_str(), TestVersionCheck_::TIME_NOW);
 
-    SEQAN_ASSERT(fileExists(TestVersionCheck_::SEQAN_VERSION_FILENAME.c_str()));
-    SEQAN_ASSERT(fileExists(TestVersionCheck_::SEQAN_TIMESTAMP_FILENAME.c_str()));
     SEQAN_ASSERT(fileExists(TestVersionCheck_::APP_VERSION_FILENAME.c_str()));
     SEQAN_ASSERT(fileExists(TestVersionCheck_::APP_TIMESTAMP_FILENAME.c_str()));
 
     _removeFilesFromPath(); // clear files again
-    SEQAN_ASSERT(!fileExists(TestVersionCheck_::SEQAN_VERSION_FILENAME.c_str()));
-    SEQAN_ASSERT(!fileExists(TestVersionCheck_::SEQAN_TIMESTAMP_FILENAME.c_str()));
     SEQAN_ASSERT(!fileExists(TestVersionCheck_::APP_VERSION_FILENAME.c_str()));
     SEQAN_ASSERT(!fileExists(TestVersionCheck_::APP_TIMESTAMP_FILENAME.c_str()));
 }
 
-SEQAN_DEFINE_TEST(test_option_dev)
+SEQAN_DEFINE_TEST(test_option_on)
 {
     int argc(3);
-    const char * argv[3] = {TestVersionCheck_::APP_NAME, TestVersionCheck_::OPTION_VERSION_CHECK,
-                            TestVersionCheck_::OPTION_DEV};
+    const char * argv[3] = {TestVersionCheck_::APP_NAME.c_str(), TestVersionCheck_::OPTION_VERSION_CHECK,
+                            TestVersionCheck_::OPTION_ON};
     String<CharString> stream_result;
     bool app_call_succeeded(false);
-    bool seqan_call_succeeded(false);
 
-    ArgumentParser::ParseResult res = _simulateArgumentParser(stream_result, app_call_succeeded,
-                                                              seqan_call_succeeded, argc, argv);
+    ArgumentParser::ParseResult res = _simulateArgumentParser(stream_result, app_call_succeeded, argc, argv);
 
     SEQAN_ASSERT_EQ(res, ArgumentParser::PARSE_OK);
     SEQAN_ASSERT_EQ(stream_result[0], "");
@@ -174,48 +152,19 @@ SEQAN_DEFINE_TEST(test_option_dev)
 
     // make sure that all files now exist
     SEQAN_ASSERT(fileExists(TestVersionCheck_::APP_TIMESTAMP_FILENAME.c_str()));
-    SEQAN_ASSERT(fileExists(TestVersionCheck_::SEQAN_TIMESTAMP_FILENAME.c_str()));
     if (app_call_succeeded)
         SEQAN_ASSERT(fileExists(TestVersionCheck_::APP_VERSION_FILENAME.c_str()));
-    if (seqan_call_succeeded)
-        SEQAN_ASSERT(fileExists(TestVersionCheck_::SEQAN_VERSION_FILENAME.c_str()));
-}
-
-SEQAN_DEFINE_TEST(test_option_app_only)
-{
-    int argc(3);
-    const char * argv[3] = {TestVersionCheck_::APP_NAME, TestVersionCheck_::OPTION_VERSION_CHECK,
-                            TestVersionCheck_::OPTION_APP_ONLY};
-    String<CharString> stream_result;
-    bool app_call_succeeded(false);
-    bool seqan_call_succeeded(false);
-
-    ArgumentParser::ParseResult res = _simulateArgumentParser(stream_result, app_call_succeeded,
-                                                              seqan_call_succeeded, argc, argv);
-
-    SEQAN_ASSERT_EQ(res, ArgumentParser::PARSE_OK);
-    SEQAN_ASSERT_EQ(stream_result[0], "");
-    SEQAN_ASSERT_EQ(stream_result[1], "");
-
-    // make sure that only app files exist
-    SEQAN_ASSERT(fileExists(TestVersionCheck_::APP_TIMESTAMP_FILENAME.c_str()));
-    SEQAN_ASSERT(!fileExists(TestVersionCheck_::SEQAN_TIMESTAMP_FILENAME.c_str()));
-    if (app_call_succeeded)
-        SEQAN_ASSERT(fileExists(TestVersionCheck_::APP_VERSION_FILENAME.c_str()));
-    SEQAN_ASSERT(!fileExists(TestVersionCheck_::SEQAN_VERSION_FILENAME.c_str()));
 }
 
 SEQAN_DEFINE_TEST(test_option_off)
 {
     int argc(3);
-    const char * argv[3] = {TestVersionCheck_::APP_NAME, TestVersionCheck_::OPTION_VERSION_CHECK,
+    const char * argv[3] = {TestVersionCheck_::APP_NAME.c_str(), TestVersionCheck_::OPTION_VERSION_CHECK,
                             TestVersionCheck_::OPTION_OFF};
     String<CharString> stream_result;
     bool app_call_succeeded(false);
-    bool seqan_call_succeeded(false);
 
-    ArgumentParser::ParseResult res = _simulateArgumentParser(stream_result, app_call_succeeded,
-                                                              seqan_call_succeeded, argc, argv);
+    ArgumentParser::ParseResult res = _simulateArgumentParser(stream_result, app_call_succeeded, argc, argv);
 
     SEQAN_ASSERT_EQ(res, ArgumentParser::PARSE_OK);
     SEQAN_ASSERT_EQ(stream_result[0], "");
@@ -223,78 +172,54 @@ SEQAN_DEFINE_TEST(test_option_off)
 
     // make sure that no files exist
     SEQAN_ASSERT(!fileExists(TestVersionCheck_::APP_TIMESTAMP_FILENAME.c_str()));
-    SEQAN_ASSERT(!fileExists(TestVersionCheck_::SEQAN_TIMESTAMP_FILENAME.c_str()));
     SEQAN_ASSERT(!fileExists(TestVersionCheck_::APP_VERSION_FILENAME.c_str()));
-    SEQAN_ASSERT(!fileExists(TestVersionCheck_::SEQAN_VERSION_FILENAME.c_str()));
 }
 
 // case: the current argument parser has a smaller seqan version than is present in the version file
 SEQAN_DEFINE_TEST(test_smaller_seqan_version)
 {
     int argc(3);
-    const char * argv[3] = {TestVersionCheck_::APP_NAME, TestVersionCheck_::OPTION_VERSION_CHECK,
-                            TestVersionCheck_::OPTION_DEV};
+    const char * argv[3] = {TestVersionCheck_::APP_NAME.c_str(), TestVersionCheck_::OPTION_VERSION_CHECK,
+                            TestVersionCheck_::OPTION_ON};
     String<CharString> stream_result;
     bool app_call_succeeded(false);
-    bool seqan_call_succeeded(false);
 
-    // create version file with a greater version than the current (2.3.4)
-    _createFile(TestVersionCheck_::SEQAN_VERSION_FILENAME.c_str(), "20.5.9");
+    // create version file with euqal app version and a greater seqan version than the current (2.3.4)
+    std::stringstream version_info;
+    version_info << "2.3.4" << std::endl << "20.5.9";
+    _createFile(TestVersionCheck_::APP_VERSION_FILENAME.c_str(), version_info.str());
 
     // create timestamp file that dates one day before current to trigger a message
-    _createFile(TestVersionCheck_::SEQAN_TIMESTAMP_FILENAME.c_str(), TestVersionCheck_::TIME_NOW - 86401); // one day = 86400 seconds
+    _createFile(TestVersionCheck_::APP_TIMESTAMP_FILENAME.c_str(), TestVersionCheck_::TIME_NOW - 86401); // one day = 86400 seconds
 
-    ArgumentParser::ParseResult res = _simulateArgumentParser(stream_result, app_call_succeeded,
-                                                              seqan_call_succeeded, argc, argv);
+    ArgumentParser::ParseResult res = _simulateArgumentParser(stream_result, app_call_succeeded, argc, argv);
 
     SEQAN_ASSERT_EQ(res, ArgumentParser::PARSE_OK);
     SEQAN_ASSERT_EQ(stream_result[0], "");
     SEQAN_ASSERT_EQ(stream_result[1], VersionControlTags_<>::MESSAGE_SEQAN_UPDATE);
 }
 
-// case: the current argument parser has a smaller seqan version than is present in the version file
-//       but because app_only is specified, no message will be shown
-SEQAN_DEFINE_TEST(test_smaller_seqan_version_app_only)
-{
-    int argc(3);
-    const char * argv[3] = {TestVersionCheck_::APP_NAME, TestVersionCheck_::OPTION_VERSION_CHECK,
-                            TestVersionCheck_::OPTION_APP_ONLY};
-    String<CharString> stream_result;
-    bool app_call_succeeded(false);
-    bool seqan_call_succeeded(false);
-
-    // create version file with a greater version than the current (2.3.4)
-    _createFile(TestVersionCheck_::SEQAN_VERSION_FILENAME.c_str(), "20.5.9");
-
-    // create timestamp file that dates one day before current to trigger a message
-    _createFile(TestVersionCheck_::SEQAN_TIMESTAMP_FILENAME.c_str(), TestVersionCheck_::TIME_NOW - 86401); // one day = 86400 seconds
-
-    ArgumentParser::ParseResult res = _simulateArgumentParser(stream_result, app_call_succeeded,
-                                                              seqan_call_succeeded, argc, argv);
-
-    SEQAN_ASSERT_EQ(res, ArgumentParser::PARSE_OK);
-    SEQAN_ASSERT_EQ(stream_result[0], "");
-    SEQAN_ASSERT_EQ(stream_result[1], "");
-}
-
 // case: the current argument parser has a smaller app version than is present in the version file
 SEQAN_DEFINE_TEST(test_smaller_app_version)
 {
     int argc(3);
-    const char * argv[3] = {TestVersionCheck_::APP_NAME, TestVersionCheck_::OPTION_VERSION_CHECK,
-                            TestVersionCheck_::OPTION_DEV};
+    const char * argv[3] = {TestVersionCheck_::APP_NAME.c_str(), TestVersionCheck_::OPTION_VERSION_CHECK,
+                            TestVersionCheck_::OPTION_ON};
     String<CharString> stream_result;
     bool app_call_succeeded(false);
-    bool seqan_call_succeeded(false);
 
-    // create version file with a greater version than the current (2.3.4)
-    _createFile(TestVersionCheck_::APP_VERSION_FILENAME.c_str(), "20.5.9");
+    // create version file with equal seqan version and a greater app version than the current (2.3.4)
+    std::string seqan_version = std::to_string(SEQAN_VERSION_MAJOR) + "." +
+                                std::to_string(SEQAN_VERSION_MINOR) + "." +
+                                std::to_string(SEQAN_VERSION_PATCH);
+    std::stringstream version_info;
+    version_info << "20.5.9" << std::endl << seqan_version;
+    _createFile(TestVersionCheck_::APP_VERSION_FILENAME.c_str(), version_info.str());
 
     // create timestamp file that dates one day before current to trigger a message
     _createFile(TestVersionCheck_::APP_TIMESTAMP_FILENAME.c_str(), TestVersionCheck_::TIME_NOW - 86401); // one day = 86400 seconds
 
-    ArgumentParser::ParseResult res = _simulateArgumentParser(stream_result, app_call_succeeded,
-                                                              seqan_call_succeeded, argc, argv);
+    ArgumentParser::ParseResult res = _simulateArgumentParser(stream_result, app_call_succeeded, argc, argv);
 
     SEQAN_ASSERT_EQ(res, ArgumentParser::PARSE_OK);
     SEQAN_ASSERT_EQ(stream_result[0], "");
@@ -305,20 +230,23 @@ SEQAN_DEFINE_TEST(test_smaller_app_version)
 SEQAN_DEFINE_TEST(test_greater_app_version)
 {
     int argc(3);
-    const char * argv[3] = {TestVersionCheck_::APP_NAME, TestVersionCheck_::OPTION_VERSION_CHECK,
-                            TestVersionCheck_::OPTION_DEV};
+    const char * argv[3] = {TestVersionCheck_::APP_NAME.c_str(), TestVersionCheck_::OPTION_VERSION_CHECK,
+                            TestVersionCheck_::OPTION_ON};
     String<CharString> stream_result;
     bool app_call_succeeded(false);
-    bool seqan_call_succeeded(false);
 
-    // create version file with a smaller version than the current (2.3.4)
-    _createFile(TestVersionCheck_::APP_VERSION_FILENAME.c_str(), "1.5.9");
+    // create version file with equal seqan version and a smaller app version than the current (2.3.4)
+    std::string seqan_version = std::to_string(SEQAN_VERSION_MAJOR) + "." +
+                                std::to_string(SEQAN_VERSION_MINOR) + "." +
+                                std::to_string(SEQAN_VERSION_PATCH);
+    std::stringstream version_info;
+    version_info << "1.5.9" << std::endl << seqan_version;
+    _createFile(TestVersionCheck_::APP_VERSION_FILENAME.c_str(), version_info.str());
 
     // create timestamp file that dates one day before current to trigger a message
     _createFile(TestVersionCheck_::APP_TIMESTAMP_FILENAME.c_str(), TestVersionCheck_::TIME_NOW - 86401); // one day = 86400 seconds
  
-    ArgumentParser::ParseResult res = _simulateArgumentParser(stream_result, app_call_succeeded,
-                                                              seqan_call_succeeded, argc, argv);
+    ArgumentParser::ParseResult res = _simulateArgumentParser(stream_result, app_call_succeeded, argc, argv);
 
     SEQAN_ASSERT_EQ(res, ArgumentParser::PARSE_OK);
     SEQAN_ASSERT_EQ(stream_result[0], "");
@@ -328,25 +256,21 @@ SEQAN_DEFINE_TEST(test_greater_app_version)
 SEQAN_DEFINE_TEST(test_time_out)
 {
     int argc(3);
-    const char * argv[3] = {TestVersionCheck_::APP_NAME, TestVersionCheck_::OPTION_VERSION_CHECK,
-                            TestVersionCheck_::OPTION_DEV};
+    const char * argv[3] = {TestVersionCheck_::APP_NAME.c_str(), TestVersionCheck_::OPTION_VERSION_CHECK,
+                            TestVersionCheck_::OPTION_ON};
     String<CharString> stream_result;
     bool app_call_succeeded(false);
-    bool seqan_call_succeeded(false);
 
     // create timestamp files
     _createFile(TestVersionCheck_::APP_TIMESTAMP_FILENAME.c_str(), TestVersionCheck_::TIME_NOW);
-    _createFile(TestVersionCheck_::SEQAN_TIMESTAMP_FILENAME.c_str(), TestVersionCheck_::TIME_NOW);
 
-    ArgumentParser::ParseResult res = _simulateArgumentParser(stream_result, app_call_succeeded,
-                                                              seqan_call_succeeded, argc, argv);
+    ArgumentParser::ParseResult res = _simulateArgumentParser(stream_result, app_call_succeeded, argc, argv);
 
     SEQAN_ASSERT_EQ(res, ArgumentParser::PARSE_OK);
     SEQAN_ASSERT_EQ(stream_result[0], "");
     SEQAN_ASSERT_EQ(stream_result[1], "");
 
     SEQAN_ASSERT(!fileExists(TestVersionCheck_::APP_VERSION_FILENAME.c_str()));
-    SEQAN_ASSERT(!fileExists(TestVersionCheck_::SEQAN_VERSION_FILENAME.c_str()));
 }
 
 } // namespace seqan

--- a/util/cmake/SeqAnBuildSystem.cmake
+++ b/util/cmake/SeqAnBuildSystem.cmake
@@ -222,7 +222,7 @@ macro (seqan_build_system_init)
     # SeqAn Version Check
     if (SEQAN_DISABLE_VERSION_CHECK)  # Disable completely
         set (SEQAN_DEFINITIONS ${SEQAN_DEFINITIONS} -DSEQAN_DISABLE_VERSION_CHECK)
-    elseif (SEQAN_VERSION_CHECK_OPT_IN OR ("${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP"))  # Build it but make it opt-in, also when building in develop mode.
+    elseif (SEQAN_VERSION_CHECK_OPT_IN)  # Build it but make it opt-in.
         set (SEQAN_DEFINITIONS ${SEQAN_DEFINITIONS} -DSEQAN_VERSION_CHECK_OPT_IN)
     endif ()
 


### PR DESCRIPTION
This includes the following changes:
- the version-check option is now a bool and can be turned off/on by specifying off/on/yes/no/1/0...
- The server is only once asked for the current versions of both app and library (result is stored in one app.version file. This might fix #1980 since it could be cause by file handling conflicts of the seqan.version file)
- The command line messages were restricted in the following way:
   - app users will not be notified of new library versions, nor whether the app is not registered
   - app developers (DEBUG mode) will not be notified about "new app versions" they are working on, but only on new library versions and whether they want to register their app to priovide easy version updates for their users