### PR TITLE
Add BGZF_NUM_THREADS

### DIFF
--- a/include/seqan/stream/iostream_bgzf.h
+++ b/include/seqan/stream/iostream_bgzf.h
@@ -20,6 +20,10 @@
 #ifndef INCLUDE_SEQAN_STREAM_IOSTREAM_BGZF_H_
 #define INCLUDE_SEQAN_STREAM_IOSTREAM_BGZF_H_
 
+#ifndef SEQAN_BGZF_NUM_THREADS
+#define SEQAN_BGZF_NUM_THREADS 16
+#endif
+
 namespace seqan {
 
 const unsigned BGZF_MAX_BLOCK_SIZE = 64 * 1024;
@@ -146,7 +150,7 @@ public:
     std::vector<TFuture>         threads;
 
     basic_bgzf_streambuf(ostream_reference ostream_,
-                         size_t numThreads = 16,
+                         size_t numThreads = SEQAN_BGZF_NUM_THREADS,
                          size_t jobsPerThread = 8) :
         numThreads(numThreads),
         numJobs(numThreads * jobsPerThread),
@@ -494,7 +498,7 @@ public:
     TBuffer              putbackBuffer;
 
     basic_unbgzf_streambuf(istream_reference istream_,
-                           size_t numThreads = 16,
+                           size_t numThreads = SEQAN_BGZF_NUM_THREADS,
                            size_t jobsPerThread = 8) :
         serializer(istream_),
         numThreads(numThreads),

--- a/manual/source/Infrastructure/Use/CustomBuildSystem.rst
+++ b/manual/source/Infrastructure/Use/CustomBuildSystem.rst
@@ -211,6 +211,21 @@ meaning
 usage
  add compiler flag: ``-DSEQAN_DISABLE_VERSION_CHECK`` 
 
+SEQAN_BGZF_NUM_THREADS
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+possible value
+ positive integer
+
+default
+ 16
+
+meaning
+ Number of threads to use for BGZF I/O.
+
+usage
+ add compiler flag: ``-DSEQAN_BGZF_NUM_THREADS=value`` 
+
 Settings Projects Using Seqan
 -----------------------------
 


### PR DESCRIPTION
See #1899 for my remarks on the potential trouble with spawning a hardcoded number of threads.

My understanding is that it is unlikely that a consistent mechanism for developers to control how many threads seqan will use for what will be implemented in 2.x.

This patch provides at least compile time control to devs writing applications against seqan for BAM I/O.