### PR TITLE
[HOTFIX] simdified alignment code

### DIFF
--- a/include/seqan/align/dp_scout_simd.h
+++ b/include/seqan/align/dp_scout_simd.h
@@ -107,10 +107,10 @@ public:
 
     inline void updateMasksBottom()
     {
-        for (auto pos : sortedEndsV)
+        for (auto posIt  = begin(sortedEndsV, Standard()); posIt != end(sortedEndsV, Standard()); ++posIt)
             for (auto it = nextEndsH; it != end(sortedEndsH, Standard()); ++it)
             {
-                masks[pos] |= (masksH[*it] & masksV[pos]);
+                masks[*posIt] |= (masksH[*it] & masksV[*posIt]);
             }
     }
 


### PR DESCRIPTION
icc strikes yet again with mysteriously optimized ranged-based for loops

PS: As hot fix, since we support ICC16 on 2.3.*