### PR TITLE
[FIX] JST: Unused variable warning in lambda capture.

### DIFF
--- a/include/seqan/journaled_string_tree/journaled_string_tree_impl.h
+++ b/include/seqan/journaled_string_tree/journaled_string_tree_impl.h
@@ -612,6 +612,7 @@ insert(JournaledStringTree<TSequence, TConfig, TSpec> & jst,
     forEach(ids,[&jst, &coverage](TID seqId)
     {
         SEQAN_ASSERT_LT(static_cast<TSize>(seqId), length(jst));  // Check that id is valid.
+        ignoreUnusedVariableWarning(jst);
         coverage[seqId] = true;
     });
 


### PR DESCRIPTION
fixes #2014 