### PR TITLE
Fixes simd related errors on dash-board

### DIFF
--- a/include/seqan/score.h
+++ b/include/seqan/score.h
@@ -38,6 +38,7 @@
 #define SEQAN_SH_
 
 #include <seqan/basic.h>
+#include <seqan/simd.h>
 
 #include <seqan/stream.h>
 

--- a/include/seqan/simd.h
+++ b/include/seqan/simd.h
@@ -87,8 +87,10 @@
 
 // Define maximal size of vector in byte.
 #if defined(SEQAN_SEQANSIMD_ENABLED) && defined(__AVX512F__)
+    #if !(defined(NDEBUG) || defined(SEQAN_ENABLE_TESTING))
     #pragma message("SEQAN_SIMD doesn't support AVX512, thus falling back to AVX2 " \
                     "(we are using some back ported instruction for AVX2 which where introduced since AVX512)")
+    #endif
     #define SEQAN_SIZEOF_MAX_VECTOR 32
 #elif defined(__AVX512F__)
     #define SEQAN_SIZEOF_MAX_VECTOR 64

--- a/include/seqan/simd.h
+++ b/include/seqan/simd.h
@@ -60,6 +60,16 @@
     #undef SEQAN_UMESIMD_ENABLED
 #endif
 
+// SIMD operations make only sense on modern 64bit architectures.
+#if SEQAN_IS_32_BIT
+    #if !(defined(NDEBUG) || defined(SEQAN_ENABLE_TESTING))
+    #pragma message("SIMD acceleration is only available on 64bit systems")
+    #endif
+    #undef SEQAN_SIMD_ENABLED
+    #undef SEQAN_SEQANSIMD_ENABLED
+    #undef SEQAN_UMESIMD_ENABLED
+#endif
+
 // Fallback to seqan's simd implementation if nothing was specified.
 #if defined(SEQAN_SIMD_ENABLED) && !defined(SEQAN_UMESIMD_ENABLED) && !defined(SEQAN_SEQANSIMD_ENABLED)
     #define SEQAN_SEQANSIMD_ENABLED

--- a/include/seqan/simd.h
+++ b/include/seqan/simd.h
@@ -62,13 +62,14 @@
 
 // SIMD operations make only sense on modern 64bit architectures.
 #if SEQAN_IS_32_BIT
+    // TODO(marehr): If we switch to jenkins, filter out these warnings
     #if !(defined(NDEBUG) || defined(SEQAN_ENABLE_TESTING))
-    #pragma message("SIMD acceleration is only available on 64bit systems")
+        #pragma message("SIMD acceleration is only available on 64bit systems")
     #endif
     #undef SEQAN_SIMD_ENABLED
     #undef SEQAN_SEQANSIMD_ENABLED
     #undef SEQAN_UMESIMD_ENABLED
-#endif
+#endif // SEQAN_IS_32_BIT
 
 // Fallback to seqan's simd implementation if nothing was specified.
 #if defined(SEQAN_SIMD_ENABLED) && !defined(SEQAN_UMESIMD_ENABLED) && !defined(SEQAN_SEQANSIMD_ENABLED)
@@ -87,9 +88,10 @@
 
 // Define maximal size of vector in byte.
 #if defined(SEQAN_SEQANSIMD_ENABLED) && defined(__AVX512F__)
+    // TODO(marehr): If we switch to jenkins, filter out these warnings
     #if !(defined(NDEBUG) || defined(SEQAN_ENABLE_TESTING))
-    #pragma message("SEQAN_SIMD doesn't support AVX512, thus falling back to AVX2 " \
-                    "(we are using some back ported instruction for AVX2 which where introduced since AVX512)")
+        #pragma message("SEQAN_SIMD doesn't support AVX512, thus falling back to AVX2 " \
+                        "(we are using some back ported instruction for AVX2 which where introduced since AVX512)")
     #endif
     #define SEQAN_SIZEOF_MAX_VECTOR 32
 #elif defined(__AVX512F__)

--- a/util/cmake/SeqAnBuildSystem.cmake
+++ b/util/cmake/SeqAnBuildSystem.cmake
@@ -268,7 +268,7 @@ macro (seqan_build_system_init)
             set (SEQAN_CXX_FLAGS "${SEQAN_CXX_FLAGS} -ipo -no-prec-div -fp-model fast=2 -xHOST")
         endif ()
     elseif (SEQAN_ARCH_SSE4)
-        include (SeqanSimdUtility)
+        include (SeqAnSimdUtility)
 
         if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
             set (SEQAN_CXX_FLAGS "${SEQAN_CXX_FLAGS} -mpopcnt")

--- a/util/cmake/SeqAnSimdUtility.cmake
+++ b/util/cmake/SeqAnSimdUtility.cmake
@@ -398,6 +398,13 @@ macro(add_simd_platform_tests target)
         set(seqansimd_compile_blacklist "${SEQAN_SIMD_SUPPORTED_EXTENSIONS}")
     endif()
 
+    if(COMPILER_GCC AND DEFINED ENV{TRAVIS} AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0.0)
+        # Disable avx2 on travis, because sometimes gcc 5.x and 6.x crashes
+        set(seqansimd_compile_blacklist "${seqansimd_compile_blacklist};avx2")
+        set(umesimd_compile_blacklist "${umesimd_compile_blacklist};avx2")
+        message(STATUS "Disabling avx2 on travis, because gcc<=6.x crashes occasionally")
+    endif()
+
     # This checks if a simple avx2 program builds
     set(CMAKE_REQUIRED_FLAGS "${SEQAN_SIMD_AVX2_OPTIONS}")
     check_cxx_source_compiles("${SEQAN_SIMD_AVX2_SOURCE}" AVX2_SOURCE_COMPILES)

--- a/util/cmake/SeqAnSimdUtility.cmake
+++ b/util/cmake/SeqAnSimdUtility.cmake
@@ -264,6 +264,20 @@ macro(add_simd_platform_tests target)
         set(seqansimd_compile_blacklist "avx2;avx512_knl;avx512_skx;avx512_cnl")
     endif()
 
+    if (COMPILER_CLANG AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
+        if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.0.1)
+            message(STATUS "Clang 4.0.0 crashes for AVX512_skx (seqan-simd only), see https://llvm.org/bugs/show_bug.cgi?id=31731")
+            set(umesimd_compile_blacklist "")
+            set(seqansimd_compile_blacklist "avx512_skx;avx512_cnl")
+        endif()
+
+        if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.0.0)
+            message(AUTHOR_WARNING "Clang >=4.0.1 reevaluate if AVX512_skx (seqan-simd only) binaries are working.")
+            set(umesimd_compile_blacklist "")
+            set(seqansimd_compile_blacklist "")
+        endif()
+    endif()
+
     # Build the executables, but don't execute them, because clang <= 3.9.x
     # produces executables which contain invalid instructions for AVX512.
     if (COMPILER_CLANG AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.0)

--- a/util/cmake/SeqAnSimdUtility.cmake
+++ b/util/cmake/SeqAnSimdUtility.cmake
@@ -88,6 +88,7 @@
 #         (e.g. sse4, avx2, avx512_knl, avx512_skx, avx512_cnl)
 #
 
+find_package (SeqAn CONFIG REQUIRED)
 find_package (SDE)
 find_package (Umesimd)
 

--- a/util/cmake/SeqAnSimdUtility.cmake
+++ b/util/cmake/SeqAnSimdUtility.cmake
@@ -378,6 +378,13 @@ macro(add_simd_platform_tests target)
         message(STATUS "Your compiler doesn't support avx512")
     endif()
 
+    # don't use simd on 32bit architectures at all
+    if (CMAKE_SIZEOF_VOID_P EQUAL 4)
+        set(seqansimd_compile_blacklist "${SEQAN_SIMD_SUPPORTED_EXTENSIONS}")
+        set(umesimd_compile_blacklist "${SEQAN_SIMD_SUPPORTED_EXTENSIONS}")
+        message(STATUS "SIMD acceleration is only available on 64bit systems")
+    endif()
+
     add_simd_executables("${target}" "${seqansimd_compile_blacklist}")
     add_simd_tests("${target}" "${seqansimd_test_blacklist}")
 

--- a/util/cmake/SeqAnSimdUtility.cmake
+++ b/util/cmake/SeqAnSimdUtility.cmake
@@ -306,6 +306,14 @@ macro(add_simd_platform_tests target)
         set(umesimd_compile_blacklist "avx512_knl;avx512_skx;avx512_cnl")
         set(seqansimd_compile_blacklist "avx512_knl;avx512_skx;avx512_cnl")
 
+        ## seqan-simd:
+        # avx2: clang 3.7.x fails test cases:
+        #       SimdVectorTestCommon_ShuffleConstant1 type parameter (un-)signed char __vector(32) FAILED
+        #       SimdVectorTestCommon_ShuffleConstant1 type parameter (un-)signed short __vector(16) FAILED
+        if (NOT (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.6) AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.8)
+            set(seqansimd_compile_blacklist "avx2;${seqansimd_compile_blacklist}")
+        endif()
+
         if (STDLIB_VS)
             ## ume-simd:
             # avx2: Also, it can't handle avx2 on windows, because some

--- a/util/cmake/SeqAnSimdUtility.cmake
+++ b/util/cmake/SeqAnSimdUtility.cmake
@@ -324,7 +324,7 @@ macro(add_simd_platform_tests target)
         # avx2: clang 3.7.x fails test cases:
         #       SimdVectorTestCommon_ShuffleConstant1 type parameter (un-)signed char __vector(32) FAILED
         #       SimdVectorTestCommon_ShuffleConstant1 type parameter (un-)signed short __vector(16) FAILED
-        if (NOT (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.6) AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.8)
+        if (NOT (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.6) AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.8))
             set(seqansimd_compile_blacklist "avx2;${seqansimd_compile_blacklist}")
         endif()
 


### PR DESCRIPTION
Changes:
* Disable 32bit simd builds (one half of the errors)
* Hide performance warnings when testing or when NDEBUG is defined
* Disable clang3.7 avx2 seqan-simd builds. It generates wrong shuffle code.
* Disable clang4.0 avx512_skx and avx512_cnl seqan-simd builds. The compiler crashes.
* Fix not working -DSEQAN_ARCH_SSE4=1
* Massive errors on darwin (on this machine SEQAN_ARCH_SSE4 was defined and showed a missing simd.h include)

Still open:
* Icpc-17 errors in the alignment code