### PR TITLE
FMIndex: removed wrong Size spec for RankDictionary

### DIFF
--- a/include/seqan/index/index_fm_rank_dictionary_levels.h
+++ b/include/seqan/index/index_fm_rank_dictionary_levels.h
@@ -190,16 +190,6 @@ struct RankDictionaryBitsPerBlock_<TValue, Levels<TSpec, TConfig> > :
     BitsPerValue<typename RankDictionaryBlock_<TValue, Levels<TSpec, TConfig> >::Type> {};
 
 // ----------------------------------------------------------------------------
-// Metafunction Size
-// ----------------------------------------------------------------------------
-
-template <typename TValue, typename TSpec, typename TConfig>
-struct Size<RankDictionary<TValue, Levels<TSpec, TConfig> > >
-{
-    typedef typename Size<TConfig>::Type Type;
-};
-
-// ----------------------------------------------------------------------------
 // Metafunction RankDictionaryBlockSize_
 // ----------------------------------------------------------------------------
 


### PR DESCRIPTION
Note that ```Size<TConfig>``` was default type size...