### PR TITLE
CMake fixes

### DIFF
--- a/apps/alf/CMakeLists.txt
+++ b/apps/alf/CMakeLists.txt
@@ -56,7 +56,7 @@ endif (NOT SEQAN_PREFIX_SHARE_DOC)
 
 # Install alf in ${PREFIX}/bin directory
 install (TARGETS alf
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/alf for SeqAn release builds.

--- a/apps/bs_tools/CMakeLists.txt
+++ b/apps/bs_tools/CMakeLists.txt
@@ -99,7 +99,7 @@ endif (NOT SEQAN_PREFIX_SHARE_DOC)
 
 # Install bs_tools in ${PREFIX}/bin directory
 install (TARGETS bisar casbar four2three
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/bs_tools for SeqAn release builds.

--- a/apps/dfi/CMakeLists.txt
+++ b/apps/dfi/CMakeLists.txt
@@ -56,7 +56,7 @@ endif (NOT SEQAN_PREFIX_SHARE_DOC)
 
 # Install dfi in ${PREFIX}/bin directory
 install (TARGETS dfi
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/dfi for SeqAn release builds.

--- a/apps/fiona/CMakeLists.txt
+++ b/apps/fiona/CMakeLists.txt
@@ -83,7 +83,7 @@ if (NOT SEQAN_PREFIX_SHARE_DOC)
 endif (NOT SEQAN_PREFIX_SHARE_DOC)
 
 # Install fiona in ${PREFIX}/bin directory
-install (TARGETS fiona compute_gain DESTINATION bin)
+install (TARGETS fiona compute_gain DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/fiona for SeqAn release builds.

--- a/apps/fx_tools/CMakeLists.txt
+++ b/apps/fx_tools/CMakeLists.txt
@@ -55,7 +55,7 @@ endif (NOT SEQAN_PREFIX_SHARE_DOC)
 
 # Install fx_tools in ${PREFIX}/bin directory
 install (TARGETS fx_bam_coverage
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/fx_tools for SeqAn release builds.

--- a/apps/gustaf/CMakeLists.txt
+++ b/apps/gustaf/CMakeLists.txt
@@ -77,7 +77,7 @@ endif (NOT SEQAN_PREFIX_SHARE_DOC)
 
 # Install gustaf in ${PREFIX}/bin directory
 install (TARGETS gustaf gustaf_mate_joining
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/gustaf for SeqAn release builds.

--- a/apps/insegt/CMakeLists.txt
+++ b/apps/insegt/CMakeLists.txt
@@ -61,7 +61,7 @@ endif (NOT SEQAN_PREFIX_SHARE_DOC)
 
 # Install insegt in ${PREFIX}/bin directory
 install (TARGETS insegt
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/insegt for SeqAn release builds.

--- a/apps/mason2/CMakeLists.txt
+++ b/apps/mason2/CMakeLists.txt
@@ -143,7 +143,7 @@ install (TARGETS mason_frag_sequencing
                  mason_simulator
                  mason_splicing
                  mason_variator
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/mason2 for SeqAn release builds.

--- a/apps/micro_razers/CMakeLists.txt
+++ b/apps/micro_razers/CMakeLists.txt
@@ -62,7 +62,7 @@ endif (NOT SEQAN_PREFIX_SHARE_DOC)
 
 # Install micro_razers in ${PREFIX}/bin directory
 install (TARGETS micro_razers
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/micro_razers for SeqAn release builds.

--- a/apps/ngs_roi/CMakeLists.txt
+++ b/apps/ngs_roi/CMakeLists.txt
@@ -72,7 +72,7 @@ endif (NOT SEQAN_PREFIX_SHARE_DOC)
 install (TARGETS bam2roi
                  roi_feature_projection
                  roi_plot_thumbnails
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install helper scripts into ${PREFIX}/bin directory.
 install (FILES # Scripts for sorting.
@@ -83,7 +83,7 @@ install (FILES # Scripts for sorting.
                  tool_shed/roi_plot_9.sh
                  tool_shed/plot.awk
                  tool_shed/ps2pswLinks.gawk
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/ngs_roi for SeqAn release builds.

--- a/apps/pair_align/CMakeLists.txt
+++ b/apps/pair_align/CMakeLists.txt
@@ -60,7 +60,7 @@ endif (NOT SEQAN_PREFIX_SHARE_DOC)
 
 # Install pair_align in ${PREFIX}/bin directory
 install (TARGETS pair_align
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/pair_align for SeqAn release builds.

--- a/apps/param_chooser/CMakeLists.txt
+++ b/apps/param_chooser/CMakeLists.txt
@@ -62,7 +62,7 @@ endif (NOT SEQAN_PREFIX_SHARE_DOC)
 
 # Install param_chooser in ${PREFIX}/bin directory
 install (TARGETS param_chooser
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/param_chooser for SeqAn release builds.

--- a/apps/rabema/CMakeLists.txt
+++ b/apps/rabema/CMakeLists.txt
@@ -91,11 +91,11 @@ endif (NOT SEQAN_PREFIX_SHARE_DOC)
 install (TARGETS rabema_prepare_sam
                  rabema_build_gold_standard
                  rabema_evaluate
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install rabema in /bin directory
 install (TARGETS rabema_prepare_sam rabema_build_gold_standard rabema_evaluate
-        DESTINATION bin)
+        DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/pair_align for SeqAn release builds.

--- a/apps/razers/CMakeLists.txt
+++ b/apps/razers/CMakeLists.txt
@@ -66,7 +66,7 @@ endif (NOT SEQAN_PREFIX_SHARE_DOC)
 
 # Install razers in ${PREFIX}/bin directory
 install (TARGETS razers
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/razers for SeqAn release builds.

--- a/apps/razers3/CMakeLists.txt
+++ b/apps/razers3/CMakeLists.txt
@@ -92,7 +92,7 @@ endif (NOT SEQAN_PREFIX_SHARE_DOC)
 
 # Install razers3 in ${PREFIX}/bin directory
 install (TARGETS razers3
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/razers3 for SeqAn release builds.

--- a/apps/rep_sep/CMakeLists.txt
+++ b/apps/rep_sep/CMakeLists.txt
@@ -64,7 +64,7 @@ endif (NOT SEQAN_PREFIX_SHARE_DOC)
 
 # Install rep_sep in ${PREFIX}/bin directory
 install (TARGETS rep_sep
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/rep_sep for SeqAn release builds.

--- a/apps/sak/CMakeLists.txt
+++ b/apps/sak/CMakeLists.txt
@@ -68,7 +68,7 @@ endif (NOT SEQAN_PREFIX_SHARE_DOC)
 
 # Install sak in ${PREFIX}/bin directory
 install (TARGETS sak
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/sak for SeqAn release builds.
@@ -77,7 +77,7 @@ install (FILES LICENSE
                ${CMAKE_CURRENT_BINARY_DIR}/README.sak.txt
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 install (FILES ${CMAKE_CURRENT_BINARY_DIR}/sak.1
-         DESTINATION ${SEQAN_PREFIX_SHARE_DOC}/man)
+         DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
 
 # ----------------------------------------------------------------------------
 # App Test

--- a/apps/sam2matrix/CMakeLists.txt
+++ b/apps/sam2matrix/CMakeLists.txt
@@ -56,7 +56,7 @@ endif (NOT SEQAN_PREFIX_SHARE_DOC)
 
 # Install sam2matrix in ${PREFIX}/bin directory
 install (TARGETS sam2matrix
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/sam2matrix for SeqAn release builds.

--- a/apps/samcat/CMakeLists.txt
+++ b/apps/samcat/CMakeLists.txt
@@ -58,7 +58,7 @@ endif (NOT SEQAN_PREFIX_SHARE_DOC)
 
 # Install samcat in ${PREFIX}/bin directory
 install (TARGETS samcat
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/samcat for SeqAn release builds.

--- a/apps/searchjoin/CMakeLists.txt
+++ b/apps/searchjoin/CMakeLists.txt
@@ -66,7 +66,7 @@ endif (NOT SEQAN_PREFIX_SHARE_DOC)
 
 # Install searchjoin in ${PREFIX}/bin directory
 install (TARGETS s4_search s4_join
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/searchjoin for SeqAn release builds.

--- a/apps/seqan_tcoffee/CMakeLists.txt
+++ b/apps/seqan_tcoffee/CMakeLists.txt
@@ -56,7 +56,7 @@ endif (NOT SEQAN_PREFIX_SHARE_DOC)
 
 # Install seqan_tcoffee in ${PREFIX}/bin directory
 install (TARGETS seqan_tcoffee
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/seqan_tcoffee for SeqAn release builds.

--- a/apps/seqcons2/CMakeLists.txt
+++ b/apps/seqcons2/CMakeLists.txt
@@ -62,7 +62,7 @@ endif (NOT SEQAN_PREFIX_SHARE_DOC)
 
 # Install seqcons2 in ${PREFIX}/bin directory
 install (TARGETS seqcons2
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/seqcons2 for SeqAn release builds.

--- a/apps/sgip/CMakeLists.txt
+++ b/apps/sgip/CMakeLists.txt
@@ -56,7 +56,7 @@ endif (NOT SEQAN_PREFIX_SHARE_DOC)
 
 # Install sgip in ${PREFIX}/bin directory
 install (TARGETS sgip
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/sgip for SeqAn release builds.

--- a/apps/snp_store/CMakeLists.txt
+++ b/apps/snp_store/CMakeLists.txt
@@ -71,7 +71,7 @@ endif (NOT SEQAN_PREFIX_SHARE_DOC)
 
 # Install snp_store in ${PREFIX}/bin directory
 install (TARGETS snp_store
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/snp_store for SeqAn release builds.

--- a/apps/splazers/CMakeLists.txt
+++ b/apps/splazers/CMakeLists.txt
@@ -68,7 +68,7 @@ endif (NOT SEQAN_PREFIX_SHARE_DOC)
 
 # Install splazers in ${PREFIX}/bin directory
 install (TARGETS splazers
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/splazers for SeqAn release builds.

--- a/apps/stellar/CMakeLists.txt
+++ b/apps/stellar/CMakeLists.txt
@@ -60,7 +60,7 @@ endif (NOT SEQAN_PREFIX_SHARE_DOC)
 
 # Install stellar in ${PREFIX}/bin directory
 install (TARGETS stellar
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/stellar for SeqAn release builds.

--- a/apps/tree_recon/CMakeLists.txt
+++ b/apps/tree_recon/CMakeLists.txt
@@ -56,7 +56,7 @@ endif (NOT SEQAN_PREFIX_SHARE_DOC)
 
 # Install tree_recon in ${PREFIX}/bin directory
 install (TARGETS tree_recon
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/tree_recon for SeqAn release builds.

--- a/apps/yara/CMakeLists.txt
+++ b/apps/yara/CMakeLists.txt
@@ -136,7 +136,7 @@ endif (NOT SEQAN_PREFIX_SHARE_DOC)
 
 # Install yara in ${PREFIX}/bin directory
 install (TARGETS yara_indexer yara_mapper
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/yara for SeqAn release builds.

--- a/dox/CMakeLists.txt
+++ b/dox/CMakeLists.txt
@@ -77,5 +77,5 @@ if (${SEQAN_BUILD_SYSTEM} MATCHES "SEQAN_RELEASE_LIBRARY") # includes SEQAN_RELE
         --out-dir ${CMAKE_BINARY_DIR}/dox/html)
 
     install (DIRECTORY ${CMAKE_BINARY_DIR}/dox/html
-             DESTINATION share/doc/seqan)
+             DESTINATION ${CMAKE_INSTALL_DOCDIR})
 endif ()

--- a/util/cmake/SeqAnBuildSystem.cmake
+++ b/util/cmake/SeqAnBuildSystem.cmake
@@ -200,7 +200,7 @@ macro (seqan_build_system_init)
         # TODO(h-2): raise this to W4
         set (SEQAN_CXX_FLAGS "${SEQAN_CXX_FLAGS} /W3")
     else()
-        set (SEQAN_CXX_FLAGS "${SEQAN_CXX_FLAGS} -W -Wall -pedantic -fstrict-aliasing -Wstrict-aliasing")
+        set (SEQAN_CXX_FLAGS "${SEQAN_CXX_FLAGS} -W -Wall -pedantic")
         set (SEQAN_DEFINITIONS ${SEQAN_DEFINITIONS} -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64)
 
         # disable some warnings on ICC

--- a/util/cmake/SeqAnBuildSystem.cmake
+++ b/util/cmake/SeqAnBuildSystem.cmake
@@ -47,6 +47,12 @@
 include (SeqAnUsabilityAnalyzer)
 include (CheckCXXCompilerFlag)
 
+if (DEFINED CMAKE_INSTALL_DOCDIR)
+    set(CMAKE_INSTALL_DOCDIR_IS_SET ON)
+endif ()
+
+include (GNUInstallDirs)
+
 set (COMPILER_CLANG FALSE)
 set (COMPILER_GCC FALSE)
 set (COMPILER_LINTEL FALSE)
@@ -383,24 +389,24 @@ macro (seqan_setup_library)
         install (FILES LICENSE
                        README.rst
                        CHANGELOG.rst
-                 DESTINATION share/doc/seqan)
+                 DESTINATION ${CMAKE_INSTALL_DOCDIR})
         # Install pkg-config file, except on Windows.
         if (NOT CMAKE_SYSTEM_NAME MATCHES Windows)
             configure_file("util/pkgconfig/seqan.pc.in" "${CMAKE_BINARY_DIR}/util/pkgconfig/seqan-${SEQAN_VERSION_MAJOR}.pc" @ONLY)
-            install(FILES "${CMAKE_BINARY_DIR}/util/pkgconfig/seqan-${SEQAN_VERSION_MAJOR}.pc" DESTINATION lib/pkgconfig)
+            install(FILES "${CMAKE_BINARY_DIR}/util/pkgconfig/seqan-${SEQAN_VERSION_MAJOR}.pc" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig)
         endif (NOT CMAKE_SYSTEM_NAME MATCHES Windows)
         # Install FindSeqAn TODO(h-2) rename seqan-config.cmake to seqan-config${SEQAN_VERSION_MAJOR}.cmake after 2.x cycle
-        install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/util/cmake/seqan-config.cmake" DESTINATION lib/cmake/seqan/)
+        install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/util/cmake/seqan-config.cmake" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/cmake/seqan/)
 
         # Install headers
         file (GLOB HEADERS
-              RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+              RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/include/
               include/seqan/[A-z]*/[A-z]/[A-z]*.h
               include/seqan/[A-z]*/[A-z]*.h
               include/seqan/[A-z]*.h)
         foreach (HEADER ${HEADERS})
             get_filename_component (_DESTINATION ${HEADER} PATH)
-            install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/${HEADER} DESTINATION ${_DESTINATION})
+            install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/include/${HEADER} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${_DESTINATION})
         endforeach ()
     endif ()
 
@@ -457,8 +463,11 @@ macro (seqan_setup_install_vars APP_NAME)
         set (SEQAN_PREFIX_SHARE ".")
         set (SEQAN_PREFIX_SHARE_DOC ".")
     else ()
-        set (SEQAN_PREFIX_SHARE "share/${APP_NAME}")
-        set (SEQAN_PREFIX_SHARE_DOC "share/doc/${APP_NAME}")
+        if (NOT DEFINED CMAKE_INSTALL_DOCDIR_IS_SET)
+            set (CMAKE_INSTALL_DOCDIR "${CMAKE_INSTALL_DATAROOTDIR}/doc" CACHE STRING "Documentation root (DATAROOTDIR/doc)" FORCE)
+        endif ()
+        set (SEQAN_PREFIX_SHARE "${CMAKE_INSTALL_DATADIR}/${APP_NAME}")
+        set (SEQAN_PREFIX_SHARE_DOC "${CMAKE_INSTALL_DOCDIR}/${APP_NAME}")
     endif ()
 endmacro (seqan_setup_install_vars)
 

--- a/util/pkgconfig/seqan.pc.in
+++ b/util/pkgconfig/seqan.pc.in
@@ -1,6 +1,4 @@
-prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=${prefix}
-includedir=${prefix}/include
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: @CMAKE_PROJECT_NAME@
 Description: C++ library for biological sequence analysis

--- a/util/skel/app_template/CMakeLists.txt
+++ b/util/skel/app_template/CMakeLists.txt
@@ -48,7 +48,7 @@ endif (NOT SEQAN_PREFIX_SHARE_DOC)
 
 # Install %(NAME)s in ${PREFIX}/bin directory
 install (TARGETS %(NAME)s
-         DESTINATION bin)
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/%(NAME)s for SeqAn release builds.


### PR DESCRIPTION
**[FEATURE] Use GNUInstallDirs to allow changing target directories**

* `GNUInstallDirs` allows for changing all target directories, which makes parallel installations of SeqAn a lot easier.
* Simplify the `includedir` specification in the `.pc` file.
* Nest all applications' documentation in the seqan docdir, as this prevents pollution of the global docdir and keeps seqan apps together. This can be changed by using `CMAKE_INSTALL_DOCDIR`.
* Install man page into global mandir, as `man` will not find it otherwise.
* Install CMake support file and `.pc` file into arch-independent `CMAKE_INSTALL_DATAROOTDIR`.

**[FIX] Remove code generation flags**

* `-fstrict-aliasing` should not be added to `CXXFLAGS` unconditionally, as it is already implied by `-O2` and `-O3`. When compiling with `-O0`, no code generation affecting flags should be added to the compile line.
  See also:
    https://gcc.gnu.org/onlinedocs/gcc-6.3.0/gcc/Optimize-Options.html#index-O2-707
    
* `-Wstrict-aliasing` is completely unnecessary, as it is implied by -Wall.
  See also:
    https://gcc.gnu.org/onlinedocs/gcc-6.3.0/gcc/Warning-Options.html#index-Wall-304