### PR TITLE
[FIX] re-add FindSeqAn.cmake as symlink

### DIFF
--- a/util/cmake/FindSeqAn.cmake
+++ b/util/cmake/FindSeqAn.cmake
@@ -1,0 +1,1 @@
+seqan-config.cmake


### PR DESCRIPTION
in the form of a symlink

fixes #1996 