### PR TITLE
Improvement of DP code

### DIFF
--- a/apps/bs_tools/casbar_score.h
+++ b/apps/bs_tools/casbar_score.h
@@ -363,16 +363,17 @@ sequenceEntryForScore(Score<TScoreValue, BsTagList<TBsProfileScore, TModel, TCel
 // Modify to use different scoring function at first and last row
 // (end gaps score different)
 // Computes the score and tracks it if enabled.
-template <typename TDPScout, typename TTraceMatrixNavigator, typename TScoreValue, typename TGapCosts,
-          typename TSequenceHValue, typename TSequenceVValue, typename TBsProfileScore, typename TModel, typename TCellDescriptor2, typename TColumnDescriptor,
+template <typename TDPScout, typename TTraceMatrixNavigator,
+          typename TCellTuple,
+          typename TSequenceHValue,
+          typename TSequenceVValue,
+          typename TScoreValue, typename TBsProfileScore, typename TModel, typename TCellDescriptor2,
+          typename TColumnDescriptor,
           typename TDPProfile>
 inline void
 _computeCell(TDPScout & scout,
              TTraceMatrixNavigator & traceMatrixNavigator,
-             DPCell_<TScoreValue, TGapCosts> & activeCell,
-             DPCell_<TScoreValue, TGapCosts> const & previousDiagonal,
-             DPCell_<TScoreValue, TGapCosts> const & previousHorizontal,
-             DPCell_<TScoreValue, TGapCosts> const & previousVertical,
+             TCellTuple recursionCells,
              TSequenceHValue const & seqHVal,
              TSequenceVValue const & seqVVal,
              Score<TScoreValue, BsTagList<TBsProfileScore, TModel, TCellDescriptor2> > const & scoringScheme,
@@ -385,7 +386,7 @@ _computeCell(TDPScout & scout,
 
     Score<TScoreValue, BsTagList<TBsProfileScore, TModel, FirstCell> > scoringSchemeDummy(scoringScheme);
     assignValue(traceMatrixNavigator,
-                _computeScore(activeCell, previousDiagonal, previousHorizontal, previousVertical, seqHVal, seqVVal,
+                _computeScore(recursionCells, seqHVal, seqVVal,
                               scoringSchemeDummy, typename RecursionDirection_<TMetaColumn, TCellDescriptor>::Type(),
                               TDPProfile()));
 //	std::cout << "("<< activeCell._score << "," << previousDiagonal._score << "," << previousHorizontal._score << "," << previousVertical._score << ") ";
@@ -395,23 +396,24 @@ _computeCell(TDPScout & scout,
         bool isLastRow = And<IsSameType<TCellDescriptor, LastCell>,
                              Or<IsSameType<typename TColumnDescriptor::TLocation, PartialColumnBottom>,
                                 IsSameType<typename TColumnDescriptor::TLocation, FullColumn> > >::VALUE;
-        _scoutBestScore(scout, activeCell, traceMatrixNavigator, isLastColumn, isLastRow);
+        _scoutBestScore(scout, std::get<0>(recursionCells), traceMatrixNavigator, isLastColumn, isLastRow);
     }
 }
 
 // Modify to use different scoring function at first and last row
 // (end gaps score different)
 // Computes the score and tracks it if enabled.
-template <typename TDPScout, typename TTraceMatrixNavigator, typename TScoreValue, typename TGapCosts,
-          typename TSequenceHValue, typename TSequenceVValue, typename TBsProfileScore, typename TModel, typename TCellDescriptor2, typename TColumnDescriptor,
+template <typename TDPScout, typename TTraceMatrixNavigator,
+          typename TCellTuple,
+          typename TSequenceHValue,
+          typename TSequenceVValue,
+          typename TScoreValue, typename TBsProfileScore, typename TModel, typename TCellDescriptor2,
+          typename TColumnDescriptor,
           typename TDPProfile>
 inline void
 _computeCell(TDPScout & scout,
              TTraceMatrixNavigator & traceMatrixNavigator,
-             DPCell_<TScoreValue, TGapCosts> & activeCell,
-             DPCell_<TScoreValue, TGapCosts> const & previousDiagonal,
-             DPCell_<TScoreValue, TGapCosts> const & previousHorizontal,
-             DPCell_<TScoreValue, TGapCosts> const & previousVertical,
+             TCellTuple recursionCells,
              TSequenceHValue const & seqHVal,
              TSequenceVValue const & seqVVal,
              Score<TScoreValue, BsTagList<TBsProfileScore, TModel, TCellDescriptor2> > const & scoringScheme,
@@ -424,7 +426,7 @@ _computeCell(TDPScout & scout,
 
     Score<TScoreValue, BsTagList<TBsProfileScore, TModel, LastCell> > scoringSchemeDummy(scoringScheme);
     assignValue(traceMatrixNavigator,
-                _computeScore(activeCell, previousDiagonal, previousHorizontal, previousVertical, seqHVal, seqVVal,
+                _computeScore(recursionCells, seqHVal, seqVVal,
                               scoringSchemeDummy, typename RecursionDirection_<TMetaColumn, TCellDescriptor>::Type(),
                               TDPProfile()));
 //	std::cout << "("<< activeCell._score << "," << previousDiagonal._score << "," << previousHorizontal._score << "," << previousVertical._score << ") ";
@@ -434,7 +436,7 @@ _computeCell(TDPScout & scout,
         bool isLastRow = And<IsSameType<TCellDescriptor, LastCell>,
                              Or<IsSameType<typename TColumnDescriptor::TLocation, PartialColumnBottom>,
                                 IsSameType<typename TColumnDescriptor::TLocation, FullColumn> > >::VALUE;
-        _scoutBestScore(scout, activeCell, traceMatrixNavigator, isLastColumn, isLastRow);
+        _scoutBestScore(scout, std::get<0>(recursionCells), traceMatrixNavigator, isLastColumn, isLastRow);
     }
 }
 

--- a/include/seqan/align/dp_algorithm_impl.h
+++ b/include/seqan/align/dp_algorithm_impl.h
@@ -272,16 +272,15 @@ _isBandEnabled(DPBandConfig<TBandSpec> const & /*band*/)
 // ----------------------------------------------------------------------------
 
 // Computes the score and tracks it if enabled.
-template <typename TDPScout, typename TTraceMatrixNavigator, typename TScoreValue, typename TGapCosts,
+template <typename TDPScout,
+          typename TTraceMatrixNavigator,
+          typename TRecursionCellTuple,
           typename TSequenceHValue, typename TSequenceVValue, typename TScoringScheme, typename TColumnDescriptor,
           typename TCellDescriptor, typename TDPProfile>
 inline void
 _computeCell(TDPScout & scout,
              TTraceMatrixNavigator & traceMatrixNavigator,
-             DPCell_<TScoreValue, TGapCosts> & activeCell,
-             DPCell_<TScoreValue, TGapCosts> const & previousDiagonal,
-             DPCell_<TScoreValue, TGapCosts> const & previousHorizontal,
-             DPCell_<TScoreValue, TGapCosts> const & previousVertical,
+             TRecursionCellTuple recursionCells,
              TSequenceHValue const & seqHVal,
              TSequenceVValue const & seqVVal,
              TScoringScheme const & scoringScheme,
@@ -291,15 +290,15 @@ _computeCell(TDPScout & scout,
 {
     typedef DPMetaColumn_<TDPProfile, TColumnDescriptor> TMetaColumn;
     assignValue(traceMatrixNavigator,
-                _computeScore(activeCell, previousDiagonal, previousHorizontal, previousVertical, seqHVal, seqVVal,
-                              scoringScheme, typename RecursionDirection_<TMetaColumn, TCellDescriptor>::Type(),
+                _computeScore(recursionCells, seqHVal, seqVVal, scoringScheme,
+                              typename RecursionDirection_<TMetaColumn, TCellDescriptor>::Type(),
                               TDPProfile()));
 
     if (TrackingEnabled_<TMetaColumn, TCellDescriptor>::VALUE)
     {
         typedef typename LastColumnEnabled_<TDPProfile, TColumnDescriptor>::Type TIsLastColumn;
         typedef typename LastRowEnabled_<TDPProfile, TCellDescriptor, TColumnDescriptor>::Type TIsLastRow;
-        _scoutBestScore(scout, activeCell, traceMatrixNavigator,
+        _scoutBestScore(scout, std::get<0>(recursionCells), traceMatrixNavigator,
                         TIsLastColumn(), TIsLastRow());
     }
 }
@@ -338,6 +337,14 @@ _computeTrack(TDPScout & scout,
               TColumnDescriptor const &,
               TDPProfile const &)
 {
+    using TDPScoreValue = std::decay_t<decltype(value(dpScoreMatrixNavigator))>;
+    // Caching these cells improves performance significantly.
+    TDPScoreValue prevDiag;
+    TDPScoreValue prevHori;
+    TDPScoreValue prevVert;
+
+    setCachedCells(dpScoreMatrixNavigator, prevDiag, prevHori, prevVert);
+
     // Set the iterator to the begin of the track.
     _goNextCell(dpScoreMatrixNavigator, TColumnDescriptor(), FirstCell());
     _goNextCell(dpTraceMatrixNavigator, TColumnDescriptor(), FirstCell());
@@ -349,13 +356,20 @@ _computeTrack(TDPScout & scout,
     _preInitScoutVertical(scout);
 
     // Compute the first cell.
-    _computeCell(scout, dpTraceMatrixNavigator, value(dpScoreMatrixNavigator),
-                 previousCellDiagonal(dpScoreMatrixNavigator), previousCellHorizontal(dpScoreMatrixNavigator),
-                 previousCellVertical(dpScoreMatrixNavigator), tmpSeqH, seqVValue, scoringScheme,
+    _computeCell(scout,
+                 dpTraceMatrixNavigator,
+                 std::forward_as_tuple(value(dpScoreMatrixNavigator),
+                                       previousCellDiagonal(dpScoreMatrixNavigator),
+                                       previousCellHorizontal(dpScoreMatrixNavigator),
+                                       previousCellVertical(dpScoreMatrixNavigator)),
+                 tmpSeqH,
+                 seqVValue,
+                 scoringScheme,
                  TColumnDescriptor(), FirstCell(), TDPProfile());
 
     TSeqVIterator iter = seqBegin;
     TSeqVIterator itEnd = (seqEnd - 1);
+
     // Compute the inner cells of the current track.
     for (; iter != itEnd; ++iter)
     {
@@ -367,19 +381,29 @@ _computeTrack(TDPScout & scout,
         // For all other cases, the function returns always false.
         if (SEQAN_UNLIKELY(_reachedVerticalEndPoint(scout, iter)))
         {
-            _computeCell(scout, dpTraceMatrixNavigator, value(dpScoreMatrixNavigator),
-                         previousCellDiagonal(dpScoreMatrixNavigator), previousCellHorizontal(dpScoreMatrixNavigator),
-                         previousCellVertical(dpScoreMatrixNavigator), tmpSeqH,
-                         sequenceEntryForScore(scoringScheme, container(iter), position(iter)), scoringScheme,
+            _computeCell(scout,
+                         dpTraceMatrixNavigator,
+                         std::forward_as_tuple(value(dpScoreMatrixNavigator),
+                                               previousCellDiagonal(dpScoreMatrixNavigator),
+                                               previousCellHorizontal(dpScoreMatrixNavigator),
+                                               previousCellVertical(dpScoreMatrixNavigator)),
+                         tmpSeqH,
+                         sequenceEntryForScore(scoringScheme, container(iter), position(iter)),
+                         scoringScheme,
                          TColumnDescriptor(), LastCell(), TDPProfile());
             _nextVerticalEndPos(scout);
         }
         else
         {
-            _computeCell(scout, dpTraceMatrixNavigator, value(dpScoreMatrixNavigator),
-                         previousCellDiagonal(dpScoreMatrixNavigator), previousCellHorizontal(dpScoreMatrixNavigator),
-                         previousCellVertical(dpScoreMatrixNavigator), tmpSeqH,
-                         sequenceEntryForScore(scoringScheme, container(iter), position(iter)), scoringScheme,
+            _computeCell(scout,
+                         dpTraceMatrixNavigator,
+                         std::forward_as_tuple(value(dpScoreMatrixNavigator),
+                                               previousCellDiagonal(dpScoreMatrixNavigator),
+                                               previousCellHorizontal(dpScoreMatrixNavigator),
+                                               previousCellVertical(dpScoreMatrixNavigator)),
+                         tmpSeqH,
+                         sequenceEntryForScore(scoringScheme, container(iter), position(iter)),
+                         scoringScheme,
                          TColumnDescriptor(), InnerCell(), TDPProfile());
         }
         _incVerticalPos(scout);
@@ -388,10 +412,15 @@ _computeTrack(TDPScout & scout,
     _goNextCell(dpScoreMatrixNavigator, TColumnDescriptor(), LastCell());
     _goNextCell(dpTraceMatrixNavigator, TColumnDescriptor(), LastCell());
     // Compute the last cell.
-    _computeCell(scout, dpTraceMatrixNavigator, value(dpScoreMatrixNavigator),
-                 previousCellDiagonal(dpScoreMatrixNavigator), previousCellHorizontal(dpScoreMatrixNavigator),
-                 previousCellVertical(dpScoreMatrixNavigator), tmpSeqH,
-                 sequenceEntryForScore(scoringScheme, container(iter), position(iter)), scoringScheme,
+    _computeCell(scout,
+                 dpTraceMatrixNavigator,
+                 std::forward_as_tuple(value(dpScoreMatrixNavigator),
+                                       previousCellDiagonal(dpScoreMatrixNavigator),
+                                       previousCellHorizontal(dpScoreMatrixNavigator),
+                                       previousCellVertical(dpScoreMatrixNavigator)),
+                 tmpSeqH,
+                 sequenceEntryForScore(scoringScheme, container(iter), position(iter)),
+                 scoringScheme,
                  TColumnDescriptor(), LastCell(), TDPProfile());
 }
 
@@ -418,16 +447,24 @@ _computeAlignmentHelperCheckTerminate(DPScout_<TDPCell,Terminator_<TSpec> > cons
 // ----------------------------------------------------------------------------
 
 // Computes the standard DP-algorithm.
-template <typename TDPScout, typename TDPScoreMatrixNavigator, typename TDPTraceMatrixNavigator, typename TSequenceH,
-          typename TSequenceV, typename TScoringScheme, typename TAlignmentAlgo, typename TGapCosts, typename TTraceFlag>
+template <typename TDPScout,
+          typename TDPScoreMatrixNavigator,
+          typename TDPTraceMatrixNavigator,
+          typename TSequenceH,
+          typename TSequenceV,
+          typename TScoringScheme,
+          typename TBand,
+          typename TAlignmentAlgo, typename TGapCosts, typename TTraceFlag>
 inline void
-_computeUnbandedAlignment(TDPScout & scout,
-                          TDPScoreMatrixNavigator & dpScoreMatrixNavigator,
-                          TDPTraceMatrixNavigator & dpTraceMatrixNavigator,
-                          TSequenceH const & seqH,
-                          TSequenceV const & seqV,
-                          TScoringScheme const & scoringScheme,
-                          DPProfile_<TAlignmentAlgo, TGapCosts, TTraceFlag> const & dpProfile)
+_computeAlignmentImpl(TDPScout & scout,
+                      TDPScoreMatrixNavigator & dpScoreMatrixNavigator,
+                      TDPTraceMatrixNavigator & dpTraceMatrixNavigator,
+                      TSequenceH const & seqH,
+                      TSequenceV const & seqV,
+                      TScoringScheme const & scoringScheme,
+                      TBand const & /*band*/,
+                      DPProfile_<TAlignmentAlgo, TGapCosts, TTraceFlag> const & dpProfile,
+                      NavigateColumnWise const & /*tag*/)
 {
     typedef typename Iterator<TSequenceH const, Rooted>::Type TConstSeqHIterator;
     typedef typename Iterator<TSequenceV const, Rooted>::Type TConstSeqVIterator;
@@ -504,22 +541,28 @@ _computeUnbandedAlignment(TDPScout & scout,
 }
 
 // ----------------------------------------------------------------------------
-// Function _computeBandedAlignment()
+// Function _computeAlignment() banded
 // ----------------------------------------------------------------------------
 
 // Computes the banded DP-algorithm.
-template <typename TDPScout, typename TDPScoreMatrixNavigator, typename TDPTraceMatrixNavigator, typename TSequenceH,
-          typename TSequenceV, typename TScoringScheme, typename TBand, typename TAlignmentAlgo, typename TGapCosts,
-          typename TTraceFlag>
+template <typename TDPScout,
+          typename TDPScoreMatrixNavigator,
+          typename TDPTraceMatrixNavigator,
+          typename TSequenceH,
+          typename TSequenceV,
+          typename TScoringScheme,
+          typename TBand,
+          typename TAlignmentAlgo, typename TGapCosts, typename TTraceFlag>
 inline void
-_computeBandedAlignment(TDPScout & scout,
-                        TDPScoreMatrixNavigator & dpScoreMatrixNavigator,
-                        TDPTraceMatrixNavigator & dpTraceMatrixNavigator,
-                        TSequenceH const & seqH,
-                        TSequenceV const & seqV,
-                        TScoringScheme const & scoringScheme,
-                        TBand const & band,
-                        DPProfile_<TAlignmentAlgo, TGapCosts, TTraceFlag> const & dpProfile)
+_computeAlignmentImpl(TDPScout & scout,
+                      TDPScoreMatrixNavigator & dpScoreMatrixNavigator,
+                      TDPTraceMatrixNavigator & dpTraceMatrixNavigator,
+                      TSequenceH const & seqH,
+                      TSequenceV const & seqV,
+                      TScoringScheme const & scoringScheme,
+                      TBand const & band,
+                      DPProfile_<TAlignmentAlgo, TGapCosts, TTraceFlag> const & dpProfile,
+                      NavigateColumnWiseBanded const & /*tag*/)
 {
     typedef DPProfile_<TAlignmentAlgo, TGapCosts, TTraceFlag> TDPProfile;
     typedef typename MakeSigned<typename Size<TSequenceH>::Type>::Type TSignedSizeSeqH;
@@ -527,7 +570,20 @@ _computeBandedAlignment(TDPScout & scout,
     typedef typename Iterator<TSequenceH const, Rooted>::Type TConstSeqHIterator;
     typedef typename Iterator<TSequenceV const, Rooted>::Type TConstSeqVIterator;
 
+    using TDPScoreValue = std::decay_t<decltype(value(dpScoreMatrixNavigator))>;
+    // Caching these cells improves performance significantly.
+    TDPScoreValue prevDiag;
+    TDPScoreValue prevHori;
+    TDPScoreValue prevVert;
 
+    setCachedCells(dpScoreMatrixNavigator, prevDiag, prevHori, prevVert);
+
+    if (upperDiagonal(band) == lowerDiagonal(band))
+    {
+        _computeHammingDistance(scout, dpScoreMatrixNavigator, dpTraceMatrixNavigator, seqH, seqV, scoringScheme, band,
+                                dpProfile);
+        return;
+    }
     // Now we have the problem of not knowing when we are in the last cell.
 
     // ============================================================================
@@ -568,9 +624,9 @@ _computeBandedAlignment(TDPScout & scout,
         _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), FirstCell());
         _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), FirstCell());
         // Only one cell
-        _computeCell(scout, dpTraceMatrixNavigator, value(dpScoreMatrixNavigator),
+        _computeCell(scout, dpTraceMatrixNavigator, std::forward_as_tuple(value(dpScoreMatrixNavigator),
                      previousCellDiagonal(dpScoreMatrixNavigator), previousCellHorizontal(dpScoreMatrixNavigator),
-                     previousCellVertical(dpScoreMatrixNavigator),
+                     previousCellVertical(dpScoreMatrixNavigator)),
                      sequenceEntryForScore(scoringScheme, seqH, position(seqHIterBegin)),
                      sequenceEntryForScore(scoringScheme, seqV, 0), scoringScheme,
                      MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), FirstCell(), TDPProfile());
@@ -585,9 +641,9 @@ _computeBandedAlignment(TDPScout & scout,
         _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom>(), FirstCell());
         _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom>(), FirstCell());
         // Only one cell
-        _computeCell(scout, dpTraceMatrixNavigator, value(dpScoreMatrixNavigator),
+        _computeCell(scout, dpTraceMatrixNavigator, std::forward_as_tuple(value(dpScoreMatrixNavigator),
                      previousCellDiagonal(dpScoreMatrixNavigator), previousCellHorizontal(dpScoreMatrixNavigator),
-                     previousCellVertical(dpScoreMatrixNavigator),
+                     previousCellVertical(dpScoreMatrixNavigator)),
                      sequenceEntryForScore(scoringScheme, seqH, 0),
                      sequenceEntryForScore(scoringScheme, seqV, position(seqVBegin)), scoringScheme,
                      MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom>(), FirstCell(), TDPProfile());
@@ -619,9 +675,9 @@ _computeBandedAlignment(TDPScout & scout,
         _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), FirstCell());
         _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), FirstCell());
         // Should we not just compute the cell?
-        _computeCell(scout, dpTraceMatrixNavigator, value(dpScoreMatrixNavigator),
+        _computeCell(scout, dpTraceMatrixNavigator, std::forward_as_tuple(value(dpScoreMatrixNavigator),
                      previousCellDiagonal(dpScoreMatrixNavigator), previousCellHorizontal(dpScoreMatrixNavigator),
-                     previousCellVertical(dpScoreMatrixNavigator),
+                     previousCellVertical(dpScoreMatrixNavigator)),
                      sequenceEntryForScore(scoringScheme, seqH, position(seqHIterBegin)),
                      sequenceEntryForScore(scoringScheme, seqV, 0),
                      scoringScheme,
@@ -631,19 +687,24 @@ _computeBandedAlignment(TDPScout & scout,
             _scoutBestScore(scout, value(dpScoreMatrixNavigator), dpTraceMatrixNavigator, False(), False());
     }
     else  // Upper diagonal >= 0 and lower Diagonal < 0
-    if (lowerDiagonal(band) <= -seqVlength)      // The band is bounded by the top and bottom of the matrix.
-        _computeTrack(scout, dpScoreMatrixNavigator, dpTraceMatrixNavigator,
-                      sequenceEntryForScore(scoringScheme, seqH, 0),
-                      sequenceEntryForScore(scoringScheme, seqV, 0),
-                      seqVBegin, seqVEnd, scoringScheme,
-                      MetaColumnDescriptor<DPInitialColumn, FullColumn>(), dpProfile);
-    else       // The band is bounded by the top but not the bottom of the matrix.
-        _computeTrack(scout, dpScoreMatrixNavigator, dpTraceMatrixNavigator,
-                      sequenceEntryForScore(scoringScheme, seqH, 0),
-                      sequenceEntryForScore(scoringScheme, seqV, 0),
-                      seqVBegin, seqVEnd, scoringScheme,
-                      MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), dpProfile);
-
+    {
+        if (lowerDiagonal(band) <= -seqVlength)      // The band is bounded by the top and bottom of the matrix.
+        {
+            _computeTrack(scout, dpScoreMatrixNavigator, dpTraceMatrixNavigator,
+                          sequenceEntryForScore(scoringScheme, seqH, 0),
+                          sequenceEntryForScore(scoringScheme, seqV, 0),
+                          seqVBegin, seqVEnd, scoringScheme,
+                          MetaColumnDescriptor<DPInitialColumn, FullColumn>(), dpProfile);
+        }
+        else       // The band is bounded by the top but not the bottom of the matrix.
+        {
+            _computeTrack(scout, dpScoreMatrixNavigator, dpTraceMatrixNavigator,
+                          sequenceEntryForScore(scoringScheme, seqH, 0),
+                          sequenceEntryForScore(scoringScheme, seqV, 0),
+                          seqVBegin, seqVEnd, scoringScheme,
+                          MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), dpProfile);
+        }
+    }
     if (_computeAlignmentHelperCheckTerminate(scout))
     {
             return;
@@ -736,6 +797,8 @@ _computeBandedAlignment(TDPScout & scout,
     // POSTPROCESSING
     // ============================================================================
 
+    setCachedCells(dpScoreMatrixNavigator, prevDiag, prevHori, prevVert);
+
     // Check where the last track of the column is located.
     if (seqHIter - begin(seqH, Rooted()) < seqHlength - 1)  // Case 1: The band ends before the final column is reached.
     {
@@ -743,9 +806,9 @@ _computeBandedAlignment(TDPScout & scout,
         _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnBottom>(), FirstCell());
         _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnBottom>(), FirstCell());
 
-        _computeCell(scout, dpTraceMatrixNavigator, value(dpScoreMatrixNavigator),
+        _computeCell(scout, dpTraceMatrixNavigator, std::forward_as_tuple(value(dpScoreMatrixNavigator),
                      previousCellDiagonal(dpScoreMatrixNavigator), previousCellHorizontal(dpScoreMatrixNavigator),
-                     previousCellVertical(dpScoreMatrixNavigator),
+                     previousCellVertical(dpScoreMatrixNavigator)),
                      sequenceEntryForScore(scoringScheme, seqH, position(seqHIter)),
                      sequenceEntryForScore(scoringScheme, seqV, position(seqVBegin)),
                      scoringScheme,
@@ -763,9 +826,9 @@ _computeBandedAlignment(TDPScout & scout,
             _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnBottom>(), FirstCell());
             _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnBottom>(), FirstCell());
 
-            _computeCell(scout, dpTraceMatrixNavigator, value(dpScoreMatrixNavigator),
+            _computeCell(scout, dpTraceMatrixNavigator, std::forward_as_tuple(value(dpScoreMatrixNavigator),
                          previousCellDiagonal(dpScoreMatrixNavigator), previousCellHorizontal(dpScoreMatrixNavigator),
-                         previousCellVertical(dpScoreMatrixNavigator),
+                         previousCellVertical(dpScoreMatrixNavigator)),
                          sequenceEntryForScore(scoringScheme, seqH, position(seqHIter)),
                          sequenceEntryForScore(scoringScheme, seqV, position(seqVBegin)),
                          scoringScheme,
@@ -843,325 +906,10 @@ _computeBandedAlignment(TDPScout & scout,
                                   seqVBegin, seqVEnd, scoringScheme,
                                   MetaColumnDescriptor<DPFinalColumn, PartialColumnMiddle>(), dpProfile);
                 }
-
             }
         }
     }
 }
-
-// TODO(rmaerker): This is denbug code only.
-//template <typename TDPScout, typename TDPScoreMatrixNavigator, typename TDPTraceMatrixNavigator, typename TSequenceH,
-//    typename TSequenceV, typename TScoringScheme, typename TBand, typename TAlignmentAlgo, typename TGapCosts,
-//    typename TTraceFlag>
-//inline void
-//_debugBandedAlignment(TDPScout & scout,
-//                        TDPScoreMatrixNavigator & dpScoreMatrixNavigator,
-//                        TDPTraceMatrixNavigator & dpTraceMatrixNavigator,
-//                        TSequenceH const & seqH,
-//                        TSequenceV const & seqV,
-//                        TScoringScheme const & scoringScheme,
-//                        TBand const & band,
-//                        DPProfile_<TAlignmentAlgo, TGapCosts, TTraceFlag> const & dpProfile)
-//{
-//    typedef DPProfile_<TAlignmentAlgo, TGapCosts, TTraceFlag> TDPProfile;
-//    typedef typename Value<TSequenceH>::Type TSeqHValue;
-//    typedef typename Value<TSequenceV>::Type TSeqVValue;
-//    typedef typename Iterator<TSequenceH const, Standard>::Type TConstSeqHIterator;
-//    typedef typename Iterator<TSequenceV const, Standard>::Type TConstSeqVIterator;
-//
-//
-//    String<std::string> testMatrix;
-//    resize(testMatrix, (length(seqH) + 1) * (length(seqV)+1));
-//    // Now we have the problem of not knowing when we are in the last cell.
-//
-//    // INITIALIZATION
-//    TConstSeqVIterator seqVBegin = begin(seqV, Standard()) - _min(0, 1+upperDiagonal(band));
-//    TConstSeqVIterator seqVEnd = begin(seqV, Standard()) - _min(0, _max(-static_cast<int>(length(seqV)), lowerDiagonal(band)));
-//
-////    std::cout << "Begin Pos: " << seqVBegin - begin(seqV) << "\n";
-////    std::cout << "End Pos: " << seqVEnd - begin(seqV) << "\n";
-//
-//    // We have to distinguish two band sizes. Some which spans the whole matrix in between and thus who not.
-//    // This can be distinguished, if UpperDiagonal > length(seqV) + LowerDiagonal
-//
-//    // We start at the least at the first sequence or wherever the lower diagonal begins first.
-//    TConstSeqHIterator seqHIterBegin = begin(seqH, Standard()) + _max(0, _min(static_cast<int>(length(seqH) - 1), lowerDiagonal(band)));
-//    // TODO(rmaerker): Cehck if this assertion is correct.
-////    SEQAN_ASSERT_NEQ(seqHIterBegin, end(seqH, Standard()));  // The iterator never points to the end of the horizontal sequence.
-//
-//    // The horizontal initial phase ends after the upper diagonal but at most after the horizontal sequence, or there is no horizontal initialization phase.
-//    TConstSeqHIterator seqHIterEndColumnTop = begin(seqH, Standard()) + _min(static_cast<int>(length(seqH))-1, _max(0, upperDiagonal(band)));
-//
-//    // The middle band phase ends after the lower diagonal crosses the bottom of the alignment matrix or after the horizontal sequence if it is smaller.
-//    TConstSeqHIterator seqHIterEndColumnMiddle = begin(seqH, Standard()) + _min(static_cast<int>(length(seqH))-1, _max(0,static_cast<int>(length(seqV)) + lowerDiagonal(band)));
-//    // Swap the two iterators if we are in a band that spans over the full column.
-//    if (upperDiagonal(band) > static_cast<int>(length(seqV)) + lowerDiagonal(band))
-//        std::swap(seqHIterEndColumnTop, seqHIterEndColumnMiddle);
-//
-//    // The bottom band phase ends after the upper diagonal of the band crosses the bottom of the matrix or after the horizontal sequence if it is smaller.
-//    TConstSeqHIterator seqHIterEndColumnBottom = begin(seqH, Standard()) + _max(0, _min(static_cast<int>(length(seqH)),
-//                                                 upperDiagonal(band) + static_cast<int>(length(seqV))) -1);
-//
-////    std::cout << "seqHIterBegin Pos H: " << seqHIterBegin - begin(seqH) << "\n";
-////    std::cout << "seqHIterEndColumnTop Pos H: " << seqHIterEndColumnTop - begin(seqH) << "\n";
-////    std::cout << "seqHIterEndColumnMiddle Pos H: " << seqHIterEndColumnMiddle - begin(seqH) << "\n";
-////    std::cout << "seqHIterEndColumnBottom Pos H: " << seqHIterEndColumnBottom - begin(seqH) << "\n";
-////
-////    std::cout << "_activeColIterator Pos: " << dpScoreMatrixNavigator._activeColIterator - begin(*dpScoreMatrixNavigator._ptrDataContainer) << "\n";
-////    std::cout << "_prevColIterator Pos: " << dpScoreMatrixNavigator._prevColIterator - begin(*dpScoreMatrixNavigator._ptrDataContainer) << "\n";
-//
-//    // The Initial column can be PartialColumnTop which is given if the upper diagonal is >= 0,
-//    // otherwise it only can be PartialColumnMiddle or PartialColumnBottom depending where the lower diagonal is.
-//
-//    // Have to check for single initialization cells in InitialColumn and FinalColumn.
-//    if (seqHIterBegin == end(seqH)-1)
-//    {
-//        // Set the iterator to the begin of the track.
-//        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), FirstCell());
-//        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), FirstCell());
-//        // Only one cell
-//        _computeCell(scout, dpTraceMatrixNavigator, value(dpScoreMatrixNavigator),
-//                previousCellDiagonal(dpScoreMatrixNavigator), previousCellHorizontal(dpScoreMatrixNavigator),
-//                previousCellVertical(dpScoreMatrixNavigator), value(seqHIterBegin), TSeqVValue(), scoringScheme,
-//                MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), FirstCell(), TDPProfile());
-////      std::cout << _scoreOfCell(value(dpScoreMatrixNavigator)) << "\n";
-//      std::stringstream stream;
-//      stream << _scoreOfCell(value(dpScoreMatrixNavigator));
-//      testMatrix[length(seqH) * length(seqV)] = stream.str();
-//        // we might need to additionally track this point.
-//        if (TrackingEnabled_<DPMetaColumn_<TDPProfile, MetaColumnDescriptor<DPFinalColumn, PartialColumnTop> >, FirstCell>::VALUE)
-//            _scoutBestScore(scout, _scoreOfCell(value(dpScoreMatrixNavigator)), dpTraceMatrixNavigator);
-//        return;
-//    }
-//    if (seqHIterEndColumnBottom == begin(seqH))
-//    {
-//        // Set the iterator to the begin of the track.
-//        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom>(), FirstCell());
-//        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom>(), FirstCell());
-//        // Only one cell
-//        _computeCell(scout, dpTraceMatrixNavigator, value(dpScoreMatrixNavigator),
-//                previousCellDiagonal(dpScoreMatrixNavigator), previousCellHorizontal(dpScoreMatrixNavigator),
-//                previousCellVertical(dpScoreMatrixNavigator), TSeqHValue(), value(seqVBegin), scoringScheme,
-//                MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom>(), FirstCell(), TDPProfile());
-////      std::cout << _scoreOfCell(value(dpScoreMatrixNavigator)) << "\n";
-//      std::stringstream stream;
-//      stream << _scoreOfCell(value(dpScoreMatrixNavigator));
-//      testMatrix[length(seqH) * length(seqV)] = stream.str();
-//        // We might need to additionally track this point.
-//        if (TrackingEnabled_<DPMetaColumn_<TDPProfile, MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom> >, LastCell>::VALUE)
-//            _scoutBestScore(scout, _scoreOfCell(value(dpScoreMatrixNavigator)), dpTraceMatrixNavigator);
-//        return;
-//    }
-//
-//    if (upperDiagonal(band) < 0)
-//    {
-//        ++seqVBegin;
-//        if (lowerDiagonal(band) > -static_cast<int>(length(seqV)))
-//          _computeTrack(scout, dpScoreMatrixNavigator, dpTraceMatrixNavigator,
-//                  TSeqHValue(), value(seqVBegin-1), seqVBegin, seqVEnd, scoringScheme,
-//                  MetaColumnDescriptor<DPInitialColumn, PartialColumnMiddle>(), dpProfile, 0, seqVBegin - begin(seqV) + 1, testMatrix);
-//        else
-//          _computeTrack(scout, dpScoreMatrixNavigator, dpTraceMatrixNavigator,
-//                  TSeqHValue(), value(seqVBegin-1), seqVBegin, seqVEnd, scoringScheme,
-//                  MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom>(), dpProfile, 0, seqVBegin - begin(seqV) + 1, testMatrix);
-//    }
-//    else if (lowerDiagonal(band) >= 0)
-//    {
-//        // Set the iterator to the begin of the track.
-//        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), FirstCell());
-//        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), FirstCell());
-//        // Should we not just compute the cell?
-//        _computeCell(scout, dpTraceMatrixNavigator, value(dpScoreMatrixNavigator),
-//                previousCellDiagonal(dpScoreMatrixNavigator), previousCellHorizontal(dpScoreMatrixNavigator),
-//                previousCellVertical(dpScoreMatrixNavigator), value(seqHIterBegin), TSeqVValue(), scoringScheme,
-//                MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), FirstCell(), TDPProfile());
-//        // we might need to additionally track this point.
-////      std::cout << _scoreOfCell(value(dpScoreMatrixNavigator)) << "\n";
-//      int col = lowerDiagonal(band);
-//      std::stringstream stream;
-//      stream << _scoreOfCell(value(dpScoreMatrixNavigator));
-//      testMatrix[col * (length(seqV) + 1)] = stream.str();
-//        if (TrackingEnabled_<DPMetaColumn_<TDPProfile, MetaColumnDescriptor<DPInnerColumn, PartialColumnTop> >, FirstCell>::VALUE)
-//            _scoutBestScore(scout, _scoreOfCell(value(dpScoreMatrixNavigator)), dpTraceMatrixNavigator);
-//    }
-//    else  // Upper diagonal >= 0 and lower Diagonal < 0
-//        if (lowerDiagonal(band) <= -static_cast<int>(length(seqV)))  // The band is bounded by the top and bottom of the matrix.
-//          _computeTrack(scout, dpScoreMatrixNavigator, dpTraceMatrixNavigator,
-//                  TSeqHValue(), TSeqVValue(), seqVBegin, seqVEnd, scoringScheme,
-//                  MetaColumnDescriptor<DPInitialColumn, FullColumn>(), dpProfile, 0, 0, testMatrix);
-//        else   // The band is bounded by the top but not the bottom of the matrix.
-//          _computeTrack(scout, dpScoreMatrixNavigator, dpTraceMatrixNavigator,
-//                  TSeqHValue(), TSeqVValue(), seqVBegin, seqVEnd, scoringScheme,
-//                  MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), dpProfile, 0,0, testMatrix);
-//
-//
-//    // RECURSION
-//    TConstSeqHIterator seqHIter = seqHIterBegin;
-//    // Compute the first part of the band, where the band is bounded by the top but not by the bottom of the matrix.
-//    for (;seqHIter != seqHIterEndColumnTop; ++seqHIter)
-//    {
-////      std::cout << value(seqHIter) << ":\t";
-//        ++seqVEnd;
-//      _computeTrack(scout, dpScoreMatrixNavigator, dpTraceMatrixNavigator,
-//              value(seqHIter), TSeqVValue(), seqVBegin, seqVEnd, scoringScheme,
-//              MetaColumnDescriptor<DPInnerColumn, PartialColumnTop>(), dpProfile, ((seqHIter - begin(seqH)) + 1)*(length(seqV) +1), 0, testMatrix);
-//    }
-//
-//    // Check whether the band spans over the full column or not at some point.
-//    if (upperDiagonal(band) > static_cast<int>(length(seqV)) + lowerDiagonal(band))
-//    {
-//        // Compute the second part of the band, where the band is bounded by the top and the bottom of the matrix.
-//        // We might want to track the current cell here, since this is the first cell that crosses the bottom.
-//        // TODO(rmaerker): We have to check if the initial column/ row can be tracked!!!
-//        if (TrackingEnabled_<DPMetaColumn_<TDPProfile, MetaColumnDescriptor<DPInnerColumn, FullColumn> >, LastCell>::VALUE)
-//                _scoutBestScore(scout, _scoreOfCell(value(dpScoreMatrixNavigator)), dpTraceMatrixNavigator);
-//        for (;seqHIter != seqHIterEndColumnMiddle; ++seqHIter)
-//        {
-//          _computeTrack(scout, dpScoreMatrixNavigator, dpTraceMatrixNavigator,
-//                  value(seqHIter), TSeqVValue(), seqVBegin, seqVEnd, scoringScheme,
-//                  MetaColumnDescriptor<DPInnerColumn, FullColumn>(), dpProfile, (seqHIter - begin(seqH) + 1) * (length(seqV) + 1), 0, testMatrix);
-//        }
-//    }
-//    else // Compute the second part of the band, where the band is not bounded by the top and bottom of the matrix
-//    {
-//        for (;seqHIter != seqHIterEndColumnMiddle; ++seqHIter)
-//        {
-//            ++seqVBegin;
-//            ++seqVEnd;
-//          _computeTrack(scout, dpScoreMatrixNavigator, dpTraceMatrixNavigator,
-//                  value(seqHIter), value(seqVBegin-1), seqVBegin, seqVEnd, scoringScheme,
-//                  MetaColumnDescriptor<DPInnerColumn, PartialColumnMiddle>(), dpProfile, (seqHIter - begin(seqH) +1) * (length(seqV)+1), seqVBegin - begin(seqV), testMatrix);
-//        }   // We might want to track the current cell here, since this is the first cell that crosses the bottom.
-//        if (TrackingEnabled_<DPMetaColumn_<TDPProfile, MetaColumnDescriptor<DPInnerColumn, PartialColumnBottom> >, LastCell>::VALUE)
-//        {
-//            // TODO(rmaerker): This is only a hot fix.
-//            if (lowerDiagonal(band) + length(seqV) < length(seqH))
-//                _scoutBestScore(scout, _scoreOfCell(value(dpScoreMatrixNavigator)), dpTraceMatrixNavigator);
-//        }
-//    }
-//    // Compute the third part of the band, where the band, is bounded by the bottom but not by the top of the matrix.
-//    for (;seqHIter != seqHIterEndColumnBottom; ++seqHIter)
-//    {
-//        ++seqVBegin;
-//      _computeTrack(scout, dpScoreMatrixNavigator, dpTraceMatrixNavigator,
-//              value(seqHIter), value(seqVBegin-1), seqVBegin, seqVEnd, scoringScheme,
-//              MetaColumnDescriptor<DPInnerColumn, PartialColumnBottom>(), dpProfile, (seqHIter - begin(seqH) + 1) * (length(seqV) + 1), seqVBegin - begin(seqV), testMatrix);
-//    }
-//
-//    // Where ends the last cell?
-//    if(seqHIter - begin(seqH) < static_cast<int>(length(seqH))-1)  // Case 1: The band ends before the final column is reached.
-//    {
-//        // Set the iterator to the begin of the track.
-//        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnBottom>(), FirstCell());
-//        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnBottom>(), FirstCell());
-//
-//        _computeCell(scout, dpTraceMatrixNavigator, value(dpScoreMatrixNavigator),
-//                previousCellDiagonal(dpScoreMatrixNavigator), previousCellHorizontal(dpScoreMatrixNavigator),
-//                previousCellVertical(dpScoreMatrixNavigator), value(seqHIter), value(seqVBegin), scoringScheme,
-//                MetaColumnDescriptor<DPInnerColumn, PartialColumnBottom>(), FirstCell(), TDPProfile());
-////      std::cout << _scoreOfCell(value(dpScoreMatrixNavigator)) << "\n";
-//      std::stringstream stream;
-//      stream << _scoreOfCell(value(dpScoreMatrixNavigator));
-//      testMatrix[(seqHIter - begin(seqH) + 1) * (length(seqV) + 1) + length(seqV)] = stream.str();
-//        // We might need to additionally track this point.
-//        if (TrackingEnabled_<DPMetaColumn_<TDPProfile, MetaColumnDescriptor<DPInnerColumn, PartialColumnBottom> >, LastCell>::VALUE)
-//            _scoutBestScore(scout, _scoreOfCell(value(dpScoreMatrixNavigator)), dpTraceMatrixNavigator);
-//    }
-//    else if(seqHIter == end(seqH)-1)  // Case 2: The band ends somewhere in the final column of the matrix.
-//    {
-//        if (upperDiagonal(band) == static_cast<int>(length(seqH))-static_cast<int>(length(seqV)))  // Case2a: The band ends in the last cell of the final column.  // He should be here....
-//        {
-//            // Set the iterator to the begin of the track.
-//            _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnBottom>(), FirstCell());
-//            _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnBottom>(), FirstCell());
-//
-//            _computeCell(scout, dpTraceMatrixNavigator, value(dpScoreMatrixNavigator),
-//                    previousCellDiagonal(dpScoreMatrixNavigator), previousCellHorizontal(dpScoreMatrixNavigator),
-//                    previousCellVertical(dpScoreMatrixNavigator), value(seqHIter), value(seqVBegin), scoringScheme,
-//                    MetaColumnDescriptor<DPFinalColumn, PartialColumnBottom>(), FirstCell(), TDPProfile());
-////          std::cout << _scoreOfCell(value(dpScoreMatrixNavigator)) << "\n";
-//          std::stringstream stream;
-//          stream << _scoreOfCell(value(dpScoreMatrixNavigator));
-//          testMatrix[(length(seqH) * (length(seqV) + 1)) + length(seqV)] = stream.str();
-//            // we might need to additionally track this point.
-//            if (TrackingEnabled_<DPMetaColumn_<TDPProfile, MetaColumnDescriptor<DPFinalColumn, PartialColumnBottom> >, LastCell>::VALUE)
-//                _scoutBestScore(scout, _scoreOfCell(value(dpScoreMatrixNavigator)), dpTraceMatrixNavigator);
-//        }
-//        else  // Case2b: At least two cells intersect between the band and the matrix in the final column of the matrix.
-//        {
-//            if (upperDiagonal(band) >= static_cast<int>(length(seqH)))  // The band is bounded by the top of the matrix only or by the top and the bottom.
-//            {
-//                if (lowerDiagonal(band) + static_cast<int>(length(seqV)) > static_cast<int>(length(seqH))) // The band is bounded by the top of the matrix
-//                {
-//                    ++seqVEnd;
-//                  _computeTrack(scout, dpScoreMatrixNavigator, dpTraceMatrixNavigator,
-//                          value(seqHIter), TSeqVValue(), seqVBegin, seqVEnd, scoringScheme,
-//                          MetaColumnDescriptor<DPFinalColumn, PartialColumnTop>(), dpProfile, length(seqH) * (length(seqV) + 1), 0, testMatrix);
-//                }
-//                else  // The band is bounded by the top and the bottom of the matrix.
-//                {
-//                    if (lowerDiagonal(band) + static_cast<int>(length(seqV)) + 1 > static_cast<int>(length(seqH)) )
-//                    {
-//                        ++seqVEnd;
-//                      _computeTrack(scout, dpScoreMatrixNavigator, dpTraceMatrixNavigator,
-//                              value(seqHIter), TSeqVValue(), seqVBegin, seqVEnd, scoringScheme,
-//                              MetaColumnDescriptor<DPFinalColumn, PartialColumnTop>(), dpProfile, length(seqH) * (length(seqV) + 1), 0, testMatrix);
-//                        if (TrackingEnabled_<DPMetaColumn_<TDPProfile, MetaColumnDescriptor<DPFinalColumn, FullColumn> >, LastCell>::VALUE)
-//                            _scoutBestScore(scout, _scoreOfCell(value(dpScoreMatrixNavigator)), dpTraceMatrixNavigator);
-//                    }
-//                    else
-//                      _computeTrack(scout, dpScoreMatrixNavigator, dpTraceMatrixNavigator,
-//                              value(seqHIter), TSeqVValue(), seqVBegin, seqVEnd, scoringScheme,
-//                              MetaColumnDescriptor<DPFinalColumn, FullColumn>(), dpProfile, length(seqH) * (length(seqV) +1), 0, testMatrix);
-//
-//                }
-//
-//            }
-//            else  // The band is bounded by bottom of matrix or completely unbounded.
-//            {
-//                ++seqVBegin;
-//                if (lowerDiagonal(band) + length(seqV) <= length(seqH)) // The band is bounded by the bottom of the matrix.
-//                {
-//                    if (lowerDiagonal(band) + length(seqV) == length(seqH))
-//                    {
-//                        ++seqVEnd;
-//                      _computeTrack(scout, dpScoreMatrixNavigator, dpTraceMatrixNavigator,
-//                          value(seqHIter), value(seqVBegin-1), seqVBegin, seqVEnd, scoringScheme,
-//                          MetaColumnDescriptor<DPFinalColumn, PartialColumnMiddle>(), dpProfile, length(seqH) * (length(seqV)+1), seqVBegin - begin(seqV), testMatrix);
-//                      if (TrackingEnabled_<DPMetaColumn_<TDPProfile, MetaColumnDescriptor<DPFinalColumn, PartialColumnBottom> >, LastCell>::VALUE)
-//                          _scoutBestScore(scout, _scoreOfCell(value(dpScoreMatrixNavigator)), dpTraceMatrixNavigator);
-//                    }
-//                    else
-//                    {
-//                      _computeTrack(scout, dpScoreMatrixNavigator, dpTraceMatrixNavigator,
-//                          value(seqHIter), value(seqVBegin-1), seqVBegin, seqVEnd, scoringScheme,
-//                          MetaColumnDescriptor<DPFinalColumn, PartialColumnBottom>(), dpProfile, length(seqH) * (length(seqV) + 1), seqVBegin - begin(seqV), testMatrix);
-//                    }
-//                }
-//                else  // The band is unbounded by the matrix.
-//                {
-//                    ++seqVEnd;
-//                  _computeTrack(scout, dpScoreMatrixNavigator, dpTraceMatrixNavigator,
-//                      value(seqHIter), value(seqVBegin-1), seqVBegin, seqVEnd, scoringScheme,
-//                      MetaColumnDescriptor<DPFinalColumn, PartialColumnMiddle>(), dpProfile, length(seqH) * (length(seqV)+1), seqVBegin - begin(seqV), testMatrix);
-//                }
-//
-//            }
-//        }
-//    }
-//
-//    for (unsigned i = 0; i <= length(seqV); ++i)
-//    {
-//      for (unsigned j = 0; j <= length(seqH); ++j)
-//      {
-//          unsigned pos = j * (length(seqV) + 1) + i;
-//          //if (!testMatrix[pos].empty())
-//              std::cout << testMatrix[pos] << "\t" << std::flush;
-//      }
-//      std::cout << std::endl;
-//    }
-//
-//}
 
 // ----------------------------------------------------------------------------
 // Function _computeHammingDistance()
@@ -1202,7 +950,7 @@ _computeHammingDistance(TDPScout & scout,
     TConstSeqVIterator itVEnd = begin(seqV, Rooted()) + _min(seqVlength - 1, lowerDiagonal(band) + seqHlength);
 
     assignValue(dpTraceMatrixNavigator,
-                _computeScore(value(dpScoreMatrixNavigator), TDPCell(), TDPCell(), TDPCell(),
+                _computeScore(std::forward_as_tuple(value(dpScoreMatrixNavigator), TDPCell(), TDPCell(), TDPCell()),
                               sequenceEntryForScore(scoringScheme, seqH, position(itH)),
                               sequenceEntryForScore(scoringScheme, seqV, position(itV)),
                               scoringScheme, RecursionDirectionZero(), TDPProfile()));
@@ -1252,7 +1000,7 @@ _computeHammingDistance(TDPScout & scout,
         _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, FullColumn>(), FirstCell());
         _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, FullColumn>(), FirstCell());
         assignValue(dpTraceMatrixNavigator,
-                    _computeScore(value(dpScoreMatrixNavigator), prevDiagonal, TDPCell(), TDPCell(),
+                    _computeScore(std::forward_as_tuple(value(dpScoreMatrixNavigator), prevDiagonal, TDPCell(), TDPCell()),
                                   sequenceEntryForScore(scoringScheme, seqH, position(itH)),
                                   sequenceEntryForScore(scoringScheme, seqV, position(itV)),
                                   scoringScheme, RecursionDirectionDiagonal(), TDPProfile()));
@@ -1271,7 +1019,7 @@ _computeHammingDistance(TDPScout & scout,
     _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, FullColumn>(), FirstCell());
 
     assignValue(dpTraceMatrixNavigator,
-                _computeScore(value(dpScoreMatrixNavigator), prevDiagonal, TDPCell(), TDPCell(),
+                _computeScore(std::forward_as_tuple(value(dpScoreMatrixNavigator), prevDiagonal, TDPCell(), TDPCell()),
                               sequenceEntryForScore(scoringScheme, seqH, position(itH)),
                               sequenceEntryForScore(scoringScheme, seqV, position(itV)),
                               scoringScheme, RecursionDirectionDiagonal(), TDPProfile()));
@@ -1534,8 +1282,12 @@ _computeAlignment(DPContext<TScoreValue, TGapScheme> & dpContext,
     typedef DPMatrix_<TDPScoreValue, TScoreMatrixSpec> TDPScoreMatrix;
     typedef DPMatrix_<TTraceValue, FullDPMatrix> TDPTraceMatrix;
 
-    typedef DPMatrixNavigator_<TDPScoreMatrix, DPScoreMatrix, NavigateColumnWise> TDPScoreMatrixNavigator;
-    typedef DPMatrixNavigator_<TDPTraceMatrix, DPTraceMatrix<TTraceFlag>, NavigateColumnWise> TDPTraceMatrixNavigator;
+    using TNavigationSpec = std::conditional_t<std::is_same<TBandSwitch, BandOff>::value,
+                                               NavigateColumnWise,
+                                               NavigateColumnWiseBanded>;
+
+    typedef DPMatrixNavigator_<TDPScoreMatrix, DPScoreMatrix, TNavigationSpec> TDPScoreMatrixNavigator;
+    typedef DPMatrixNavigator_<TDPTraceMatrix, DPTraceMatrix<TTraceFlag>, TNavigationSpec> TDPTraceMatrixNavigator;
 
     typedef typename ScoutSpecForAlignmentAlgorithm_<TAlignmentAlgorithm, TScoutState>::Type TDPScoutSpec;
     typedef DPScout_<TDPScoreValue, TDPScoutSpec> TDPScout;
@@ -1572,11 +1324,8 @@ _computeAlignment(DPContext<TScoreValue, TGapScheme> & dpContext,
     if (IsTracebackEnabled_<TTraceFlag>::VALUE)
         resize(dpTraceMatrix);
 
-    TDPScoreMatrixNavigator dpScoreMatrixNavigator;
-    TDPTraceMatrixNavigator dpTraceMatrixNavigator;
-
-    _init(dpScoreMatrixNavigator, dpScoreMatrix, band);
-    _init(dpTraceMatrixNavigator, dpTraceMatrix, band);
+    TDPScoreMatrixNavigator dpScoreMatrixNavigator{dpScoreMatrix, band};
+    TDPTraceMatrixNavigator dpTraceMatrixNavigator{dpTraceMatrix, band};
 
     TDPScout dpScout(scoutState);
 #if SEQAN_ALIGN_SIMD_PROFILE
@@ -1584,13 +1333,9 @@ _computeAlignment(DPContext<TScoreValue, TGapScheme> & dpContext,
     timer = sysTime();
 #endif
     // Execute the alignment.
-    if (!_isBandEnabled(band))
-        _computeUnbandedAlignment(dpScout, dpScoreMatrixNavigator, dpTraceMatrixNavigator, seqH, seqV, scoreScheme, dpProfile);
-    else if (upperDiagonal(band) == lowerDiagonal(band))
-        _computeHammingDistance(dpScout, dpScoreMatrixNavigator, dpTraceMatrixNavigator, seqH, seqV, scoreScheme, band, dpProfile);
-    else
-        _computeBandedAlignment(dpScout, dpScoreMatrixNavigator, dpTraceMatrixNavigator, seqH, seqV, scoreScheme,
-                                band, dpProfile);
+    _computeAlignmentImpl(dpScout, dpScoreMatrixNavigator, dpTraceMatrixNavigator, seqH, seqV, scoreScheme, band,
+                          dpProfile, TNavigationSpec{});
+
 #if SEQAN_ALIGN_SIMD_PROFILE
     profile.alignTimer += sysTime() - timer;
     timer = sysTime();

--- a/include/seqan/align/dp_cell.h
+++ b/include/seqan/align/dp_cell.h
@@ -50,6 +50,12 @@ namespace seqan {
 // Tags, Classes, Enums
 // ============================================================================
 
+struct DynamicGapExtensionHorizontal_;
+typedef Tag<DynamicGapExtensionHorizontal_> DynamicGapExtensionHorizontal;
+
+struct DynamicGapExtensionVertical_;
+typedef Tag<DynamicGapExtensionVertical_> DynamicGapExtensionVertical;
+
 // ----------------------------------------------------------------------------
 // Class DPCell_
 // ----------------------------------------------------------------------------
@@ -276,6 +282,65 @@ inline void
 setGapExtension(DPCell_<TScoreValue, TGapSpec> & /*dpCell*/, TF1 , TF2, TScoreValue)
 {
     // no-op
+}
+
+// ----------------------------------------------------------------------------
+// Function isGapExtension()
+// ----------------------------------------------------------------------------
+
+template <typename TScoreValue, typename TGapSpec,
+          typename TSpec>
+inline bool
+isGapExtension(DPCell_<TScoreValue, TGapSpec> const & /*cell*/,
+               TSpec const & /*spec*/)
+{
+    return false;
+}
+
+// ----------------------------------------------------------------------------
+// Function operator==()
+// ----------------------------------------------------------------------------
+
+template <typename TScoreValue, typename TGapCosts>
+inline bool operator==(DPCell_<TScoreValue, TGapCosts> const & lhs,
+                       DPCell_<TScoreValue, TGapCosts> const & rhs)
+{
+    return _scoreOfCell(lhs) == _scoreOfCell(rhs) &&
+           _horizontalScoreOfCell(lhs) == _horizontalScoreOfCell(rhs) &&
+           _verticalScoreOfCell(lhs) == _verticalScoreOfCell(rhs);
+}
+
+// ----------------------------------------------------------------------------
+// Function operator!=()
+// ----------------------------------------------------------------------------
+
+template <typename TScoreValue, typename TGapCosts>
+inline bool operator!=(DPCell_<TScoreValue, TGapCosts> const & lhs,
+                       DPCell_<TScoreValue, TGapCosts> const & rhs)
+{
+    return !(lhs == rhs);
+}
+
+// ----------------------------------------------------------------------------
+// Function operator<<()
+// ----------------------------------------------------------------------------
+
+template <typename TStream,
+          typename TScoreValue, typename TGapCosts>
+inline TStream& operator<<(TStream & stream,
+                           DPCell_<TScoreValue, TGapCosts> const & cell)
+{
+    stream << "M: " << _scoreOfCell(cell);
+    if (std::is_same<TGapCosts, AffineGaps>::value)
+    {
+        stream << " <H: " << _horizontalScoreOfCell(cell) << " V: " << _verticalScoreOfCell(cell) << ">";
+    }
+    else if (std::is_same<TGapCosts, DynamicGaps>::value)
+    {
+        stream << " <H: " << isGapExtension(cell, DynamicGapExtensionHorizontal{}) <<
+                  " V: " << isGapExtension(cell, DynamicGapExtensionVertical{}) << ">";
+    }
+    return stream;
 }
 
 }  // namespace seqan

--- a/include/seqan/align/dp_cell_dynamic.h
+++ b/include/seqan/align/dp_cell_dynamic.h
@@ -67,12 +67,6 @@ struct FlagMaskType
 // Tags, Classes, Enums
 // ============================================================================
 
-struct DynamicGapExtensionHorizontal_;
-typedef Tag<DynamicGapExtensionHorizontal_> DynamicGapExtensionHorizontal;
-
-struct DynamicGapExtensionVertical_;
-typedef Tag<DynamicGapExtensionVertical_> DynamicGapExtensionVertical;
-
 enum DynamicGapsMask
 {
     MASK_VERTICAL_GAP = 1,

--- a/include/seqan/align/dp_formula_affine.h
+++ b/include/seqan/align/dp_formula_affine.h
@@ -60,8 +60,7 @@ namespace seqan {
 // ----------------------------------------------------------------------------
 
 template <typename TScoreValue, typename TTraceValueL, typename TTraceValueGap>
-inline SEQAN_FUNC_ENABLE_IF(Not<Is<SimdVectorConcept<TScoreValue> > >,
-                            typename TraceBitMap_<TScoreValue>::Type)
+inline SEQAN_FUNC_ENABLE_IF(Not<Is<SimdVectorConcept<TScoreValue> > >, typename TraceBitMap_<TScoreValue>::Type)
 _internalComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
                       TScoreValue const & rightCompare,
                       TTraceValueL,
@@ -96,9 +95,9 @@ _internalComputeScore(DPCell_<TScoreValue, TAffineGaps> & activeCell,
                       TracebackOn<TracebackConfig_<SingleTrace, TGapsPlacement> > const &,
                       RecursionDirectionDiagonal const &)
 {
-    return (activeCell._score <= rightCompare) ?
-        (activeCell._score = rightCompare, TraceBitMap_<TScoreValue>::DIAGONAL | leftTrace) :
-        (leftTrace | gapTrace);
+    return (activeCell._score <= rightCompare)
+        ? (activeCell._score = rightCompare, TraceBitMap_<TScoreValue>::DIAGONAL | leftTrace)
+        : (leftTrace | gapTrace);
 }
 
 template <typename TScoreValue, typename TAffineGaps, typename TTraceValueL, typename TTraceValueGap, typename TGapsPlacement>
@@ -126,11 +125,11 @@ _internalComputeScore(DPCell_<TScoreValue, TAffineGaps> & activeCell,
                       TracebackOn<TracebackConfig_<CompleteTrace, TGapsPlacement> >  const &,
                       RecursionDirectionDiagonal const &)
 {
-    return (activeCell._score <= rightCompare) ?
-        ((activeCell._score == rightCompare) ?
-            (leftTrace | TraceBitMap_<TScoreValue>::DIAGONAL | gapTrace) :
-            (activeCell._score = rightCompare, TraceBitMap_<TScoreValue>::DIAGONAL | leftTrace)) :
-        (leftTrace | gapTrace);
+    return (activeCell._score <= rightCompare)
+        ? ((activeCell._score == rightCompare)
+            ? (leftTrace | TraceBitMap_<TScoreValue>::DIAGONAL | gapTrace)
+            : (activeCell._score = rightCompare, TraceBitMap_<TScoreValue>::DIAGONAL | leftTrace))
+        : (leftTrace | gapTrace);
 }
 
 template <typename TScoreValue, typename TAffineGaps, typename TTraceValueL, typename TTraceValueGap, typename TGapsPlacement>
@@ -163,7 +162,8 @@ _internalComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
                       TracebackOff const &,
                       RecursionDirectionHorizontal const &)
 {
-    _horizontalScoreOfCell(activeCell) = std::max(_horizontalScoreOfCell(activeCell), rightCompare);
+    using std::max;
+    _horizontalScoreOfCell(activeCell) = max(_horizontalScoreOfCell(activeCell), rightCompare);
     return TraceBitMap_<TScoreValue>::NONE;
 }
 
@@ -189,9 +189,9 @@ _internalComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
                       TracebackOn<TracebackConfig_<SingleTrace, TGapsPlacement> >  const &,
                       RecursionDirectionHorizontal const &)
 {
-    return (activeCell._horizontalScore < rightCompare) ?
-        (activeCell._horizontalScore = rightCompare, rightTrace) :
-        (leftTrace);
+    return (activeCell._horizontalScore < rightCompare)
+        ? (activeCell._horizontalScore = rightCompare, rightTrace)
+        : (leftTrace);
 }
 
 template <typename TScoreValue, typename TTraceValueL, typename TTraceValueR, typename TGapsPlacement>
@@ -217,11 +217,11 @@ _internalComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
                       TracebackOn<TracebackConfig_<CompleteTrace, TGapsPlacement> >  const &,
                       RecursionDirectionHorizontal const &)
 {
-    return (activeCell._horizontalScore <= rightCompare) ?
-        ((activeCell._horizontalScore == rightCompare) ?
-            (leftTrace | rightTrace) :
-            (activeCell._horizontalScore = rightCompare, rightTrace)) :
-        leftTrace;
+    return (activeCell._horizontalScore <= rightCompare)
+        ? ((activeCell._horizontalScore == rightCompare)
+            ? (leftTrace | rightTrace)
+            : (activeCell._horizontalScore = rightCompare, rightTrace))
+        : (leftTrace);
 }
 
 template <typename TScoreValue, typename TTraceValueL, typename TTraceValueR, typename TGapsPlacement>
@@ -237,8 +237,7 @@ _internalComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
     TScoreValue cmpE = cmpEq(rightCompare, activeCell._horizontalScore);
     activeCell._horizontalScore = blend(activeCell._horizontalScore, rightCompare, cmpG);
 
-    TScoreValue result = leftTrace;
-    result = blend(result, rightTrace, cmpG);
+    auto result = blend(leftTrace, rightTrace, cmpG);
     return blend(result, leftTrace | rightTrace, cmpE);
 }
 
@@ -255,7 +254,8 @@ _internalComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
                       TracebackOff const &,
                       RecursionDirectionVertical const &)
 {
-    _verticalScoreOfCell(activeCell) = std::max(_verticalScoreOfCell(activeCell), rightCompare);
+    using std::max;
+    _verticalScoreOfCell(activeCell) = max(_verticalScoreOfCell(activeCell), rightCompare);
     return TraceBitMap_<TScoreValue>::NONE;
 }
 
@@ -281,9 +281,9 @@ _internalComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
                       TracebackOn<TracebackConfig_<SingleTrace, TGapsPlacement> >  const &,
                       RecursionDirectionVertical const &)
 {
-    return (activeCell._verticalScore < rightCompare) ?
-        (activeCell._verticalScore = rightCompare, rightTrace) :
-        (leftTrace);
+    return (activeCell._verticalScore < rightCompare)
+        ? (activeCell._verticalScore = rightCompare, rightTrace)
+        : (leftTrace);
 }
 
 template <typename TScoreValue, typename TTraceValueL, typename TTraceValueR, typename TGapsPlacement>
@@ -309,11 +309,11 @@ _internalComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
                       TracebackOn<TracebackConfig_<CompleteTrace, TGapsPlacement> >  const &,
                       RecursionDirectionVertical const &)
 {
-    return (activeCell._verticalScore <= rightCompare) ?
-                ((activeCell._verticalScore == rightCompare) ?
-                    (leftTrace | rightTrace) :
-                    (activeCell._verticalScore = rightCompare, rightTrace)) :
-                (leftTrace);
+    return (activeCell._verticalScore <= rightCompare)
+        ? ((activeCell._verticalScore == rightCompare)
+            ? (leftTrace | rightTrace)
+            : (activeCell._verticalScore = rightCompare, rightTrace))
+        : (leftTrace);
 }
 
 template <typename TScoreValue, typename TTraceValueL, typename TTraceValueR, typename TGapsPlacement>
@@ -344,7 +344,8 @@ inline SEQAN_FUNC_ENABLE_IF(Not<Is<SimdVectorConcept<TScoreValue>>>,
 _internalComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
                       TracebackOff const &)
 {
-    _scoreOfCell(activeCell) = std::max(_horizontalScoreOfCell(activeCell), _verticalScoreOfCell(activeCell));
+    using std::max;
+    _scoreOfCell(activeCell) = max(_horizontalScoreOfCell(activeCell), _verticalScoreOfCell(activeCell));
     return TraceBitMap_<TScoreValue>::NONE;
 }
 
@@ -363,9 +364,9 @@ inline SEQAN_FUNC_ENABLE_IF(Not<Is<SimdVectorConcept<TScoreValue> > >, typename 
 _internalComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
                       TracebackOn<TracebackConfig_<SingleTrace, TGapsPlacement> >  const &)
 {
-    return (activeCell._verticalScore < activeCell._horizontalScore) ?
-        (activeCell._score = activeCell._horizontalScore, TraceBitMap_<TScoreValue>::MAX_FROM_HORIZONTAL_MATRIX) :
-        (activeCell._score = activeCell._verticalScore, TraceBitMap_<TScoreValue>::MAX_FROM_VERTICAL_MATRIX);
+    return (activeCell._verticalScore < activeCell._horizontalScore)
+        ? (activeCell._score = activeCell._horizontalScore, TraceBitMap_<TScoreValue>::MAX_FROM_HORIZONTAL_MATRIX)
+        : (activeCell._score = activeCell._verticalScore, TraceBitMap_<TScoreValue>::MAX_FROM_VERTICAL_MATRIX);
 }
 
 template <typename TScoreValue, typename TGapsPlacement>
@@ -385,12 +386,13 @@ inline SEQAN_FUNC_ENABLE_IF(Not<Is<SimdVectorConcept<TScoreValue> > >, typename 
 _internalComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
                       TracebackOn<TracebackConfig_<CompleteTrace, TGapsPlacement> >  const &)
 {
-    return (activeCell._horizontalScore <= activeCell._verticalScore) ?
-        ((activeCell._horizontalScore == activeCell._verticalScore) ?
-            (activeCell._score = activeCell._horizontalScore, TraceBitMap_<TScoreValue>::MAX_FROM_VERTICAL_MATRIX |
-                                                              TraceBitMap_<TScoreValue>::MAX_FROM_HORIZONTAL_MATRIX) :
-            (activeCell._score = activeCell._verticalScore, TraceBitMap_<TScoreValue>::MAX_FROM_VERTICAL_MATRIX)) :
-        (activeCell._score = activeCell._horizontalScore, TraceBitMap_<TScoreValue>::MAX_FROM_HORIZONTAL_MATRIX);
+    return (activeCell._horizontalScore <= activeCell._verticalScore)
+        ? ((activeCell._horizontalScore == activeCell._verticalScore)
+            ? (activeCell._score = activeCell._horizontalScore,
+               TraceBitMap_<TScoreValue>::MAX_FROM_VERTICAL_MATRIX |
+               TraceBitMap_<TScoreValue>::MAX_FROM_HORIZONTAL_MATRIX)
+            : (activeCell._score = activeCell._verticalScore, TraceBitMap_<TScoreValue>::MAX_FROM_VERTICAL_MATRIX))
+        : (activeCell._score = activeCell._horizontalScore, TraceBitMap_<TScoreValue>::MAX_FROM_HORIZONTAL_MATRIX);
 }
 
 template <typename TScoreValue, typename TGapsPlacement>
@@ -414,14 +416,13 @@ _internalComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
 // ----------------------------------------------------------------------------
 
 template <typename TScoreValue,
-          typename TDiag, typename THor, typename TVer,
           typename TSequenceHValue, typename TSequenceVValue, typename TScoringScheme,
           typename TAlgorithm, typename TTracebackConfig>
 inline typename TraceBitMap_<TScoreValue>::Type
 _doComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
-                TDiag const & previousDiagonal,
-                THor const & previousHorizontal,
-                TVer const & previousVertical,
+                DPCell_<TScoreValue, AffineGaps> const & previousDiagonal,
+                DPCell_<TScoreValue, AffineGaps> const & previousHorizontal,
+                DPCell_<TScoreValue, AffineGaps> const & previousVertical,
                 TSequenceHValue const & seqHVal,
                 TSequenceVValue const & seqVVal,
                 TScoringScheme const & scoringScheme,
@@ -430,8 +431,9 @@ _doComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
 {
     typedef typename TraceBitMap_<TScoreValue>::Type TTraceValue;
 
-    // Now we have to find a smart version to solve this problem. Which is not as easy I would think.
-    _horizontalScoreOfCell(activeCell) = _horizontalScoreOfCell(previousHorizontal) + scoreGapExtendHorizontal(scoringScheme, seqHVal, seqVVal);
+    // Compute horizontal direction.
+    _horizontalScoreOfCell(activeCell) = _horizontalScoreOfCell(previousHorizontal) +
+                                         scoreGapExtendHorizontal(scoringScheme, seqHVal, seqVVal);
     TTraceValue tvGap =
         _internalComputeScore(activeCell,
                               static_cast<TScoreValue>(_scoreOfCell(previousHorizontal) +
@@ -441,8 +443,9 @@ _doComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
                               TTracebackConfig(),
                               RecursionDirectionHorizontal());
 
-    // Now we can decide for the optimal score in horizontal score or not?
-    _verticalScoreOfCell(activeCell) = _verticalScoreOfCell(previousVertical) + scoreGapExtendVertical(scoringScheme, seqHVal, seqVVal);
+    // Compute vertical direction.
+    _verticalScoreOfCell(activeCell) = _verticalScoreOfCell(previousVertical) +
+                                       scoreGapExtendVertical(scoringScheme, seqHVal, seqVVal);
     tvGap |=
         _internalComputeScore(activeCell,
                               static_cast<TScoreValue>(_scoreOfCell(previousVertical) +
@@ -452,8 +455,8 @@ _doComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
                               TTracebackConfig(),
                               RecursionDirectionVertical());
 
-    // Finds the maximum between the vertical and the horizontal matrix. Stores the flag for coming from a potential direction.
-    TTraceValue tvMax = _internalComputeScore(activeCell, TTracebackConfig());  // Stores from where the maximal score comes.
+    // Get max from horiztonal and/or vertical direction and compare with diagonal direction.
+    TTraceValue tvMax = _internalComputeScore(activeCell, TTracebackConfig());
     return _internalComputeScore(activeCell,
                                  static_cast<TScoreValue>(_scoreOfCell(previousDiagonal) +
                                                           score(scoringScheme, seqHVal, seqVVal)),
@@ -465,14 +468,13 @@ _doComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
 // ----------------------------------------------------------------------------
 
 template <typename TScoreValue,
-          typename TDiag, typename THor, typename TVer,
           typename TSequenceHValue, typename TSequenceVValue, typename TScoringScheme,
           typename TAlgorithm, typename TTracebackConfig>
 inline typename TraceBitMap_<TScoreValue>::Type
 _doComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
-                TDiag const & previousDiagonal,
-                THor const & previousHorizontal,
-                TVer const & /*previousVertical*/,
+                DPCell_<TScoreValue, AffineGaps> const & previousDiagonal,
+                DPCell_<TScoreValue, AffineGaps> const & previousHorizontal,
+                DPCell_<TScoreValue, AffineGaps> const & /*previousVertical*/,
                 TSequenceHValue const & seqHVal,
                 TSequenceVValue const & seqVVal,
                 TScoringScheme const & scoringScheme,
@@ -481,9 +483,9 @@ _doComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
 {
     typedef typename TraceBitMap_<TScoreValue>::Type TTraceValue;
 
+    // Compute horiztonal direction.
     _horizontalScoreOfCell(activeCell) = _horizontalScoreOfCell(previousHorizontal) +
                                          scoreGapExtendHorizontal(scoringScheme, seqHVal, seqVVal);
-    _verticalScoreOfCell(activeCell) = DPCellDefaultInfinity<DPCell_<TScoreValue, AffineGaps> >::VALUE;
     TTraceValue tv = _internalComputeScore(activeCell,
                                            static_cast<TScoreValue>(_scoreOfCell(previousHorizontal) +
                                                                     scoreGapOpenHorizontal(scoringScheme,
@@ -493,6 +495,9 @@ _doComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
                                            TraceBitMap_<TScoreValue>::HORIZONTAL_OPEN,
                                            TTracebackConfig(),
                                            RecursionDirectionHorizontal());
+    // Ignore vertical direction in upper diagonal.
+    _verticalScoreOfCell(activeCell) = DPCellDefaultInfinity<DPCell_<TScoreValue, AffineGaps> >::VALUE;
+    // Compute diagonal direction and compare with horizontal.
     _scoreOfCell(activeCell) = _horizontalScoreOfCell(activeCell);
     return _internalComputeScore(activeCell,
                                  static_cast<TScoreValue>(_scoreOfCell(previousDiagonal) +
@@ -508,14 +513,13 @@ _doComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
 // ----------------------------------------------------------------------------
 
 template <typename TScoreValue,
-          typename TDiag, typename THor, typename TVer,
           typename TSequenceHValue, typename TSequenceVValue, typename TScoringScheme,
           typename TAlgorithm, typename TTracebackConfig>
 inline typename TraceBitMap_<TScoreValue>::Type
 _doComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
-                TDiag const & previousDiagonal,
-                THor const & /*previousHorizontal*/,
-                TVer const & previousVertical,
+                DPCell_<TScoreValue, AffineGaps> const & previousDiagonal,
+                DPCell_<TScoreValue, AffineGaps> const & /*previousHorizontal*/,
+                DPCell_<TScoreValue, AffineGaps> const & previousVertical,
                 TSequenceHValue const & seqHVal,
                 TSequenceVValue const & seqVVal,
                 TScoringScheme const & scoringScheme,
@@ -524,10 +528,9 @@ _doComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
 {
     typedef typename TraceBitMap_<TScoreValue>::Type TTraceValue;
 
-    _verticalScoreOfCell(activeCell) = _verticalScoreOfCell(previousVertical) + scoreGapExtendVertical(scoringScheme, seqHVal, seqVVal);
-
-    _horizontalScoreOfCell(activeCell) = DPCellDefaultInfinity<DPCell_<TScoreValue, AffineGaps> >::VALUE;
-    // This computes the difference between the vertical extend and vertical open.
+    // Compute vertical direction.
+    _verticalScoreOfCell(activeCell) = _verticalScoreOfCell(previousVertical) +
+                                       scoreGapExtendVertical(scoringScheme, seqHVal, seqVVal);
     TTraceValue tv =
         _internalComputeScore(activeCell,
                               static_cast<TScoreValue>(_scoreOfCell(previousVertical) +
@@ -536,8 +539,9 @@ _doComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
                               TraceBitMap_<TScoreValue>::VERTICAL_OPEN,
                               TTracebackConfig(),
                               RecursionDirectionVertical());
-
-    // Up to here, activeCell stores the highest value of vertical or vertical open.
+    // Ignore horizontal direction in lower diagonal.
+    _horizontalScoreOfCell(activeCell) = DPCellDefaultInfinity<DPCell_<TScoreValue, AffineGaps> >::VALUE;
+    // Compute diagonal direction and compare with vertical.
     _scoreOfCell(activeCell) = _verticalScoreOfCell(activeCell);
     return _internalComputeScore(activeCell,
                                  static_cast<TScoreValue>(_scoreOfCell(previousDiagonal) +
@@ -545,7 +549,7 @@ _doComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
                                  tv,
                                  TraceBitMap_<TScoreValue>::MAX_FROM_VERTICAL_MATRIX,
                                  TTracebackConfig(),
-                                 RecursionDirectionDiagonal());  // Now we have this problem. How do we determine if the max comes from the vertical distance.
+                                 RecursionDirectionDiagonal());
 }
 
 // ----------------------------------------------------------------------------
@@ -553,21 +557,22 @@ _doComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
 // ----------------------------------------------------------------------------
 
 template <typename TScoreValue,
-          typename TDiag, typename THor, typename TVer,
           typename TSequenceHValue, typename TSequenceVValue, typename TScoringScheme,
           typename TAlgorithm, typename TTracebackConfig>
 inline typename TraceBitMap_<TScoreValue>::Type
 _doComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
-                TDiag const & /*previousDiagonal*/,
-                THor const & previousHorizontal,
-                TVer const & /*previousVertical*/,
+                DPCell_<TScoreValue, AffineGaps> const & /*previousDiagonal*/,
+                DPCell_<TScoreValue, AffineGaps> const & previousHorizontal,
+                DPCell_<TScoreValue, AffineGaps> const & /*previousVertical*/,
                 TSequenceHValue const & seqHVal,
                 TSequenceVValue const & seqVVal,
                 TScoringScheme const & scoringScheme,
                 RecursionDirectionHorizontal const &,
                 DPProfile_<TAlgorithm, AffineGaps, TTracebackConfig> const &)
 {
-    _horizontalScoreOfCell(activeCell) = _horizontalScoreOfCell(previousHorizontal) + scoreGapExtendHorizontal(scoringScheme, seqHVal, seqVVal);
+    // Compute horizontal direction.
+    _horizontalScoreOfCell(activeCell) = _horizontalScoreOfCell(previousHorizontal) +
+                                         scoreGapExtendHorizontal(scoringScheme, seqHVal, seqVVal);
     auto traceDir = _internalComputeScore(activeCell,
                                 static_cast<TScoreValue>(_scoreOfCell(previousHorizontal) +
                                                          scoreGapOpenHorizontal(scoringScheme, seqHVal, seqVVal)),
@@ -575,6 +580,7 @@ _doComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
                                 TraceBitMap_<TScoreValue>::HORIZONTAL_OPEN,
                                 TTracebackConfig(),
                                 RecursionDirectionHorizontal()) | TraceBitMap_<TScoreValue>::MAX_FROM_HORIZONTAL_MATRIX;
+    // Ignore vertical direction.
     _verticalScoreOfCell(activeCell) = DPCellDefaultInfinity<DPCell_<TScoreValue, AffineGaps> >::VALUE;
     _scoreOfCell(activeCell) = _horizontalScoreOfCell(activeCell);
     return traceDir;
@@ -585,21 +591,22 @@ _doComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
 // ----------------------------------------------------------------------------
 
 template <typename TScoreValue,
-          typename TDiag, typename THor, typename TVer,
           typename TSequenceHValue, typename TSequenceVValue, typename TScoringScheme,
           typename TAlgorithm, typename TTracebackConfig>
 inline typename TraceBitMap_<TScoreValue>::Type
 _doComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
-                TDiag const & /*previousDiagonal*/,
-                THor const & /*previousHorizontal*/,
-                TVer const & previousVertical,
+                DPCell_<TScoreValue, AffineGaps> const & /*previousDiagonal*/,
+                DPCell_<TScoreValue, AffineGaps> const & /*previousHorizontal*/,
+                DPCell_<TScoreValue, AffineGaps> const & previousVertical,
                 TSequenceHValue const & seqHVal,
                 TSequenceVValue const & seqVVal,
                 TScoringScheme const & scoringScheme,
                 RecursionDirectionVertical const &,
                 DPProfile_<TAlgorithm, AffineGaps, TTracebackConfig> const &)
 {
-    _verticalScoreOfCell(activeCell) = _verticalScoreOfCell(previousVertical) + scoreGapExtendVertical(scoringScheme, seqHVal, seqVVal);
+    // Compute vertical direction.
+    _verticalScoreOfCell(activeCell) = _verticalScoreOfCell(previousVertical) +
+                                       scoreGapExtendVertical(scoringScheme, seqHVal, seqVVal);
     auto traceDir = _internalComputeScore(activeCell,
                                  static_cast<TScoreValue>(_scoreOfCell(previousVertical) +
                                                           scoreGapOpenVertical(scoringScheme, seqHVal, seqVVal)),
@@ -607,7 +614,7 @@ _doComputeScore(DPCell_<TScoreValue, AffineGaps> & activeCell,
                                  TraceBitMap_<TScoreValue>::VERTICAL_OPEN,
                                  TTracebackConfig(),
                                  RecursionDirectionVertical()) | TraceBitMap_<TScoreValue>::MAX_FROM_VERTICAL_MATRIX;
-    // Here we distinguish between vertical and vertical open.
+    // Ignore horizontal direction.
     _horizontalScoreOfCell(activeCell) = DPCellDefaultInfinity<DPCell_<TScoreValue, AffineGaps> >::VALUE;
     _scoreOfCell(activeCell) = _verticalScoreOfCell(activeCell);
     return traceDir;

--- a/include/seqan/align/dp_formula_dynamic.h
+++ b/include/seqan/align/dp_formula_dynamic.h
@@ -623,12 +623,14 @@ _doComputeScore(DPCell_<TScoreValue, DynamicGaps> & activeCell,
                                  TTracebackConfig(), tag) | TraceBitMap_<TScoreValue>::MAX_FROM_HORIZONTAL_MATRIX;
 }
 
+// NOTE(rrahn): Here we copy the previousCellHorizontal as it might refer to the same value as acticeCell.
+// Since we cannot assure here to read the value before we write it, we have to take a copy from it.
 template <typename TScoreValue, typename TSequenceHValue, typename TSequenceVValue, typename TScoringScheme,
           typename TAlgorithm, typename TTracebackConfig>
 inline SEQAN_FUNC_ENABLE_IF(Is<SimdVectorConcept<TScoreValue> >, typename TraceBitMap_<TScoreValue>::Type)
 _doComputeScore(DPCell_<TScoreValue, DynamicGaps> & activeCell,
                 DPCell_<TScoreValue, DynamicGaps> const & /*previousDiagonal*/,
-                DPCell_<TScoreValue, DynamicGaps> const previousHorizontal, // NOTE(rrahn): We want the copy here. Don't change!!!
+                DPCell_<TScoreValue, DynamicGaps> const previousHorizontal, // NOTE(rrahn): Don't change!!!
                 DPCell_<TScoreValue, DynamicGaps> const & /*previousVertical*/,
                 TSequenceHValue const & seqHVal,
                 TSequenceVValue const & seqVVal,

--- a/include/seqan/align/dp_formula_dynamic.h
+++ b/include/seqan/align/dp_formula_dynamic.h
@@ -609,7 +609,7 @@ template <typename TScoreValue, typename TSequenceHValue, typename TSequenceVVal
 inline SEQAN_FUNC_ENABLE_IF(Not<Is<SimdVectorConcept<TScoreValue> > >, typename TraceBitMap_<TScoreValue>::Type)
 _doComputeScore(DPCell_<TScoreValue, DynamicGaps> & activeCell,
                 DPCell_<TScoreValue, DynamicGaps> const & /*previousDiagonal*/,
-                DPCell_<TScoreValue, DynamicGaps> const & previousHorizontal,
+                DPCell_<TScoreValue, DynamicGaps> const previousHorizontal,  // NOTE(rrahn): We want the copy here. Don't change!!!
                 DPCell_<TScoreValue, DynamicGaps> const & /*previousVertical*/,
                 TSequenceHValue const & seqHVal,
                 TSequenceVValue const & seqVVal,
@@ -628,7 +628,7 @@ template <typename TScoreValue, typename TSequenceHValue, typename TSequenceVVal
 inline SEQAN_FUNC_ENABLE_IF(Is<SimdVectorConcept<TScoreValue> >, typename TraceBitMap_<TScoreValue>::Type)
 _doComputeScore(DPCell_<TScoreValue, DynamicGaps> & activeCell,
                 DPCell_<TScoreValue, DynamicGaps> const & /*previousDiagonal*/,
-                DPCell_<TScoreValue, DynamicGaps> const & previousHorizontal,
+                DPCell_<TScoreValue, DynamicGaps> const previousHorizontal, // NOTE(rrahn): We want the copy here. Don't change!!!
                 DPCell_<TScoreValue, DynamicGaps> const & /*previousVertical*/,
                 TSequenceHValue const & seqHVal,
                 TSequenceVValue const & seqVVal,

--- a/include/seqan/align/dp_formula_linear.h
+++ b/include/seqan/align/dp_formula_linear.h
@@ -67,8 +67,8 @@ _internalComputeScore(DPCell_<TScoreValue, LinearGaps> & activeCell,
                       TTraceValueR,
                       TracebackOff const &)
 {
-    if (activeCell._score < rightCompare)
-        activeCell._score = rightCompare;
+    using std::max;
+    activeCell._score = max(activeCell._score, rightCompare);
     return TraceBitMap_<TScoreValue>::NONE;
 }
 
@@ -93,12 +93,7 @@ _internalComputeScore(DPCell_<TScoreValue, LinearGaps> & activeCell,
                       TTraceValueR rightTrace,
                       TracebackOn<TracebackConfig_<SingleTrace, TGapsPlacement> > const &)
 {
-    if (activeCell._score < rightCompare)
-    {
-        activeCell._score = rightCompare;
-        return rightTrace;
-    }
-    return leftTrace;
+    return (activeCell._score <= rightCompare) ? (activeCell._score = rightCompare, rightTrace) : (leftTrace);
 }
 
 template <typename TScoreValue, typename TTraceValueL, typename TTraceValueR, typename TGapsPlacement>
@@ -122,12 +117,10 @@ _internalComputeScore(DPCell_<TScoreValue, LinearGaps> & activeCell,
                       TTraceValueR rightTrace,
                       TracebackOn<TracebackConfig_<CompleteTrace, TGapsPlacement> > const &)
 {
-    if (activeCell._score < rightCompare)
-    {
-        activeCell._score = rightCompare;
-        return rightTrace;
-    }
-    return (activeCell._score == rightCompare) ? (rightTrace | leftTrace) : (leftTrace);
+    return (activeCell._score <= rightCompare) ?
+        ((activeCell._score == rightCompare) ? (rightTrace | leftTrace) :
+                                               (activeCell._score = rightCompare, rightTrace)) :
+        (leftTrace);
 }
 
 template <typename TScoreValue, typename TTraceValueL, typename TTraceValueR, typename TGapsPlacement>
@@ -164,20 +157,22 @@ _doComputeScore(DPCell_<TScoreValue, LinearGaps> & activeCell,
                 DPProfile_<TAlgorithm, LinearGaps, TTracebackConfig> const &)
 {
     typedef typename TraceBitMap_<TScoreValue>::Type TTraceValue;
-    activeCell._score = _scoreOfCell(previousDiagonal) + score(scoringScheme, seqHVal, seqVVal);
 
-    TScoreValue tmpScore = _scoreOfCell(previousVertical) + scoreGapExtendVertical(scoringScheme, seqHVal, seqVVal);
+    activeCell._score = _scoreOfCell(previousHorizontal) + scoreGapExtendHorizontal(scoringScheme, seqHVal, seqVVal);
 
-    TTraceValue tv = _internalComputeScore(activeCell,
-                                           tmpScore,
-                                           TraceBitMap_<TScoreValue>::DIAGONAL,
-                                           TraceBitMap_<TScoreValue>::VERTICAL | TraceBitMap_<TScoreValue>::MAX_FROM_VERTICAL_MATRIX,
-                                           TTracebackConfig());
-    tmpScore = _scoreOfCell(previousHorizontal) + scoreGapExtendHorizontal(scoringScheme, seqHVal, seqVVal);
+    TTraceValue tv =
+        _internalComputeScore(activeCell,
+                              static_cast<TScoreValue>(_scoreOfCell(previousVertical) +
+                                                       scoreGapExtendVertical(scoringScheme, seqHVal, seqVVal)),
+                              TraceBitMap_<TScoreValue>::HORIZONTAL | TraceBitMap_<TScoreValue>::MAX_FROM_HORIZONTAL_MATRIX,
+                              TraceBitMap_<TScoreValue>::VERTICAL | TraceBitMap_<TScoreValue>::MAX_FROM_VERTICAL_MATRIX,
+                              TTracebackConfig());
+
     return _internalComputeScore(activeCell,
-                                 tmpScore,
+                                 static_cast<TScoreValue>(_scoreOfCell(previousDiagonal) +
+                                                          score(scoringScheme, seqHVal, seqVVal)),
                                  tv,
-                                 TraceBitMap_<TScoreValue>::HORIZONTAL | TraceBitMap_<TScoreValue>::MAX_FROM_HORIZONTAL_MATRIX,
+                                 TraceBitMap_<TScoreValue>::DIAGONAL,
                                  TTracebackConfig());
 }
 
@@ -198,12 +193,12 @@ _doComputeScore(DPCell_<TScoreValue, LinearGaps> & activeCell,
                 RecursionDirectionUpperDiagonal const &,
                 DPProfile_<TAlgorithm, LinearGaps, TTracebackConfig> const &)
 {
-    activeCell._score = _scoreOfCell(previousDiagonal) + score(scoringScheme, seqHVal, seqVVal);
-    TScoreValue tmpScore = _scoreOfCell(previousHorizontal) + scoreGapExtendHorizontal(scoringScheme, seqHVal, seqVVal);
+    activeCell._score = _scoreOfCell(previousHorizontal) + scoreGapExtendHorizontal(scoringScheme, seqHVal, seqVVal);
     return _internalComputeScore(activeCell,
-                                 tmpScore,
-                                 TraceBitMap_<TScoreValue>::DIAGONAL,
+                                 static_cast<TScoreValue>(_scoreOfCell(previousDiagonal) +
+                                                          score(scoringScheme, seqHVal, seqVVal)),
                                  TraceBitMap_<TScoreValue>::HORIZONTAL | TraceBitMap_<TScoreValue>::MAX_FROM_HORIZONTAL_MATRIX,
+                                 TraceBitMap_<TScoreValue>::DIAGONAL,
                                  TTracebackConfig());
 }
 
@@ -224,13 +219,12 @@ _doComputeScore(DPCell_<TScoreValue, LinearGaps> & activeCell,
                 RecursionDirectionLowerDiagonal const &,
                 DPProfile_<TAlgorithm, LinearGaps, TTracebackConfig> const &)
 {
-    activeCell._score = _scoreOfCell(previousDiagonal) + score(scoringScheme, seqHVal, seqVVal);
-    TScoreValue tmpScore = _scoreOfCell(previousVertical) + scoreGapExtendVertical(scoringScheme, seqHVal, seqVVal);
-
+    activeCell._score = _scoreOfCell(previousVertical) + scoreGapExtendVertical(scoringScheme, seqHVal, seqVVal);
     return _internalComputeScore(activeCell,
-                                 tmpScore,
-                                 TraceBitMap_<TScoreValue>::DIAGONAL,
+                                 static_cast<TScoreValue>(_scoreOfCell(previousDiagonal) +
+                                                          score(scoringScheme, seqHVal, seqVVal)),
                                  TraceBitMap_<TScoreValue>::VERTICAL | TraceBitMap_<TScoreValue>::MAX_FROM_VERTICAL_MATRIX,
+                                 TraceBitMap_<TScoreValue>::DIAGONAL,
                                  TTracebackConfig());
 }
 

--- a/include/seqan/align/dp_formula_linear.h
+++ b/include/seqan/align/dp_formula_linear.h
@@ -158,7 +158,8 @@ _doComputeScore(DPCell_<TScoreValue, LinearGaps> & activeCell,
 {
     typedef typename TraceBitMap_<TScoreValue>::Type TTraceValue;
 
-    activeCell._score = _scoreOfCell(previousHorizontal) + scoreGapExtendHorizontal(scoringScheme, seqHVal, seqVVal);
+    _scoreOfCell(activeCell) = _scoreOfCell(previousHorizontal) +
+                               scoreGapExtendHorizontal(scoringScheme, seqHVal, seqVVal);
 
     TTraceValue tv =
         _internalComputeScore(activeCell,
@@ -193,7 +194,8 @@ _doComputeScore(DPCell_<TScoreValue, LinearGaps> & activeCell,
                 RecursionDirectionUpperDiagonal const &,
                 DPProfile_<TAlgorithm, LinearGaps, TTracebackConfig> const &)
 {
-    activeCell._score = _scoreOfCell(previousHorizontal) + scoreGapExtendHorizontal(scoringScheme, seqHVal, seqVVal);
+    _scoreOfCell(activeCell) = _scoreOfCell(previousHorizontal) +
+                               scoreGapExtendHorizontal(scoringScheme, seqHVal, seqVVal);
     return _internalComputeScore(activeCell,
                                  static_cast<TScoreValue>(_scoreOfCell(previousDiagonal) +
                                                           score(scoringScheme, seqHVal, seqVVal)),
@@ -219,7 +221,7 @@ _doComputeScore(DPCell_<TScoreValue, LinearGaps> & activeCell,
                 RecursionDirectionLowerDiagonal const &,
                 DPProfile_<TAlgorithm, LinearGaps, TTracebackConfig> const &)
 {
-    activeCell._score = _scoreOfCell(previousVertical) + scoreGapExtendVertical(scoringScheme, seqHVal, seqVVal);
+    _scoreOfCell(activeCell) = _scoreOfCell(previousVertical) + scoreGapExtendVertical(scoringScheme, seqHVal, seqVVal);
     return _internalComputeScore(activeCell,
                                  static_cast<TScoreValue>(_scoreOfCell(previousDiagonal) +
                                                           score(scoringScheme, seqHVal, seqVVal)),
@@ -245,7 +247,8 @@ _doComputeScore(DPCell_<TScoreValue, LinearGaps> & activeCell,
                 RecursionDirectionHorizontal const &,
                 DPProfile_<TAlgorithm, LinearGaps, TTracebackConfig> const &)
 {
-    activeCell._score = _scoreOfCell(previousHorizontal) + scoreGapExtendHorizontal(scoringScheme, seqHVal, seqVVal);
+    _scoreOfCell(activeCell) = _scoreOfCell(previousHorizontal) +
+                               scoreGapExtendHorizontal(scoringScheme, seqHVal, seqVVal);
 
     if (!IsTracebackEnabled_<TTracebackConfig>::VALUE)
         return TraceBitMap_<TScoreValue>::NONE;
@@ -271,7 +274,7 @@ _doComputeScore(DPCell_<TScoreValue, LinearGaps> & activeCell,
                 RecursionDirectionVertical const &,
                 DPProfile_<TAlgorithm, LinearGaps, TTracebackConfig> const &)
 {
-    activeCell._score = _scoreOfCell(previousVertical) + scoreGapExtendVertical(scoringScheme, seqHVal, seqVVal);
+    _scoreOfCell(activeCell) = _scoreOfCell(previousVertical) + scoreGapExtendVertical(scoringScheme, seqHVal, seqVVal);
 
     if (!IsTracebackEnabled_<TTracebackConfig>::VALUE)
         return TraceBitMap_<TScoreValue>::NONE;

--- a/include/seqan/align/dp_matrix_navigator.h
+++ b/include/seqan/align/dp_matrix_navigator.h
@@ -83,6 +83,14 @@ struct NavigateColumnWise_;
 typedef Tag<NavigateColumnWise_> NavigateColumnWise;
 
 // ----------------------------------------------------------------------------
+// Tag NavigateColumnWiseBanded
+// ----------------------------------------------------------------------------
+
+// Facilitates banded column wise navigation through the dp-matrix.
+struct NavigateColumnWiseBanded_;
+typedef Tag<NavigateColumnWiseBanded_> NavigateColumnWiseBanded;
+
+// ----------------------------------------------------------------------------
 // Class DPMatrixNavigator_
 // ----------------------------------------------------------------------------
 

--- a/include/seqan/align/dp_matrix_navigator_score_matrix.h
+++ b/include/seqan/align/dp_matrix_navigator_score_matrix.h
@@ -56,21 +56,68 @@ namespace seqan {
 // The navigator for the score matrix.
 //
 // This navigator runs on a FullDPMatrix while it navigates column wise.
-template <typename TValue>
-class DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPScoreMatrix, NavigateColumnWise>
+template <typename TValue, typename TNavigationSpec>
+class DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPScoreMatrix, TNavigationSpec>
 {
 public:
     typedef  DPMatrix_<TValue, FullDPMatrix> TDPMatrix_;
     typedef typename Pointer_<TDPMatrix_>::Type TDPMatrixPointer_;
     typedef typename Iterator<TDPMatrix_, Standard>::Type TDPMatrixIterator;
 
+    template <typename TBandSpec,
+              std::enable_if_t<std::is_same<TBandSpec, BandOff>::value, int> = 0>
+    DPMatrixNavigator_(DPMatrix_<TValue, FullDPMatrix> & matrix,
+                       DPBandConfig<TBandSpec> const & /*band*/)
+    {
+        _ptrDataContainer = &matrix;
+        _prevColIteratorOffset = _dataFactors(matrix)[DPMatrixDimension_::HORIZONTAL];
+        _activeColIterator = begin(matrix, Standard());
+        _prevColIterator = _activeColIterator - _prevColIteratorOffset;
+        _laneLeap = 1;
+        *_activeColIterator = TValue{};
+    }
+
+    template <typename TBandSpec,
+              std::enable_if_t<!std::is_same<TBandSpec, BandOff>::value, int> = 0>
+    DPMatrixNavigator_(DPMatrix_<TValue, FullDPMatrix> & matrix,
+                       DPBandConfig<TBandSpec> const & band)
+    {
+        using TMatrixSize = typename Size<DPMatrix_<TValue, SparseDPMatrix>>::Type;
+        using TSignedSize = std::make_signed_t<TMatrixSize>;
+
+        _ptrDataContainer = &matrix;
+        _prevColIteratorOffset = _dataFactors(matrix)[DPMatrixDimension_::HORIZONTAL];
+        // Band begins within the first row.
+        if (lowerDiagonal(band) >= 0)
+        {
+            _laneLeap = _min(length(matrix, DPMatrixDimension_::VERTICAL), bandSize(band));
+            _activeColIterator = begin(matrix, Standard()) + _dataLengths(matrix)[DPMatrixDimension_::VERTICAL] - 1;
+        }
+        else if (upperDiagonal(band) <= 0)  // Band begins within the first column.
+        {
+            _laneLeap = 1;
+            _activeColIterator = begin(matrix, Standard());
+        }
+        else  // Band intersects with the point of origin.
+        {
+            TMatrixSize lengthVertical = length(matrix, DPMatrixDimension_::VERTICAL);
+            int lastPos = _max(-static_cast<TSignedSize>(lengthVertical - 1), lowerDiagonal(band));
+            _laneLeap = lengthVertical + lastPos;
+            _activeColIterator = begin(matrix, Standard()) + _laneLeap - 1;
+        }
+        // Set previous iterator to same position, one column left.
+        _prevColIterator = _activeColIterator - _prevColIteratorOffset;
+        *_activeColIterator =TValue{};
+    }
+
     TDPMatrixPointer_ _ptrDataContainer     = nullptr;  // Pointer to the matrix this navigator is working on.
+    TValue* _prevCellDiagonal               = nullptr;  // The previous diagonal cell
+    TValue* _prevCellHorizontal             = nullptr;  // The previous Horizontal cell
+    TValue* _prevCellVertical               = nullptr;  // The previous Vertical cell
     int _laneLeap                           = 0;  // Stores the jump to the next column
+    size_t _prevColIteratorOffset           = 0;  // Offset to reset the previous column iterator when going to the next cell.
     TDPMatrixIterator _activeColIterator    = TDPMatrixIterator();  // The active column iterator.
     TDPMatrixIterator _prevColIterator      = TDPMatrixIterator();  // The previous column iterator.
-    TValue _prevCellDiagonal                = TValue();  // The previous diagonal cell
-    TValue _prevCellHorizontal              = TValue();  // The previous Horizontal cell
-    TValue _prevCellVertical                = TValue();  // The previous Vertical cell
 };
 
 // ============================================================================
@@ -82,270 +129,279 @@ public:
 // ============================================================================
 
 // ----------------------------------------------------------------------------
-// Function _init()
+// Function _goNextCell                                     [banded, FirstCell]
 // ----------------------------------------------------------------------------
 
-// Initializes the navigator for an unbanded alignment.
-template <typename TValue>
+// Needed to avoid ambigious overload.
+template <typename TValue, typename TDPMatrixSpec>
 inline void
-_init(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPScoreMatrix, NavigateColumnWise> & navigator,
-      DPMatrix_<TValue, FullDPMatrix> & dpMatrix,
-      DPBandConfig<BandOff> const &)
-{
-    navigator._ptrDataContainer = &dpMatrix;
-    navigator._activeColIterator = begin(dpMatrix, Standard());
-    navigator._prevColIterator = navigator._activeColIterator - _dataFactors(dpMatrix)[DPMatrixDimension_::HORIZONTAL];
-    navigator._laneLeap = 1;
-    assignValue(navigator._activeColIterator, TValue());
-}
-
-// Initializes the navigator for a banded alignment.
-template <typename TValue>
-inline void
-_init(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPScoreMatrix, NavigateColumnWise> & navigator,
-      DPMatrix_<TValue, FullDPMatrix> & dpMatrix,
-      DPBandConfig<BandOn> const & band)
-{
-    typedef typename Size<DPMatrix_<TValue, FullDPMatrix> >::Type TMatrixSize;
-    typedef typename MakeSigned<TMatrixSize>::Type TSignedSize;
-    navigator._ptrDataContainer = &dpMatrix;
-
-
-    // Band begins within the first row.
-    if (lowerDiagonal(band) >= 0)
-    {
-        navigator._laneLeap = _min(length(dpMatrix, DPMatrixDimension_::VERTICAL), bandSize(band));
-        navigator._activeColIterator = begin(dpMatrix, Standard()) + _dataLengths(dpMatrix)[DPMatrixDimension_::VERTICAL] - 1;
-    }
-    else if (upperDiagonal(band) <= 0)  // Band begins within the first column.
-    {
-        navigator._laneLeap = 1;
-        navigator._activeColIterator = begin(dpMatrix, Standard());
-    }
-    else  // Band intersects with the point of origin.
-    {
-        TMatrixSize lengthVertical = length(dpMatrix, DPMatrixDimension_::VERTICAL);
-        int lastPos = _max(-static_cast<TSignedSize>(lengthVertical - 1), lowerDiagonal(band));
-        navigator._laneLeap = lengthVertical + lastPos;
-        navigator._activeColIterator = begin(dpMatrix, Standard()) + navigator._laneLeap - 1;
-    }
-    // Set previous iterator to same position, one column left.
-    navigator._prevColIterator = navigator._activeColIterator - _dataFactors(dpMatrix)[DPMatrixDimension_::HORIZONTAL];
-    assignValue(navigator._activeColIterator, TValue());
-}
-
-// ----------------------------------------------------------------------------
-// Function _goNextCell()                          [DPInitialColumn, FirstCell]
-// ----------------------------------------------------------------------------
-
-// In the initial column we don't need to do anything because, the navigagtor is already initialized.
-template <typename TValue>
-inline void
-_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPScoreMatrix, NavigateColumnWise> & /*dpNavigator*/,
+_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, TDPMatrixSpec>, DPScoreMatrix, NavigateColumnWiseBanded> & /*dpNavigator*/,
             MetaColumnDescriptor<DPInitialColumn, PartialColumnTop> const &,
             FirstCell const &)
 {
     // no-op
 }
 
-template <typename TValue>
+// Needed to avoid ambigious overload.
+template <typename TValue, typename TDPMatrixSpec>
 inline void
-_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPScoreMatrix, NavigateColumnWise> & /*dpNavigator*/,
+_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, TDPMatrixSpec>, DPScoreMatrix, NavigateColumnWiseBanded> & /*dpNavigator*/,
             MetaColumnDescriptor<DPInitialColumn, FullColumn> const &,
             FirstCell const &)
 {
     // no-op
 }
 
-template <typename TValue, typename TColumnLocation>
+// specialized for initialization column and all other column locations.
+template <typename TValue, typename TDPMatrixSpec,
+          typename TColumnLocation>
 inline void
-_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPScoreMatrix, NavigateColumnWise> & /*dpNavigator*/,
+_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, TDPMatrixSpec>, DPScoreMatrix, NavigateColumnWiseBanded> & /*dpNavigator*/,
             MetaColumnDescriptor<DPInitialColumn, TColumnLocation> const &,
             FirstCell const &)
 {
     // no-op
 }
 
-// ----------------------------------------------------------------------------
-// Function _goNextCell()                         [PartialColumnTop, FirstCell]
-// ----------------------------------------------------------------------------
-
-// We are in the banded case, where the band crosses the first row.
-// The left cell of the active cell is not valid, beacause we only can come from horizontal direction.
-// The lower left cell of the active cell is the horizontal direction.
-template <typename TValue, typename TColumnType>
+//  specialized for all other column types located at the top.
+template <typename TValue, typename TDPMatrixSpec,
+          typename TColumnType>
 inline void
-_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPScoreMatrix, NavigateColumnWise> & dpNavigator,
+_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, TDPMatrixSpec>, DPScoreMatrix, NavigateColumnWiseBanded> & dpNavigator,
             MetaColumnDescriptor<TColumnType, PartialColumnTop> const &,
             FirstCell const &)
 {
     --dpNavigator._laneLeap;
     dpNavigator._activeColIterator += dpNavigator._laneLeap;
-    dpNavigator._prevColIterator += dpNavigator._laneLeap;
-    dpNavigator._prevCellHorizontal = value(++dpNavigator._prevColIterator);
+    dpNavigator._prevColIterator = dpNavigator._activeColIterator - dpNavigator._prevColIteratorOffset;
+    _scoreOfCell(*dpNavigator._prevCellHorizontal) = _scoreOfCell(*(++dpNavigator._prevColIterator));
+}
+
+template <typename TValue, typename TDPMatrixSpec,
+          typename TColumnType>
+inline void
+_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, TDPMatrixSpec>, DPScoreMatrix, NavigateColumnWiseBanded> & dpNavigator,
+            MetaColumnDescriptor<TColumnType, FullColumn> const &,
+            FirstCell const &)
+{
+    dpNavigator._activeColIterator += dpNavigator._laneLeap;
+    dpNavigator._prevColIterator = dpNavigator._activeColIterator - dpNavigator._prevColIteratorOffset;
+    _scoreOfCell(*dpNavigator._prevCellHorizontal) = _scoreOfCell(*dpNavigator._prevColIterator);
+}
+
+// version for all other column types and locations.
+template <typename TValue, typename TDPMatrixSpec,
+          typename TColumnType, typename TColumnLocation>
+inline void
+_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, TDPMatrixSpec>, DPScoreMatrix, NavigateColumnWiseBanded> & dpNavigator,
+            MetaColumnDescriptor<TColumnType, TColumnLocation> const &,
+            FirstCell const &)
+{
+    dpNavigator._activeColIterator += dpNavigator._laneLeap;
+    dpNavigator._prevColIterator = dpNavigator._activeColIterator - dpNavigator._prevColIteratorOffset;
+    _scoreOfCell(*dpNavigator._prevCellDiagonal) = _scoreOfCell(*dpNavigator._prevColIterator);
+    _scoreOfCell(*dpNavigator._prevCellHorizontal) = _scoreOfCell(*(++dpNavigator._prevColIterator));
 }
 
 // ----------------------------------------------------------------------------
-// Function _goNextCell()                               [FullColumn, FirstCell]
+// Function _goNextCell                                   [unbanded, FirstCell]
 // ----------------------------------------------------------------------------
 
-// We are in the unbanded case or in the middle phase of the wide band.
-// The left cell of the active cell represents horizontal direction.
-template <typename TValue, typename TColumnType>
+// specialized for initalization column.
+template <typename TValue>
+inline void
+_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPScoreMatrix, NavigateColumnWise> & /*dpNavigator*/,
+            MetaColumnDescriptor<DPInitialColumn, FullColumn> const &,
+            FirstCell const &)
+{
+    // no-op
+}
+
+// all other column types.
+template <typename TValue,
+          typename TColumnType>
 inline void
 _goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPScoreMatrix, NavigateColumnWise> & dpNavigator,
             MetaColumnDescriptor<TColumnType, FullColumn> const &,
             FirstCell const &)
 {
+    // Set to begin of column.
     dpNavigator._activeColIterator += dpNavigator._laneLeap;
-    dpNavigator._prevColIterator += dpNavigator._laneLeap;
-    dpNavigator._prevCellHorizontal = value(dpNavigator._prevColIterator);
+    dpNavigator._prevColIterator = dpNavigator._activeColIterator - dpNavigator._prevColIteratorOffset;
+    // Cache prevDiagH value. Becomes the next diagonal reference value.
+    _scoreOfCell(*dpNavigator._prevCellHorizontal) = _scoreOfCell(*dpNavigator._prevColIterator);
+
 }
 
 // ----------------------------------------------------------------------------
-// Function _goNextCell() [PartialColumnMiddle, PartialColumnBottom, FirstCell]
+// Function _goNextCell                                     [banded, InnerCell]
 // ----------------------------------------------------------------------------
 
-// We are in the banded case.
-// The left cell of the active cell represents diagonal direction. The lower left diagonal represents the horizontal direction.
-
-template <typename TValue, typename TColumnType, typename TColumnLocation>
+// specilized for the initialization column and all column locations.
+template <typename TValue, typename TDPMatrixSpec,
+          typename TColumnLocation>
 inline void
-_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPScoreMatrix, NavigateColumnWise> & dpNavigator,
-            MetaColumnDescriptor<TColumnType, TColumnLocation> const &,
-            FirstCell const &)
-{
-    dpNavigator._activeColIterator += dpNavigator._laneLeap;
-    dpNavigator._prevColIterator += dpNavigator._laneLeap;
-    dpNavigator._prevCellDiagonal = value(dpNavigator._prevColIterator);
-    dpNavigator._prevCellHorizontal = value(++dpNavigator._prevColIterator);
-}
-
-// ----------------------------------------------------------------------------
-// Function _goNextCell                            [DPInitialColumn, InnerCell]
-// ----------------------------------------------------------------------------
-
-// If we are in the initial column, we only need to represent the vertical direction.
-// But we still have to update the previous column iterator.
-template <typename TValue, typename TColumnLocation>
-inline void
-_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPScoreMatrix, NavigateColumnWise> & dpNavigator,
+_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, TDPMatrixSpec>, DPScoreMatrix, NavigateColumnWiseBanded> & dpNavigator,
             MetaColumnDescriptor<DPInitialColumn, TColumnLocation> const &,
             InnerCell const &)
 {
-    dpNavigator._prevCellVertical = value(dpNavigator._activeColIterator);
+    _cachePrevVertical(dpNavigator);
     ++dpNavigator._activeColIterator;
-    ++dpNavigator._prevColIterator;  // Do we have to increase the prevColIterator....
 }
 
-// ----------------------------------------------------------------------------
-// Function _goNextCell                                  [AnyColumn, InnerCell]
-// ----------------------------------------------------------------------------
-
-// For any other column type and location we can use the same navigation procedure.
-template <typename TValue, typename TColumnType, typename TColumnLocation>
+// specialized for the standard band processing.
+template <typename TValue, typename TDPMatrixSpec,
+          typename TColumnType, typename TColumnLocation>
 inline void
-_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPScoreMatrix, NavigateColumnWise> & dpNavigator,
+_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, TDPMatrixSpec>, DPScoreMatrix, NavigateColumnWiseBanded> & dpNavigator,
             MetaColumnDescriptor<TColumnType, TColumnLocation> const &,
             InnerCell const &)
 {
-    dpNavigator._prevCellDiagonal = dpNavigator._prevCellHorizontal;
-    dpNavigator._prevCellVertical = value(dpNavigator._activeColIterator);
-    dpNavigator._prevCellHorizontal = value(++dpNavigator._prevColIterator);
+    _cachePrevVertical(dpNavigator);
+    _scoreOfCell(*dpNavigator._prevCellDiagonal) = _scoreOfCell(*dpNavigator._prevCellHorizontal);
     ++dpNavigator._activeColIterator;
+    _scoreOfCell(*dpNavigator._prevCellHorizontal) = _scoreOfCell(*(++dpNavigator._prevColIterator));
 }
 
 // ----------------------------------------------------------------------------
-// Function _goNextCell                             [DPInitialColumn, LastCell]
+// Function _goNextCell                                   [unbanded, InnerCell]
 // ----------------------------------------------------------------------------
 
-// If we are in the initial column we only need to represent the vertical direction.
-// But we still have to update the previous column iterator.
-template <typename TValue, typename TColumnLocation>
-inline void
-_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPScoreMatrix, NavigateColumnWise> & dpNavigator,
-            MetaColumnDescriptor<DPInitialColumn, TColumnLocation> const &,
-            LastCell const &)
-{
-    dpNavigator._prevCellVertical = value(dpNavigator._activeColIterator);
-    ++dpNavigator._activeColIterator;
-    ++dpNavigator._prevColIterator;
-}
-
-// We need this function to avoid ambiguous function calls.
+// specialized for the initialization column.
 template <typename TValue>
 inline void
 _goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPScoreMatrix, NavigateColumnWise> & dpNavigator,
+            MetaColumnDescriptor<DPInitialColumn, FullColumn> const &,
+            InnerCell const &)
+{
+    _cachePrevVertical(dpNavigator);
+    ++dpNavigator._activeColIterator;
+}
+
+// version for the all other column types.
+template <typename TValue,
+          typename TColumnType>
+inline void
+_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPScoreMatrix, NavigateColumnWise> & dpNavigator,
+            MetaColumnDescriptor<TColumnType, FullColumn> const &,
+            InnerCell const &)
+{
+    _cachePrevVertical(dpNavigator);
+    // Cache prevDiag from prevDiagH;
+    _scoreOfCell(*dpNavigator._prevCellDiagonal) = _scoreOfCell(*dpNavigator._prevCellHorizontal);
+    // Cache prevDiagH from current;
+    _scoreOfCell(*dpNavigator._prevCellHorizontal) = _scoreOfCell(*(++dpNavigator._prevColIterator));
+    ++dpNavigator._activeColIterator;
+}
+
+// ----------------------------------------------------------------------------
+// Function _goNextCell                                      [banded, LastCell]
+// ----------------------------------------------------------------------------
+
+// specilaized for initialization column and bottom column.
+template <typename TValue, typename TDPMatrixSpec>
+inline void
+_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, TDPMatrixSpec>, DPScoreMatrix, NavigateColumnWiseBanded> & dpNavigator,
             MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom> const &,
             LastCell const &)
 {
-    dpNavigator._prevCellVertical = value(dpNavigator._activeColIterator);
+    // dpNavigator._prevCellVertical = value(dpNavigator._activeColIterator);
+    _cachePrevVertical(dpNavigator);
+    ++dpNavigator._activeColIterator;
+}
+
+// specilaized for initialization column and all other column locations.
+template <typename TValue, typename TDPMatrixSpec,
+          typename TColumnLocation>
+inline void
+_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, TDPMatrixSpec>, DPScoreMatrix, NavigateColumnWiseBanded> & dpNavigator,
+            MetaColumnDescriptor<DPInitialColumn, TColumnLocation> const &,
+            LastCell const &)
+{
+    _cachePrevVertical(dpNavigator);
+    ++dpNavigator._activeColIterator;
+}
+
+// specialized for all column types and bottom column.
+template <typename TValue, typename TDPMatrixSpec,
+          typename TColumnType>
+inline void
+_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, TDPMatrixSpec>, DPScoreMatrix, NavigateColumnWiseBanded> & dpNavigator,
+            MetaColumnDescriptor<TColumnType, PartialColumnBottom> const &,
+            LastCell const &)
+{
+    _cachePrevVertical(dpNavigator);
+    _scoreOfCell(*dpNavigator._prevCellDiagonal) = _scoreOfCell(*dpNavigator._prevCellHorizontal);
+    ++dpNavigator._activeColIterator;
+    ++dpNavigator._prevColIterator;
+    ++dpNavigator._laneLeap;
+}
+
+// generic case for all other column types and column locations.
+template <typename TValue, typename TDPMatrixSpec,
+          typename TColumnType, typename TColumnLocation>
+inline void
+_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, TDPMatrixSpec>, DPScoreMatrix, NavigateColumnWiseBanded> & dpNavigator,
+            MetaColumnDescriptor<TColumnType, TColumnLocation> const &,
+            LastCell const &)
+{
+    _cachePrevVertical(dpNavigator);
+    _scoreOfCell(*dpNavigator._prevCellDiagonal) = _scoreOfCell(*dpNavigator._prevCellHorizontal);
     ++dpNavigator._activeColIterator;
     ++dpNavigator._prevColIterator;
 }
 
-// We need this function to avoid ambiguous function calls.
+// ----------------------------------------------------------------------------
+// Function _goNextCell                                    [unbanded, LastCell]
+// ----------------------------------------------------------------------------
+
+// specilaized for initialization column.
 template <typename TValue>
 inline void
 _goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPScoreMatrix, NavigateColumnWise> & dpNavigator,
             MetaColumnDescriptor<DPInitialColumn, FullColumn> const &,
             LastCell const &)
 {
-    dpNavigator._prevCellVertical = value(dpNavigator._activeColIterator);
+    _cachePrevVertical(dpNavigator);
     ++dpNavigator._activeColIterator;
-    ++dpNavigator._prevColIterator;
 }
 
-// ----------------------------------------------------------------------------
-// Function _goNextCell                                  [FullColumn, LastCell]
-// ----------------------------------------------------------------------------
-
-// If we are in a full column the values correspond to standard dp directions.
-template <typename TValue, typename TColumnType>
+// version for all other column types.
+template <typename TValue,
+          typename TColumnType>
 inline void
 _goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPScoreMatrix, NavigateColumnWise> & dpNavigator,
             MetaColumnDescriptor<TColumnType, FullColumn> const &,
             LastCell const &)
 {
-    dpNavigator._prevCellDiagonal = dpNavigator._prevCellHorizontal;
-    dpNavigator._prevCellVertical = value(dpNavigator._activeColIterator);
-    dpNavigator._prevCellHorizontal = value(++dpNavigator._prevColIterator);
-    ++dpNavigator._activeColIterator;
+    // Cache the vertical cells: prevDiagV and vertical.
+    _cachePrevVertical(dpNavigator);
+    // Cache prevDiag from prevDiagH
+    _scoreOfCell(*dpNavigator._prevCellDiagonal) = _scoreOfCell(*dpNavigator._prevCellHorizontal);
+    ++dpNavigator._activeColIterator; // go to next cell.
+    ++dpNavigator._prevColIterator; // go to next cell.
 }
 
 // ----------------------------------------------------------------------------
-// Function _goNextCell                         [PartialColumnBottom, LastCell]
+// Function _cachePrevVertical()
 // ----------------------------------------------------------------------------
 
-// If we are in banded case and are the band crosses the last row, we have to update
-// the additional leap for the current track.
-template <typename TValue, typename TColumnType>
+template <typename TValue, typename TGapSpec, typename TMatrixSpec, typename TNavigationSpec>
 inline void
-_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPScoreMatrix, NavigateColumnWise> & dpNavigator,
-            MetaColumnDescriptor<TColumnType, PartialColumnBottom> const &,
-            LastCell const &)
+_cachePrevVertical(DPMatrixNavigator_<DPMatrix_<DPCell_<TValue, TGapSpec>, TMatrixSpec>, DPScoreMatrix, TNavigationSpec> & dpNavigator)
 {
-    dpNavigator._prevCellDiagonal = dpNavigator._prevCellHorizontal;
-    dpNavigator._prevCellVertical = value(dpNavigator._activeColIterator);
-    dpNavigator._prevCellHorizontal = value(++dpNavigator._prevColIterator);
-    ++dpNavigator._activeColIterator;
-    ++dpNavigator._laneLeap;
+    // Cache prevVerical.
+    *dpNavigator._prevCellVertical = *dpNavigator._activeColIterator;
 }
 
-// ----------------------------------------------------------------------------
-// Function _goNextCell      [PartialColumnTop & PartialColumnBottom, LastCell]
-// ----------------------------------------------------------------------------
-
-// If we are in the banded case the left cell of the active represents the diagonal direction.
-template <typename TValue, typename TColumnType, typename TColumnLocation>
+template <typename TValue, typename TMatrixSpec, typename TNavigationSpec>
 inline void
-_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPScoreMatrix, NavigateColumnWise> & dpNavigator,
-            MetaColumnDescriptor<TColumnType, TColumnLocation> const &,
-            LastCell const &)
+_cachePrevVertical(DPMatrixNavigator_<DPMatrix_<DPCell_<TValue, AffineGaps>, TMatrixSpec>, DPScoreMatrix, TNavigationSpec> & dpNavigator)
 {
-    dpNavigator._prevCellDiagonal = dpNavigator._prevCellHorizontal;
-    dpNavigator._prevCellVertical = value(dpNavigator._activeColIterator);
-    ++dpNavigator._activeColIterator;
+    // Cache prevDiagV.
+    _verticalScoreOfCell(*dpNavigator._prevCellVertical) = _verticalScoreOfCell(*dpNavigator._activeColIterator);
+    // Cache prevVerical.
+    _scoreOfCell(*dpNavigator._prevCellVertical) = _scoreOfCell(*dpNavigator._activeColIterator);
 }
 
 // ----------------------------------------------------------------------------
@@ -356,14 +412,14 @@ template <typename TDPMatrix, typename TNavigationSpec>
 inline typename Reference<DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, TNavigationSpec> >::Type
 previousCellDiagonal(DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, TNavigationSpec> & dpNavigator)
 {
-    return dpNavigator._prevCellDiagonal;
+    return *dpNavigator._prevCellDiagonal;
 }
 
 template <typename TDPMatrix, typename TNavigationSpec>
 inline typename Reference<DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, TNavigationSpec> const>::Type
 previousCellDiagonal(DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, TNavigationSpec> const & dpNavigator)
 {
-    return dpNavigator._prevCellDiagonal;
+    return *dpNavigator._prevCellDiagonal;
 }
 
 // ----------------------------------------------------------------------------
@@ -374,14 +430,14 @@ template <typename TDPMatrix, typename TNavigationSpec>
 inline typename Reference<DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, TNavigationSpec> >::Type
 previousCellHorizontal(DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, TNavigationSpec> & dpNavigator)
 {
-    return dpNavigator._prevCellHorizontal;
+    return *dpNavigator._prevColIterator;
 }
 
 template <typename TDPMatrix, typename TNavigationSpec>
 inline typename Reference<DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, TNavigationSpec> const>::Type
 previousCellHorizontal(DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, TNavigationSpec> const & dpNavigator)
 {
-    return dpNavigator._prevCellHorizontal;
+    return *dpNavigator._prevColIterator;
 }
 
 // ----------------------------------------------------------------------------
@@ -392,14 +448,30 @@ template <typename TDPMatrix, typename TNavigationSpec>
 inline typename Reference<DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, TNavigationSpec> >::Type
 previousCellVertical(DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, TNavigationSpec> & dpNavigator)
 {
-    return dpNavigator._prevCellVertical;
+    return *dpNavigator._prevCellVertical;
 }
 
 template <typename TDPMatrix, typename TNavigationSpec>
 inline typename Reference<DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, TNavigationSpec> const>::Type
 previousCellVertical(DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, TNavigationSpec> const & dpNavigator)
 {
-    return dpNavigator._prevCellVertical;
+    return *dpNavigator._prevCellVertical;
+}
+
+// ----------------------------------------------------------------------------
+// Function setCachedCells()
+// ----------------------------------------------------------------------------
+
+template <typename TValue, typename TMatrixSpec, typename TNavigationSpec>
+inline void
+setCachedCells(DPMatrixNavigator_<DPMatrix_<TValue, TMatrixSpec>, DPScoreMatrix, TNavigationSpec> & dpNavigator,
+               TValue & prevDiag,
+               TValue & prevHor,
+               TValue & prevVer)
+{
+    dpNavigator._prevCellDiagonal = &prevDiag;
+    dpNavigator._prevCellHorizontal = &prevHor;
+    dpNavigator._prevCellVertical = &prevVer;
 }
 
 }  // namespace seqan

--- a/include/seqan/align/dp_matrix_navigator_score_matrix_sparse.h
+++ b/include/seqan/align/dp_matrix_navigator_score_matrix_sparse.h
@@ -1,3 +1,4 @@
+
 // ==========================================================================
 //                 SeqAn - The Library for Sequence Analysis
 // ==========================================================================
@@ -54,21 +55,63 @@ namespace seqan {
 // ----------------------------------------------------------------------------
 
 // Specialization of the score matrix navigator for a sparse dp matrix.
-template <typename TValue>
-class DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWise>
+template <typename TValue, typename TNavigationSpec>
+class DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, TNavigationSpec>
 {
 public:
     typedef  DPMatrix_<TValue, SparseDPMatrix> TDPMatrix_;
     typedef typename Pointer_<TDPMatrix_>::Type TDPMatrixPointer_;
     typedef typename Iterator<TDPMatrix_, Standard>::Type TDPMatrixIterator;
 
-    TDPMatrixPointer_ _ptrDataContainer     = nullptr;  // Pointer to the underlying matrix to navigate on.
-    int _laneLeap                           = 0;  // The distance to leap when going to the next column.
-    TDPMatrixIterator _activeColIterator    = TDPMatrixIterator();  // The iterator over the active column.
-    TDPMatrixIterator _prevColIterator      = TDPMatrixIterator();  // The iterator over the previous column.
-    TValue _prevCellDiagonal                = TValue();  // The previous value in diagonal direction.
-    TValue _prevCellHorizontal              = TValue();  // The previous value in horizontal direction.
-    TValue _prevCellVertical                = TValue();  // The previous value in vertical direction.
+    template <typename TBandSpec,
+              std::enable_if_t<std::is_same<TBandSpec, BandOff>::value, int> = 0>
+    DPMatrixNavigator_(DPMatrix_<TValue, SparseDPMatrix> & matrix,
+                       DPBandConfig<TBandSpec> const & /*band*/)
+    {
+        _ptrDataContainer = &matrix;
+        _activeColIterator = begin(matrix, Standard());
+        _prevColIterator = _activeColIterator;
+        _laneLeap = 1 - _dataLengths(matrix)[DPMatrixDimension_::VERTICAL];
+        *_activeColIterator = TValue{};
+    }
+
+    template <typename TBandSpec,
+              std::enable_if_t<!std::is_same<TBandSpec, BandOff>::value, int> = 0>
+    DPMatrixNavigator_(DPMatrix_<TValue, SparseDPMatrix> & matrix,
+                       DPBandConfig<TBandSpec> const & band)
+    {
+        typedef typename Size<DPMatrix_<TValue, SparseDPMatrix>>::Type TSize;
+        typedef std::make_signed_t<TSize> TSignedSize;
+        _ptrDataContainer = &matrix;
+
+        // Band begins within the first row.
+        if (lowerDiagonal(band) >= 0)
+        {
+            _laneLeap = 0;
+            _activeColIterator = begin(matrix, Standard()) + length(matrix, DPMatrixDimension_::VERTICAL) - 1;
+        }
+        else if (upperDiagonal(band) <= 0) // Band begins within the first column
+        {
+            _laneLeap = 1 - _dataLengths(matrix)[DPMatrixDimension_::VERTICAL];
+            _activeColIterator = begin(matrix, Standard());
+        }
+        else  // Band intersects with the point of origin.
+        {
+            _laneLeap = _max(lowerDiagonal(band), 1 - static_cast<TSignedSize>(length(matrix, DPMatrixDimension_::VERTICAL)));
+            _activeColIterator = begin(matrix, Standard()) + length(matrix, DPMatrixDimension_::VERTICAL) + _laneLeap - 1;
+        }
+        _prevColIterator = _activeColIterator;
+        *_activeColIterator = TValue{};
+    }
+
+    TDPMatrixPointer_ _ptrDataContainer   = nullptr;  // Pointer to the underlying matrix to navigate on.
+    TValue* _prevCellDiagonal             = nullptr;  // Cached value for diagonal direction.
+    TValue* _prevCellHorizontal           = nullptr;  // Cached value for horizontal direction.
+    TValue* _prevCellVertical             = nullptr;  // Cached value for vertical direction.
+    int _laneLeap                         = 0;  // The distance to leap when going to the next column.
+    size_t _prevColIteratorOffset         = 0;  // Offset to reset the previous column iterator when going to the next cell.
+    TDPMatrixIterator _activeColIterator  = TDPMatrixIterator();  // The iterator over the active column.
+    TDPMatrixIterator _prevColIterator    = TDPMatrixIterator();  // The iterator over the previous column. Only needed in the banded case.
 };
 
 // ============================================================================
@@ -80,73 +123,10 @@ public:
 // ============================================================================
 
 // ----------------------------------------------------------------------------
-// Function _init()
+// Function _goNextCell                                   [unbanded, FirstCell]
 // ----------------------------------------------------------------------------
 
-
-// Initializes the navigator for unbanded alignments
-template <typename TValue>
-inline void
-_init(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWise> & navigator,
-      DPMatrix_<TValue, SparseDPMatrix> & dpMatrix,
-      DPBandConfig<BandOff> const &)
-{
-    navigator._ptrDataContainer = &dpMatrix;
-    navigator._activeColIterator = begin(dpMatrix, Standard());
-    navigator._prevColIterator = navigator._activeColIterator;
-    navigator._laneLeap = 1 - _dataLengths(dpMatrix)[DPMatrixDimension_::VERTICAL];
-    assignValue(navigator._activeColIterator, TValue());
-}
-
-// Initializes the navigator for banded alignments
-template <typename TValue>
-inline void
-_init(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWise> & navigator,
-      DPMatrix_<TValue, SparseDPMatrix> & dpMatrix,
-      DPBandConfig<BandOn> const & band)
-{
-    typedef DPMatrix_<TValue, SparseDPMatrix> TSparseDPMatrix;
-    typedef typename Size<TSparseDPMatrix>::Type TSize;
-    typedef typename MakeSigned<TSize>::Type TSignedSize;
-    navigator._ptrDataContainer = &dpMatrix;
-
-    // Band begins within the first row.
-    if (lowerDiagonal(band) >= 0)
-    {
-        navigator._laneLeap = 0;
-        navigator._activeColIterator = begin(dpMatrix, Standard()) + length(dpMatrix, DPMatrixDimension_::VERTICAL) - 1;
-    }
-    else if (upperDiagonal(band) <= 0) // Band begins within the first column
-    {
-        navigator._laneLeap = 1 - _dataLengths(dpMatrix)[DPMatrixDimension_::VERTICAL];
-        navigator._activeColIterator = begin(dpMatrix, Standard());
-    }
-    else  // Band intersects with the point of origin.
-    {
-        navigator._laneLeap = _max(lowerDiagonal(band), 1 - static_cast<TSignedSize>(length(dpMatrix, DPMatrixDimension_::VERTICAL)));
-        navigator._activeColIterator = begin(dpMatrix, Standard()) + length(dpMatrix, DPMatrixDimension_::VERTICAL) + navigator._laneLeap - 1;
-    }
-    navigator._prevColIterator = navigator._activeColIterator;
-    assignValue(navigator._activeColIterator, TValue());
-}
-
-// ----------------------------------------------------------------------------
-// Function _goNextCell()        [DPInitialColumn, PartialColumnTop, FirstCell]
-// ----------------------------------------------------------------------------
-
-template <typename TValue>
-inline void
-_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWise> & /*dpNavigator*/,
-            MetaColumnDescriptor<DPInitialColumn, PartialColumnTop> const &,
-            FirstCell const &)
-{
-    // no-op
-}
-
-// ----------------------------------------------------------------------------
-// Function _goNextCell()              [DPInitialColumn, FullColumn, FirstCell]
-// ----------------------------------------------------------------------------
-
+// specialized for initalization column.
 template <typename TValue>
 inline void
 _goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWise> & /*dpNavigator*/,
@@ -156,212 +136,148 @@ _goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix,
     // no-op
 }
 
-// ----------------------------------------------------------------------------
-// Function _goNextCell()                          [DPInitialColumn, FirstCell]
-// ----------------------------------------------------------------------------
-
-template <typename TValue, typename TColumnLocation>
-inline void
-_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWise> & /*dpNavigator*/,
-            MetaColumnDescriptor<DPInitialColumn, TColumnLocation> const &,
-            FirstCell const &)
-{
-    // no-op
-}
-
-// ----------------------------------------------------------------------------
-// Function _goNextCell()                         [PartialColumnTop, FirstCell]
-// ----------------------------------------------------------------------------
-
-template <typename TValue, typename TColumnType>
-inline void
-_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWise> & dpNavigator,
-            MetaColumnDescriptor<TColumnType, PartialColumnTop> const &,
-            FirstCell const &)
-{
-    --dpNavigator._laneLeap;
-    dpNavigator._activeColIterator += dpNavigator._laneLeap;
-    dpNavigator._prevColIterator = dpNavigator._activeColIterator;
-    dpNavigator._prevCellHorizontal = value(++dpNavigator._prevColIterator);
-}
-
-// ----------------------------------------------------------------------------
-// Function _goNextCell()                               [FullColumn, FirstCell]
-// ----------------------------------------------------------------------------
-
-template <typename TValue, typename TColumnType>
+// all other column types.
+template <typename TValue,
+          typename TColumnType>
 inline void
 _goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWise> & dpNavigator,
             MetaColumnDescriptor<TColumnType, FullColumn> const &,
             FirstCell const &)
 {
+    // Set to begin of column.
     dpNavigator._activeColIterator += dpNavigator._laneLeap;
-    dpNavigator._prevCellHorizontal = value(dpNavigator._activeColIterator);
+    // Cache prevDiagH value. Becomes the next diagonal reference value.
+    _scoreOfCell(*dpNavigator._prevCellHorizontal) = _scoreOfCell(*dpNavigator._activeColIterator);
 }
 
 // ----------------------------------------------------------------------------
-// Function _goNextCell()                                           [FirstCell]
+// Function _goNextCell                                   [unbanded, InnerCell]
 // ----------------------------------------------------------------------------
 
-template <typename TValue, typename TColumnType, typename TColumnLocation>
-inline void
-_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWise> & dpNavigator,
-            MetaColumnDescriptor<TColumnType, TColumnLocation> const &,
-            FirstCell const &)
-{
-    dpNavigator._activeColIterator += dpNavigator._laneLeap;
-    dpNavigator._prevColIterator = dpNavigator._activeColIterator;
-    dpNavigator._prevCellDiagonal = value(dpNavigator._prevColIterator);
-    dpNavigator._prevCellHorizontal = value(++dpNavigator._prevColIterator);
-}
-
-// ----------------------------------------------------------------------------
-// Function _goNextCell                            [DPInitialColumn, InnerCell]
-// ----------------------------------------------------------------------------
-
-template <typename TValue, typename TColumnLocation>
-inline void
-_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWise> & dpNavigator,
-            MetaColumnDescriptor<DPInitialColumn, TColumnLocation> const &,
-            InnerCell const &)
-{
-    dpNavigator._prevCellVertical = value(dpNavigator._activeColIterator);
-    ++dpNavigator._activeColIterator;
-}
-
-// ----------------------------------------------------------------------------
-// Function _goNextCell                [DPInitialColumn, FullColumn, InnerCell]
-// ----------------------------------------------------------------------------
-
+// specialized for the initialization column.
 template <typename TValue>
 inline void
 _goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWise> & dpNavigator,
             MetaColumnDescriptor<DPInitialColumn, FullColumn> const &,
             InnerCell const &)
 {
-    dpNavigator._prevCellVertical = value(dpNavigator._activeColIterator);
+    // dpNavigator._prevCellVertical = value(dpNavigator._activeColIterator);
+    _cachePrevVertical(dpNavigator);
     ++dpNavigator._activeColIterator;
 }
 
-// ----------------------------------------------------------------------------
-// Function _goNextCell                                             [InnerCell]
-// ----------------------------------------------------------------------------
-
-template <typename TValue, typename TColumnType, typename TColumnLocation>
-inline void
-_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWise> & dpNavigator,
-            MetaColumnDescriptor<TColumnType, TColumnLocation> const &,
-            InnerCell const &)
-{
-    dpNavigator._prevCellDiagonal = dpNavigator._prevCellHorizontal;
-    dpNavigator._prevCellVertical = value(dpNavigator._activeColIterator);
-    dpNavigator._prevCellHorizontal = value(++dpNavigator._prevColIterator);
-    ++dpNavigator._activeColIterator;
-}
-
-// ----------------------------------------------------------------------------
-// Function _goNextCell                                 [FullColumn, InnerCell]
-// ----------------------------------------------------------------------------
-
-template <typename TValue, typename TColumnType>
+// version for the all other column types.
+template <typename TValue,
+          typename TColumnType>
 inline void
 _goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWise> & dpNavigator,
             MetaColumnDescriptor<TColumnType, FullColumn> const &,
             InnerCell const &)
 {
-    dpNavigator._prevCellDiagonal = dpNavigator._prevCellHorizontal;
-    dpNavigator._prevCellVertical = value(dpNavigator._activeColIterator);
-    dpNavigator._prevCellHorizontal = value(++dpNavigator._activeColIterator);
+    // Cache prevDiagV and vertical.
+    _cachePrevVertical(dpNavigator);
+    // Cache prevDiag from prevDiagH;
+    _scoreOfCell(*dpNavigator._prevCellDiagonal) = _scoreOfCell(*dpNavigator._prevCellHorizontal);
+    // Cache prevDiagH from current;
+    _scoreOfCell(*dpNavigator._prevCellHorizontal) = _scoreOfCell(*(++dpNavigator._activeColIterator));
 }
 
 // ----------------------------------------------------------------------------
-// Function _goNextCell                             [DPInitialColumn, LastCell]
+// Function _goNextCell                                    [unbanded, LastCell]
 // ----------------------------------------------------------------------------
 
-template <typename TValue, typename TColumnLocation>
-inline void
-_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWise> & dpNavigator,
-            MetaColumnDescriptor<DPInitialColumn, TColumnLocation> const &,
-            LastCell const &)
-{
-    dpNavigator._prevCellVertical = value(dpNavigator._activeColIterator);
-    ++dpNavigator._activeColIterator;
-}
-
-// ----------------------------------------------------------------------------
-// Function _goNextCell        [DPInitialColumn, PartialColumnBottom, LastCell]
-// ----------------------------------------------------------------------------
-
-template <typename TValue>
-inline void
-_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWise> & dpNavigator,
-            MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom> const &,
-            LastCell const &)
-{
-    dpNavigator._prevCellVertical = value(dpNavigator._activeColIterator);
-    ++dpNavigator._activeColIterator;
-}
-
-// ----------------------------------------------------------------------------
-// Function _goNextCell                 [DPInitialColumn, FullColumn, LastCell]
-// ----------------------------------------------------------------------------
-
+// specilaized for initialization column.
 template <typename TValue>
 inline void
 _goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWise> & dpNavigator,
             MetaColumnDescriptor<DPInitialColumn, FullColumn> const &,
             LastCell const &)
 {
-    dpNavigator._prevCellVertical = value(dpNavigator._activeColIterator);
+    _cachePrevVertical(dpNavigator);
     ++dpNavigator._activeColIterator;
 }
 
-// ----------------------------------------------------------------------------
-// Function _goNextCell                                              [LastCell]
-// ----------------------------------------------------------------------------
-
-template <typename TValue, typename TColumnType, typename TColumnLocation>
-inline void
-_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWise> & dpNavigator,
-            MetaColumnDescriptor<TColumnType, TColumnLocation> const &,
-            LastCell const &)
-{
-    dpNavigator._prevCellDiagonal = dpNavigator._prevCellHorizontal;
-    dpNavigator._prevCellVertical = value(dpNavigator._activeColIterator);
-    ++dpNavigator._activeColIterator;
-}
-
-// ----------------------------------------------------------------------------
-// Function _goNextCell                         [PartialColumnBottom, LastCell]
-// ----------------------------------------------------------------------------
-
-template <typename TValue, typename TColumnType>
-inline void
-_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWise> & dpNavigator,
-            MetaColumnDescriptor<TColumnType, PartialColumnBottom> const &,
-            LastCell const &)
-{
-    dpNavigator._prevCellDiagonal = dpNavigator._prevCellHorizontal;
-    dpNavigator._prevCellVertical = value(dpNavigator._activeColIterator);
-    dpNavigator._prevCellHorizontal = value(++dpNavigator._prevColIterator);
-    ++dpNavigator._activeColIterator;
-    ++dpNavigator._laneLeap;
-}
-
-// ----------------------------------------------------------------------------
-// Function _goNextCell                                  [FullColumn, LastCell]
-// ----------------------------------------------------------------------------
-
-
-template <typename TValue, typename TColumnType>
+// version for all other column types.
+template <typename TValue,
+          typename TColumnType>
 inline void
 _goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWise> & dpNavigator,
             MetaColumnDescriptor<TColumnType, FullColumn> const &,
             LastCell const &)
 {
-    dpNavigator._prevCellDiagonal = dpNavigator._prevCellHorizontal;
-    dpNavigator._prevCellVertical = value(dpNavigator._activeColIterator);
-    dpNavigator._prevCellHorizontal = value(++dpNavigator._activeColIterator);
+    _cachePrevVertical(dpNavigator);
+    _scoreOfCell(*dpNavigator._prevCellDiagonal) = _scoreOfCell(*dpNavigator._prevCellHorizontal);
+    ++dpNavigator._activeColIterator; // go to next cell.
+}
+
+// ----------------------------------------------------------------------------
+// Function previousCellDiagonal()
+// ----------------------------------------------------------------------------
+
+template <typename TValue, typename TNavigationSpec>
+inline typename Reference<DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, TNavigationSpec> >::Type
+previousCellDiagonal(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, TNavigationSpec> & dpNavigator)
+{
+    return *dpNavigator._prevCellDiagonal;
+}
+
+template <typename TValue, typename TNavigationSpec>
+inline typename Reference<DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, TNavigationSpec> const>::Type
+previousCellDiagonal(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, TNavigationSpec> const & dpNavigator)
+{
+    return *dpNavigator._prevCellDiagonal;
+}
+
+// ----------------------------------------------------------------------------
+// Function previousCellHorizontal()
+// ----------------------------------------------------------------------------
+
+// unbanded.
+template <typename TValue>
+inline typename Reference<DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWise> >::Type
+previousCellHorizontal(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWise> & dpNavigator)
+{
+    return *dpNavigator._activeColIterator;
+}
+
+template <typename TValue, typename TNavigationSpec>
+inline typename Reference<DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWise> const>::Type
+previousCellHorizontal(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWise> const & dpNavigator)
+{
+    return *dpNavigator._activeColIterator;
+}
+
+// banded.
+template <typename TValue>
+inline typename Reference<DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWiseBanded> >::Type
+previousCellHorizontal(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWiseBanded> & dpNavigator)
+{
+    return *dpNavigator._prevColIterator;
+}
+
+template <typename TValue, typename TNavigationSpec>
+inline typename Reference<DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWiseBanded> const>::Type
+previousCellHorizontal(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, NavigateColumnWiseBanded> const & dpNavigator)
+{
+    return *(dpNavigator._prevColIterator);
+}
+
+// ----------------------------------------------------------------------------
+// Function previousCellVertical()
+// ----------------------------------------------------------------------------
+
+template <typename TValue, typename TNavigationSpec>
+inline typename Reference<DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, TNavigationSpec> >::Type
+previousCellVertical(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, TNavigationSpec> & dpNavigator)
+{
+    return *dpNavigator._prevCellVertical;
+}
+
+template <typename TValue, typename TNavigationSpec>
+inline typename Reference<DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, TNavigationSpec> const>::Type
+previousCellVertical(DPMatrixNavigator_<DPMatrix_<TValue, SparseDPMatrix>, DPScoreMatrix, TNavigationSpec> const & dpNavigator)
+{
+    return *dpNavigator._prevCellVertical;
 }
 
 }  // namespace seqan

--- a/include/seqan/align/dp_matrix_navigator_trace_matrix.h
+++ b/include/seqan/align/dp_matrix_navigator_trace_matrix.h
@@ -64,14 +64,65 @@ namespace seqan {
 // specifies that this is a trace-matrix navigator while the TTraceFlag can either
 // be TracebackOn to enable the navigator or TracebackOff to disable it.
 // The last parameter specifies the kind of navigation.
-template <typename TValue, typename TTraceFlag>
-class DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, NavigateColumnWise>
+template <typename TValue, typename TTraceFlag, typename TNavigationSpec>
+class DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, TNavigationSpec>
 {
 public:
 
     typedef  DPMatrix_<TValue, FullDPMatrix> TDPMatrix_;
     typedef typename Pointer_<TDPMatrix_>::Type TDPMatrixPointer_;
     typedef typename Iterator<TDPMatrix_, Standard>::Type TDPMatrixIterator;
+
+    template <typename TBandSpec,
+              std::enable_if_t<std::is_same<TBandSpec, BandOff>::value, int> = 0>
+    DPMatrixNavigator_(DPMatrix_<TValue, FullDPMatrix> & matrix,
+                       DPBandConfig<TBandSpec> const & /*band*/)
+    {
+        if (IsSameType<TTraceFlag, TracebackOff>::VALUE)
+            return;  // Leave navigator uninitialized because it is never used.
+
+        _ptrDataContainer = &matrix;
+        _activeColIterator = begin(matrix, Standard());
+        _laneLeap = 1;
+        *_activeColIterator = TValue{};
+    }
+
+    template <typename TBandSpec,
+              std::enable_if_t<!std::is_same<TBandSpec, BandOff>::value, int> = 0>
+    DPMatrixNavigator_(DPMatrix_<TValue, FullDPMatrix> & matrix,
+                       DPBandConfig<TBandSpec> const & band)
+    {
+        using TMatrixSize = typename Size<DPMatrix_<TValue, FullDPMatrix>>::Type;
+        using TSignedSize = std::make_signed_t<TMatrixSize>;
+
+        if (std::is_same<TTraceFlag, TracebackOff>::value)
+            return;  // Leave navigator as is because it should never be used.
+
+        _ptrDataContainer = &matrix;
+
+        // Band begins within the first row.
+        if (lowerDiagonal(band) >= 0)
+        {
+            // The first cell of the first column starts at the last cell in the matrix of the current column.
+            _laneLeap = _min(length(matrix, DPMatrixDimension_::VERTICAL), bandSize(band));
+            _activeColIterator = begin(matrix, Standard()) + _dataLengths(matrix)[DPMatrixDimension_::VERTICAL] - 1;
+        }
+        else if (upperDiagonal(band) <= 0)  // Band begins within the first column.
+        {
+            // The first cell starts at the beginning of the current column.
+            _laneLeap = 1;
+            _activeColIterator = begin(matrix, Standard());
+        }
+        else  // Band intersects with the point of origin.
+        {
+            // First cell starts at position i, such that i + abs(lowerDiagonal) = length(seqV).
+            TMatrixSize lengthVertical = length(matrix, DPMatrixDimension_::VERTICAL);
+            int lastPos = _max(-static_cast<TSignedSize>(lengthVertical - 1), lowerDiagonal(band));
+            _laneLeap = lengthVertical + lastPos;
+            _activeColIterator = begin(matrix, Standard()) + _laneLeap - 1;
+        }
+        *_activeColIterator = TValue{};
+    }
 
     TDPMatrixPointer_   _ptrDataContainer  = nullptr;  // The pointer to the underlying Matrix.
     int                 _laneLeap          = 0;  // Keeps track of the jump size from one column to another.
@@ -88,99 +139,37 @@ public:
 // ============================================================================
 
 // ----------------------------------------------------------------------------
-// Function _init()
-// ----------------------------------------------------------------------------
-
-// Initializes the navigator for unbanded alignments.
-template <typename TValue, typename TTraceFlag>
-inline void
-_init(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, NavigateColumnWise> & navigator,
-      DPMatrix_<TValue, FullDPMatrix> & dpMatrix,
-      DPBandConfig<BandOff> const &)
-{
-    if (IsSameType<TTraceFlag, TracebackOff>::VALUE)
-        return;  // Leave navigator uninitialized because it is never used.
-
-    navigator._ptrDataContainer = &dpMatrix;
-    navigator._activeColIterator = begin(dpMatrix, Standard());
-    navigator._laneLeap = 1;
-    assignValue(navigator._activeColIterator, TValue());
-}
-
-// Initializes the navigator for banded alignments.
-// Note, the band size has a maximal width of length of the vertical sequence.
-template <typename TValue, typename TTraceFlag>
-inline void
-_init(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, NavigateColumnWise> & navigator,
-      DPMatrix_<TValue, FullDPMatrix> & dpMatrix,
-      DPBandConfig<BandOn> const & band)
-{
-    typedef typename Size<DPMatrix_<TValue, FullDPMatrix> >::Type TMatrixSize;
-    typedef typename MakeSigned<TMatrixSize>::Type TSignedSize;
-
-    if (IsSameType<TTraceFlag, TracebackOff>::VALUE)
-        return;  // Leave navigator as is because it should never be used.
-
-    navigator._ptrDataContainer = &dpMatrix;
-
-    // Band begins within the first row.
-    if (lowerDiagonal(band) >= 0)
-    {
-        // The first cell of the first column starts at the last cell in the matrix of the current column.
-        navigator._laneLeap = _min(length(dpMatrix, DPMatrixDimension_::VERTICAL), bandSize(band));
-        navigator._activeColIterator = begin(dpMatrix, Standard()) + _dataLengths(dpMatrix)[DPMatrixDimension_::VERTICAL] - 1;
-    }
-    else if (upperDiagonal(band) <= 0)  // Band begins within the first column.
-    {
-        // The first cell starts at the beginning of the current column.
-        navigator._laneLeap = 1;
-        navigator._activeColIterator = begin(dpMatrix, Standard());
-    }
-    else  // Band intersects with the point of origin.
-    {
-        // First cell starts at position i, such that i + abs(lowerDiagonal) = length(seqV).
-        TMatrixSize lengthVertical = length(dpMatrix, DPMatrixDimension_::VERTICAL);
-        int lastPos = _max(-static_cast<TSignedSize>(lengthVertical - 1), lowerDiagonal(band));
-        navigator._laneLeap = lengthVertical + lastPos;
-        navigator._activeColIterator = begin(dpMatrix, Standard()) + navigator._laneLeap - 1;
-    }
-    assignValue(navigator._activeColIterator, TValue());
-}
-
-// ----------------------------------------------------------------------------
-// Function _goNextCell()                          [DPInitialColumn, FirstCell]
+// Function _goNextCell()                                   [banded, FirstCell]
 // ----------------------------------------------------------------------------
 
 // In the initial column we don't need to do anything because, the navigagtor is already initialized.
-template <typename TValue, typename TTraceFlag>
+template <typename TValue, typename TTraceFlag,
+          typename TColumnLocation>
 inline void
-_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, NavigateColumnWise> & /*dpNavigator*/,
-            MetaColumnDescriptor<DPInitialColumn, PartialColumnTop> const &,
-            FirstCell const &)
-{
-    // no-op
-}
-
-template <typename TValue, typename TTraceFlag, typename TColumnLocation>
-inline void
-_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, NavigateColumnWise> & /*dpNavigator*/,
+_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, NavigateColumnWiseBanded> & /*dpNavigator*/,
             MetaColumnDescriptor<DPInitialColumn, TColumnLocation> const &,
             FirstCell const &)
 {
     // no-op
 }
 
-// ----------------------------------------------------------------------------
-// Function _goNextCell()                         [PartialColumnTop, FirstCell]
-// ----------------------------------------------------------------------------
+// overload needed to avoid ambigious overload.
+template <typename TValue, typename TTraceFlag>
+inline void
+_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, NavigateColumnWiseBanded> & /*dpNavigator*/,
+            MetaColumnDescriptor<DPInitialColumn, PartialColumnTop> const &,
+            FirstCell const &)
+{
+    // no-op
+}
 
 // We are in the banded case, where the band crosses the first row.
 // The left cell of the active cell is not valid, beacause we only can come from horizontal direction.
 // The lower left cell of the active cell is the horizontal direction.
-
-template <typename TValue, typename TTraceFlag, typename TColumnType>
+template <typename TValue, typename TTraceFlag,
+          typename TColumnType>
 inline void
-_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, NavigateColumnWise> & dpNavigator,
+_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, NavigateColumnWiseBanded> & dpNavigator,
             MetaColumnDescriptor<TColumnType, PartialColumnTop> const &,
             FirstCell const &)
 {
@@ -191,17 +180,41 @@ _goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TT
     dpNavigator._activeColIterator += dpNavigator._laneLeap;
 }
 
-// ----------------------------------------------------------------------------
-// Function _goNextCell()                       [other column types, FirstCell]
-// ----------------------------------------------------------------------------
-
 // We are in the banded case.
 // The left cell of the active cell represents diagonal direction. The lower left diagonal represents the horizontal direction.
+template <typename TValue, typename TTraceFlag,
+          typename TColumnType, typename TColumnLocation>
+inline void
+_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, NavigateColumnWiseBanded> & dpNavigator,
+            MetaColumnDescriptor<TColumnType, TColumnLocation> const &,
+            FirstCell const &)
+{
+    if (IsSameType<TTraceFlag, TracebackOff>::VALUE)
+        return;  // Do nothing since no trace back is computed.
 
-template <typename TValue, typename TTraceFlag, typename TColumnType, typename TColumnLocation>
+    // go to begin of next column.
+    dpNavigator._activeColIterator += dpNavigator._laneLeap;
+}
+
+// ----------------------------------------------------------------------------
+// Function _goNextCell()                                 [unbanded, FirstCell]
+// ----------------------------------------------------------------------------
+
+//
+template <typename TValue, typename TTraceFlag>
+inline void
+_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, NavigateColumnWise> & /*dpNavigator*/,
+            MetaColumnDescriptor<DPInitialColumn, FullColumn> const &,
+            FirstCell const &)
+{
+    // no-op
+}
+
+template <typename TValue, typename TTraceFlag,
+          typename TColumnType>
 inline void
 _goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, NavigateColumnWise> & dpNavigator,
-            MetaColumnDescriptor<TColumnType, TColumnLocation> const &,
+            MetaColumnDescriptor<TColumnType, FullColumn> const &,
             FirstCell const &)
 {
     if (IsSameType<TTraceFlag, TracebackOff>::VALUE)
@@ -211,13 +224,14 @@ _goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TT
 }
 
 // ----------------------------------------------------------------------------
-// Function _goNextCell                                 [any column, InnerCell]
+// Function _goNextCell                                     [banded, InnerCell]
 // ----------------------------------------------------------------------------
 
 // For any other column type and location we can use the same navigation procedure.
-template <typename TValue, typename TTraceFlag, typename TColumnType, typename TColumnLocation>
+template <typename TValue, typename TTraceFlag,
+          typename TColumnType, typename TColumnLocation>
 inline void
-_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, NavigateColumnWise> & dpNavigator,
+_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, NavigateColumnWiseBanded> & dpNavigator,
             MetaColumnDescriptor<TColumnType, TColumnLocation> const &,
             InnerCell const &)
 {
@@ -228,12 +242,30 @@ _goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TT
 }
 
 // ----------------------------------------------------------------------------
-// Function _goNextCell                         [PartialColumnBottom, LastCell]
+// Function _goNextCell                                   [unbanded, InnerCell]
+// ----------------------------------------------------------------------------
+
+// For any other column type and location we can use the same navigation procedure.
+template <typename TValue, typename TTraceFlag,
+          typename TColumnType>
+inline void
+_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, NavigateColumnWise> & dpNavigator,
+            MetaColumnDescriptor<TColumnType, FullColumn> const &,
+            InnerCell const &)
+{
+    if (IsSameType<TTraceFlag, TracebackOff>::VALUE)
+        return;  // Do nothing since no trace back is computed.
+
+    ++dpNavigator._activeColIterator;
+}
+
+// ----------------------------------------------------------------------------
+// Function _goNextCell                                      [banded, LastCell]
 // ----------------------------------------------------------------------------
 
 template <typename TValue, typename TTraceFlag>
 inline void
-_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, NavigateColumnWise> & dpNavigator,
+_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, NavigateColumnWiseBanded> & dpNavigator,
             MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom> const &,
             LastCell const &)
 {
@@ -245,9 +277,10 @@ _goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TT
 
 // If we are in banded case and the band crosses the last row, we have to update
 // the additional leap for the current track.
-template <typename TValue, typename TTraceFlag, typename TColumnType>
+template <typename TValue, typename TTraceFlag,
+          typename TColumnType>
 inline void
-_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, NavigateColumnWise> & dpNavigator,
+_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, NavigateColumnWiseBanded> & dpNavigator,
             MetaColumnDescriptor<TColumnType, PartialColumnBottom> const &,
             LastCell const &)
 {
@@ -258,15 +291,29 @@ _goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TT
     ++dpNavigator._laneLeap;
 }
 
+// If we are in the banded case the left cell of the active represents the diagonal direction.
+template <typename TValue, typename TTraceFlag,
+          typename TColumnType, typename TColumnLocation>
+inline void
+_goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, NavigateColumnWiseBanded> & dpNavigator,
+            MetaColumnDescriptor<TColumnType, TColumnLocation> const &,
+            LastCell const &)
+{
+    if (IsSameType<TTraceFlag, TracebackOff>::VALUE)
+        return;  // Do nothing since no trace back is computed.
+
+    ++dpNavigator._activeColIterator;
+}
+
 // ----------------------------------------------------------------------------
-// Function _goNextCell                            [any other column, LastCell]
+// Function _goNextCell                                    [unbanded, LastCell]
 // ----------------------------------------------------------------------------
 
-// If we are in the banded case the left cell of the active represents the diagonal direction.
-template <typename TValue, typename TTraceFlag, typename TColumnType, typename TColumnLocation>
+template <typename TValue, typename TTraceFlag,
+          typename TColumnType>
 inline void
 _goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, NavigateColumnWise> & dpNavigator,
-            MetaColumnDescriptor<TColumnType, TColumnLocation> const &,
+            MetaColumnDescriptor<TColumnType, FullColumn> const &,
             LastCell const &)
 {
     if (IsSameType<TTraceFlag, TracebackOff>::VALUE)
@@ -279,9 +326,9 @@ _goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TT
 // Function _traceHorizontal()
 // ----------------------------------------------------------------------------
 
-template <typename TValue, typename TTraceFlag>
+template <typename TValue, typename TTraceFlag, typename TNavigationSpec>
 inline void
-_traceHorizontal(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, NavigateColumnWise> & dpNavigator,
+_traceHorizontal(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, TNavigationSpec> & dpNavigator,
                  bool isBandShift)
 {
     if (IsSameType<TTraceFlag, TracebackOff>::VALUE)
@@ -298,9 +345,9 @@ _traceHorizontal(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatr
 // Function _traceDiagonal()
 // ----------------------------------------------------------------------------
 
-template <typename TValue, typename TTraceFlag>
+template <typename TValue, typename TTraceFlag, typename TNavigationSpec>
 inline void
-_traceDiagonal(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, NavigateColumnWise> & dpNavigator,
+_traceDiagonal(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, TNavigationSpec> & dpNavigator,
                bool isBandShift)
 {
     if (IsSameType<TTraceFlag, TracebackOff>::VALUE)
@@ -317,9 +364,9 @@ _traceDiagonal(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix
 // Function _traceVertical()
 // ----------------------------------------------------------------------------
 
-template <typename TValue, typename TTraceFlag>
+template <typename TValue, typename TTraceFlag, typename TNavigationSpec>
 inline void
-_traceVertical(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, NavigateColumnWise> & dpNavigator,
+_traceVertical(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, TNavigationSpec> & dpNavigator,
                bool /*isBandShift*/)
 {
     if (IsSameType<TTraceFlag, TracebackOff>::VALUE)
@@ -332,9 +379,10 @@ _traceVertical(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix
 // Function setToPosition()
 // ----------------------------------------------------------------------------
 
-template <typename TValue, typename TTraceFlag, typename TPosition>
+template <typename TValue, typename TTraceFlag, typename TNavigationSpec,
+          typename TPosition>
 inline void
-_setToPosition(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, NavigateColumnWise> & dpNavigator,
+_setToPosition(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, TNavigationSpec> & dpNavigator,
               TPosition const & hostPosition)
 {
     if (IsSameType<TTraceFlag, TracebackOff>::VALUE)
@@ -349,9 +397,10 @@ _setToPosition(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix
 // Sets the host position based on the given horizontal and vertical position. Note that the horizontal and
 // vertical positions must correspond to the correct size of the underlying matrix.
 // For banded matrices the vertical dimension might not equal the length of the vertical sequence.
-template <typename TValue, typename TTraceFlag, typename TPositionH, typename TPositionV>
+template <typename TValue, typename TTraceFlag, typename TNavigationSpec,
+          typename TPositionH, typename TPositionV>
 inline void
-_setToPosition(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, NavigateColumnWise> & dpNavigator,
+_setToPosition(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix<TTraceFlag>, TNavigationSpec> & dpNavigator,
               TPositionH const & horizontalPosition,
               TPositionV const & verticalPosition)
 {
@@ -368,7 +417,8 @@ _setToPosition(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix>, DPTraceMatrix
 // Function assignValue()
 // ----------------------------------------------------------------------------
 
-template <typename TDPMatrix, typename TTraceFlag, typename TNavigationSpec, typename TValue>
+template <typename TDPMatrix, typename TTraceFlag, typename TNavigationSpec,
+          typename TValue>
 inline void
 assignValue(DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TTraceFlag>, TNavigationSpec> & dpNavigator,
             TValue const & element)
@@ -449,7 +499,8 @@ value(DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TTraceFlag>, TNavigationSpec> 
     return *(begin(*dpNavigator._ptrDataContainer) + position);
 }
 
-template <typename TDPMatrix, typename TTraceFlag, typename TNavigationSpec, typename TPosition>
+template <typename TDPMatrix, typename TTraceFlag, typename TNavigationSpec,
+          typename TPosition>
 inline typename Reference<DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TTraceFlag>, TNavigationSpec> const >::Type
 value(DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TTraceFlag>, TNavigationSpec> const & dpNavigator,
       TPosition const & position)
@@ -502,7 +553,8 @@ position(DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TTraceFlag>, TNavigationSpe
 // Function _setSimdLane()
 // ----------------------------------------------------------------------------
 
-template <typename TDPMatrix, typename TTraceFlag, typename TNavigationSpec, typename TPos>
+template <typename TDPMatrix, typename TTraceFlag, typename TNavigationSpec,
+          typename TPos>
 inline void
 _setSimdLane(DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TTraceFlag>, TNavigationSpec> & dpNavigator,
              TPos const pos)

--- a/include/seqan/align_extend/dp_scout_xdrop.h
+++ b/include/seqan/align_extend/dp_scout_xdrop.h
@@ -164,16 +164,15 @@ _scoutBestScore(DPScout_<TDPCell, Terminator_<XDrop_<TDPCellValue> > > & dpScout
 // ----------------------------------------------------------------------------
 
 // Computes the score and tracks it if enabled.
-template <typename TDPScout, typename TTraceMatrixNavigator, typename TScoreValue, typename TGapCosts,
+template <typename TDPScout, typename TTraceMatrixNavigator,
+          typename TCellTuple,
+          typename TScoreValue, typename TGapCosts,
           typename TSequenceHValue, typename TSequenceVValue, typename TScoringScheme, typename TColumnDescriptor,
           typename TCellDescriptor, typename TTraceback>
 inline void
 _computeCell(TDPScout & scout,
              TTraceMatrixNavigator & traceMatrixNavigator,
-             DPCell_<TScoreValue, TGapCosts> & activeCell,
-             DPCell_<TScoreValue, TGapCosts> const & previousDiagonal,
-             DPCell_<TScoreValue, TGapCosts> const & previousHorizontal,
-             DPCell_<TScoreValue, TGapCosts> const & previousVertical,
+             TCellTuple recursionCells,
              TSequenceHValue const & seqHVal,
              TSequenceVValue const & seqVVal,
              TScoringScheme const & scoringScheme,
@@ -185,7 +184,7 @@ _computeCell(TDPScout & scout,
     typedef DPProfile_<AlignExtend_<XDrop_<TScoreValue> >, TGapCosts, TTraceback> TDPProfile;
     typedef DPMetaColumn_<TDPProfile, TColumnDescriptor> TMetaColumn;
 
-    assignValue(traceMatrixNavigator, _computeScore(activeCell, previousDiagonal, previousHorizontal, previousVertical,
+    assignValue(traceMatrixNavigator, _computeScore(recursionCells,
                                                     seqHVal, seqVVal, scoringScheme,
                                                     typename RecursionDirection_<TMetaColumn, TCellDescriptor>::Type(),
                                                     TDPProfile()));
@@ -197,7 +196,7 @@ _computeCell(TDPScout & scout,
         // for the evaluation of the termination criterium we treat
         // all lastCells as lastRows
         typedef typename IsSameType<TCellDescriptor, LastCell>::Type TIsLastRow;
-        _scoutBestScore(scout, activeCell, traceMatrixNavigator, TIsLastColumn(), TIsLastRow());
+        _scoutBestScore(scout, std::get<0>(recursionCells), traceMatrixNavigator, TIsLastColumn(), TIsLastRow());
     }
 }
 

--- a/include/seqan/align_split/align_split_interface.h
+++ b/include/seqan/align_split/align_split_interface.h
@@ -353,8 +353,7 @@ void _computeSplitTrace(TTarget & target,
     setHost(matrix, getDpTraceMatrix(dpContext));
     resize(matrix);
     SEQAN_ASSERT_EQ(length(getDpTraceMatrix(dpContext)), length(matrix));
-    TDPTraceMatrixNavigator navi;
-    _init(navi, matrix, config._band);
+    TDPTraceMatrixNavigator navi{matrix, config._band};
     _computeTraceback(target, navi, matPos, seqH, seqV, config._band, TDPProfile());
 }
 

--- a/include/seqan/seeds/banded_chain_alignment_impl.h
+++ b/include/seqan/seeds/banded_chain_alignment_impl.h
@@ -405,16 +405,19 @@ _applyBandedChainTracking(TDPScout & scout,
 // ----------------------------------------------------------------------------
 
 // Overload of _computeCell function to add functionality specific to the bande chain alignment.
-template <typename TDPScout, typename TTraceMatrixNavigator, typename TScoreValue, typename TGapCosts,
-          typename TSeqHValue, typename TSeqVValue, typename TScoringScheme, typename TColumnDescriptor,
-          typename TCellDescriptor, typename TFreeEndGaps, typename TDPMatrixLocation, typename TTracebackConfig>
+template <typename TDPScout,
+          typename TTraceMatrixNavigator,
+          typename TCellTuple,
+          typename TSeqHValue,
+          typename TSeqVValue,
+          typename TScoringScheme,
+          typename TColumnDescriptor,
+          typename TCellDescriptor,
+          typename TFreeEndGaps, typename TDPMatrixLocation, typename TGapCosts, typename TTracebackConfig>
 inline void
 _computeCell(TDPScout & scout,
              TTraceMatrixNavigator & traceMatrixNavigator,
-             DPCell_<TScoreValue, TGapCosts> & activeCell,
-             DPCell_<TScoreValue, TGapCosts> const & previousDiagonal,
-             DPCell_<TScoreValue, TGapCosts> const & previousHorizontal,
-             DPCell_<TScoreValue, TGapCosts> const & previousVertical,
+             TCellTuple recursionCells,
              TSeqHValue const & seqHVal,
              TSeqVValue const & seqVVal,
              TScoringScheme const & scoringScheme,
@@ -427,27 +430,31 @@ _computeCell(TDPScout & scout,
 
     assignValue(
         traceMatrixNavigator,
-        _computeScore(activeCell, previousDiagonal, previousHorizontal, previousVertical, seqHVal, seqVVal,
+        _computeScore(recursionCells, seqHVal, seqVVal,
                       scoringScheme, typename RecursionDirection_<TMetaColumnProfile, TCellDescriptor>::Type(),
                       TDPProfile()));
     if (TrackingEnabled_<TMetaColumnProfile, TCellDescriptor>::VALUE)
-        _applyBandedChainTracking(scout, traceMatrixNavigator, activeCell, TColumnDescriptor(), TCellDescriptor(), TDPProfile());
+        _applyBandedChainTracking(scout, traceMatrixNavigator, std::get<0>(recursionCells),
+                                  TColumnDescriptor(), TCellDescriptor(), TDPProfile());
 }
 
 // ----------------------------------------------------------------------------
 // Function _computeCell()              [BandedChainAlignment, DPInitialColumn]
 // ----------------------------------------------------------------------------
 
-template <typename TDPScout, typename TDPTraceMatrixNavigator, typename TScoreValue, typename TGapCosts,
-          typename TSeqHValue, typename TSeqVValue, typename TScoringScheme, typename TColumnType, typename TCellDescriptor,
-          typename TSpec, typename TDPMatrixLocation, typename TTracebackConfig>
+template <typename TDPScout,
+          typename TDPTraceMatrixNavigator,
+          typename TCellTuple,
+          typename TSeqHValue,
+          typename TSeqVValue,
+          typename TScoringScheme,
+          typename TColumnType,
+          typename TCellDescriptor,
+          typename TSpec, typename TDPMatrixLocation, typename TGapCosts, typename TTracebackConfig>
 inline void
 _computeCell(TDPScout & scout,
              TDPTraceMatrixNavigator & traceMatrixNavigator,
-             DPCell_<TScoreValue, TGapCosts> & activeCell,
-             DPCell_<TScoreValue, TGapCosts> const &,
-             DPCell_<TScoreValue, TGapCosts> const &,
-             DPCell_<TScoreValue, TGapCosts> const &,
+             TCellTuple recursionCells,
              TSeqHValue const &,
              TSeqVValue const &,
              TScoringScheme const & /*scoringScheme*/,
@@ -459,10 +466,11 @@ _computeCell(TDPScout & scout,
     typedef MetaColumnDescriptor<DPInitialColumn, TColumnType> TColumnDescriptor;
     typedef DPMetaColumn_<TDPProfile, TColumnDescriptor> TMetaColumnProfile;
 
-    activeCell = _verticalCellInitialization(scout, traceMatrixNavigator);
+    std::get<0>(recursionCells) = _verticalCellInitialization(scout, traceMatrixNavigator);
     assignValue(traceMatrixNavigator, +TraceBitMap_<>::NONE);
     if (TrackingEnabled_<TMetaColumnProfile, TCellDescriptor>::VALUE)
-        _applyBandedChainTracking(scout, traceMatrixNavigator, activeCell, TColumnDescriptor(), TCellDescriptor(), TDPProfile());
+        _applyBandedChainTracking(scout, traceMatrixNavigator, std::get<0>(recursionCells),
+                                  TColumnDescriptor(), TCellDescriptor(), TDPProfile());
 }
 
 // ----------------------------------------------------------------------------
@@ -492,16 +500,16 @@ _computeHorizontalInitCell(TDPScout & scout,
 // ----------------------------------------------------------------------------
 
 // For DPInnerColumn.
-template <typename TDPScout, typename TDPTraceMatrixNavigator, typename TScoreValue, typename TGapCosts,
-          typename TSeqHValue, typename TSeqVValue, typename TScoringScheme, typename TSpec, typename TDPMatrixLocation,
-          typename TTracebackConfig>
+template <typename TDPScout, typename TDPTraceMatrixNavigator,
+          typename TCellTuple,
+          typename TSeqHValue,
+          typename TSeqVValue,
+          typename TScoringScheme,
+          typename TSpec, typename TDPMatrixLocation, typename TGapCosts, typename TTracebackConfig>
 inline void
 _computeCell(TDPScout & scout,
              TDPTraceMatrixNavigator & traceMatrixNavigator,
-             DPCell_<TScoreValue, TGapCosts> & activeCell,
-             DPCell_<TScoreValue, TGapCosts> const &,
-             DPCell_<TScoreValue, TGapCosts> const &,
-             DPCell_<TScoreValue, TGapCosts> const &,
+             TCellTuple recursionCells,
              TSeqHValue const &,
              TSeqVValue const &,
              TScoringScheme const &,
@@ -510,21 +518,22 @@ _computeCell(TDPScout & scout,
              DPProfile_<BandedChainAlignment_<TSpec, TDPMatrixLocation>, TGapCosts, TracebackOn<TTracebackConfig> > const &)
 {
     typedef DPProfile_<BandedChainAlignment_<TSpec, TDPMatrixLocation>, TGapCosts, TracebackOn<TTracebackConfig> > TDPProfile;
-    _computeHorizontalInitCell(scout, traceMatrixNavigator, activeCell,
+    _computeHorizontalInitCell(scout, traceMatrixNavigator, std::get<0>(recursionCells),
                                MetaColumnDescriptor<DPInnerColumn, PartialColumnTop>(), FirstCell(), TDPProfile());
 }
 
 // For DPFinalColumn.
-template <typename TDPScout, typename TDPTraceMatrixNavigator, typename TScoreValue, typename TGapCosts,
-          typename TSeqHValue, typename TSeqVValue, typename TScoringScheme, typename TSpec, typename TDPMatrixLocation,
-          typename TTracebackConfig>
+template <typename TDPScout,
+          typename TDPTraceMatrixNavigator,
+          typename TCellTuple,
+          typename TSeqHValue,
+          typename TSeqVValue,
+          typename TScoringScheme,
+          typename TSpec, typename TDPMatrixLocation, typename TGapCosts, typename TTracebackConfig>
 inline void
 _computeCell(TDPScout & scout,
              TDPTraceMatrixNavigator & traceMatrixNavigator,
-             DPCell_<TScoreValue, TGapCosts> & activeCell,
-             DPCell_<TScoreValue, TGapCosts> const &,
-             DPCell_<TScoreValue, TGapCosts> const &,
-             DPCell_<TScoreValue, TGapCosts> const &,
+             TCellTuple recursionCells,
              TSeqHValue const &,
              TSeqVValue const &,
              TScoringScheme const &,
@@ -533,7 +542,7 @@ _computeCell(TDPScout & scout,
              DPProfile_<BandedChainAlignment_<TSpec, TDPMatrixLocation>, TGapCosts, TracebackOn<TTracebackConfig> > const &)
 {
     typedef DPProfile_<BandedChainAlignment_<TSpec, TDPMatrixLocation>, TGapCosts, TracebackOn<TTracebackConfig> > TDPProfile;
-    _computeHorizontalInitCell(scout, traceMatrixNavigator, activeCell,
+    _computeHorizontalInitCell(scout, traceMatrixNavigator, std::get<0>(recursionCells),
                                MetaColumnDescriptor<DPFinalColumn, PartialColumnTop>(), FirstCell(), TDPProfile());
 }
 
@@ -542,16 +551,17 @@ _computeCell(TDPScout & scout,
 // ----------------------------------------------------------------------------
 
 // For DPInnerColumn.
-template <typename TDPScout, typename TDPTraceMatrixNavigator, typename TScoreValue, typename TGapCosts,
-          typename TSeqHValue, typename TSeqVValue, typename TScoringScheme, typename TSpec, typename TDPMatrixLocation,
-          typename TTracebackConfig>
+template <typename TDPScout,
+          typename TDPTraceMatrixNavigator,
+          typename TCellTuple,
+          typename TSeqHValue,
+          typename TSeqVValue,
+          typename TScoringScheme,
+          typename TSpec, typename TDPMatrixLocation, typename TGapCosts, typename TTracebackConfig>
 inline void
 _computeCell(TDPScout & scout,
              TDPTraceMatrixNavigator & traceMatrixNavigator,
-             DPCell_<TScoreValue, TGapCosts> & activeCell,
-             DPCell_<TScoreValue, TGapCosts> const &,
-             DPCell_<TScoreValue, TGapCosts> const &,
-             DPCell_<TScoreValue, TGapCosts> const &,
+             TCellTuple recursionCells,
              TSeqHValue const &,
              TSeqVValue const &,
              TScoringScheme const &,
@@ -560,21 +570,22 @@ _computeCell(TDPScout & scout,
              DPProfile_<BandedChainAlignment_<TSpec, TDPMatrixLocation>, TGapCosts, TracebackOn<TTracebackConfig> > const &)
 {
     typedef DPProfile_<BandedChainAlignment_<TSpec, TDPMatrixLocation>, TGapCosts, TracebackOn<TTracebackConfig> > TDPProfile;
-    _computeHorizontalInitCell(scout, traceMatrixNavigator, activeCell,
+    _computeHorizontalInitCell(scout, traceMatrixNavigator, std::get<0>(recursionCells),
                                MetaColumnDescriptor<DPInnerColumn, FullColumn>(), FirstCell(), TDPProfile());
 }
 
 // For DPFinalColumn.
-template <typename TDPScout, typename TDPTraceMatrixNavigator, typename TScoreValue, typename TGapCosts,
-          typename TSeqHValue, typename TSeqVValue, typename TScoringScheme, typename TSpec, typename TDPMatrixLocation,
-          typename TTracebackConfig>
+template <typename TDPScout,
+          typename TDPTraceMatrixNavigator,
+          typename TCellTuple,
+          typename TSeqHValue,
+          typename TSeqVValue,
+          typename TScoringScheme,
+          typename TSpec, typename TDPMatrixLocation, typename TGapCosts, typename TTracebackConfig>
 inline void
 _computeCell(TDPScout & scout,
              TDPTraceMatrixNavigator & traceMatrixNavigator,
-             DPCell_<TScoreValue, TGapCosts> & activeCell,
-             DPCell_<TScoreValue, TGapCosts> const &,
-             DPCell_<TScoreValue, TGapCosts> const &,
-             DPCell_<TScoreValue, TGapCosts> const &,
+             TCellTuple recursionCells,
              TSeqHValue const &,
              TSeqVValue const &,
              TScoringScheme const &,
@@ -583,7 +594,7 @@ _computeCell(TDPScout & scout,
              DPProfile_<BandedChainAlignment_<TSpec, TDPMatrixLocation>, TGapCosts, TracebackOn<TTracebackConfig> > const &)
 {
     typedef DPProfile_<BandedChainAlignment_<TSpec, TDPMatrixLocation>, TGapCosts, TracebackOn<TTracebackConfig> > TDPProfile;
-    _computeHorizontalInitCell(scout, traceMatrixNavigator, activeCell,
+    _computeHorizontalInitCell(scout, traceMatrixNavigator, std::get<0>(recursionCells),
                                MetaColumnDescriptor<DPFinalColumn, FullColumn>(), FirstCell(), TDPProfile());
 }
 
@@ -691,7 +702,8 @@ _initiaizeBeginningOfBandedChain(TScoutState & scoutState,
     typedef DPProfile_<BandedChainAlignment_<TFreeEndGaps, TDPMatrixLocation>, TGapCosts, TTraceback> TDPProfile;
 
     TDPCell dpInitCellHorizontal;
-    _computeScore(dpInitCellHorizontal, TDPCell(), TDPCell(), TDPCell(), Nothing(), Nothing(), Nothing(),
+    _computeScore(std::forward_as_tuple(dpInitCellHorizontal, TDPCell(), TDPCell(), TDPCell()),
+                  Nothing(), Nothing(), Nothing(),
                   RecursionDirectionZero(), TDPProfile());
     scoutState._nextInitializationCells.insert(TInitCell(0,0, dpInitCellHorizontal));
 
@@ -699,26 +711,31 @@ _initiaizeBeginningOfBandedChain(TScoutState & scoutState,
     {
         TDPCell prevCell = dpInitCellHorizontal;
         if (IsFreeEndGap_<TFreeEndGaps, DPFirstRow>::VALUE)
-            _computeScore(dpInitCellHorizontal, TDPCell(), TDPCell(), TDPCell(), Nothing(), Nothing(), scoreScheme,
+            _computeScore(std::forward_as_tuple(dpInitCellHorizontal, TDPCell(), TDPCell(), TDPCell()),
+                  Nothing(), Nothing(), scoreScheme,
                   RecursionDirectionZero(), TDPProfile());
         else
-            _computeScore(dpInitCellHorizontal, TDPCell(), prevCell, TDPCell(), Nothing(), Nothing(), scoreScheme,
+            _computeScore(std::forward_as_tuple(dpInitCellHorizontal, TDPCell(), prevCell, TDPCell()),
+                  Nothing(), Nothing(), scoreScheme,
                   RecursionDirectionHorizontal(), TDPProfile());
         scoutState._nextInitializationCells.insert(TInitCell(activeColumn, 0, dpInitCellHorizontal));
     }
 
     TDPCell dpInitCellVertical;
-    _computeScore(dpInitCellVertical, TDPCell(), TDPCell(), TDPCell(), Nothing(), Nothing(), Nothing(),
+    _computeScore(std::forward_as_tuple(dpInitCellVertical, TDPCell(), TDPCell(), TDPCell()),
+                  Nothing(), Nothing(), Nothing(),
                   RecursionDirectionZero(), TDPProfile());
     for(TSizeV activeRow = 1; activeRow < sizeV; ++activeRow)
     {
         TDPCell prevCell = dpInitCellVertical;
         if (IsFreeEndGap_<TFreeEndGaps, DPFirstColumn>::VALUE)
-            _computeScore(dpInitCellVertical, TDPCell(), TDPCell(), TDPCell(), Nothing(), Nothing(), scoreScheme,
-                  RecursionDirectionZero(), TDPProfile());
+            _computeScore(std::forward_as_tuple(dpInitCellVertical, TDPCell(), TDPCell(), TDPCell()),
+                          Nothing(), Nothing(), scoreScheme,
+                          RecursionDirectionZero(), TDPProfile());
         else
-            _computeScore(dpInitCellVertical, TDPCell(), TDPCell(), prevCell, Nothing(), Nothing(), scoreScheme,
-                  RecursionDirectionVertical(), TDPProfile());
+            _computeScore(std::forward_as_tuple(dpInitCellVertical, TDPCell(), TDPCell(), prevCell),
+                          Nothing(), Nothing(), scoreScheme,
+                          RecursionDirectionVertical(), TDPProfile());
         scoutState._nextInitializationCells.insert(TInitCell(0, activeRow, dpInitCellVertical));
     }
 

--- a/tests/align/test_align.cpp
+++ b/tests/align/test_align.cpp
@@ -274,7 +274,6 @@ SEQAN_BEGIN_TESTSUITE(test_align)
     // Test DPMatrix Navigator.
     // ----------------------------------------------------------------------------
 
-    SEQAN_CALL_TEST(test_alignment_dp_matrix_navigator_score_matrix_full_constructor);
     SEQAN_CALL_TEST(test_alignment_dp_matrix_navigator_score_matrix_full_init_unbanded);
     SEQAN_CALL_TEST(test_alignment_dp_matrix_navigator_score_matrix_full_init_banded);
     SEQAN_CALL_TEST(test_alignment_dp_matrix_navigator_score_matrix_full_go_next_cell);
@@ -286,7 +285,6 @@ SEQAN_BEGIN_TESTSUITE(test_align)
     SEQAN_CALL_TEST(test_alignment_dp_matrix_navigator_score_matrix_full_coordinate);
     SEQAN_CALL_TEST(test_alignment_dp_matrix_navigator_score_matrix_full_container);
 
-    SEQAN_CALL_TEST(test_alignment_dp_matrix_navigator_score_matrix_sparse_constructor);
     SEQAN_CALL_TEST(test_alignment_dp_matrix_navigator_score_matrix_sparse_init_unbanded);
     SEQAN_CALL_TEST(test_alignment_dp_matrix_navigator_score_matrix_sparse_init_banded);
     SEQAN_CALL_TEST(test_alignment_dp_matrix_navigator_score_matrix_sparse_go_next);
@@ -298,7 +296,6 @@ SEQAN_BEGIN_TESTSUITE(test_align)
     SEQAN_CALL_TEST(test_alignment_dp_matrix_navigator_score_matrix_sparse_coordinate);
     SEQAN_CALL_TEST(test_alignment_dp_matrix_navigator_score_matrix_sparse_container);
 
-    SEQAN_CALL_TEST(test_alignment_dp_matrix_navigator_trace_matrix_constructor);
     SEQAN_CALL_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_init_unbanded);
     SEQAN_CALL_TEST(test_alignment_dp_matrix_navigator_trace_matrix_disabled_init_unbanded);
     SEQAN_CALL_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_init_banded);

--- a/tests/align/test_alignment_dp_formula.h
+++ b/tests/align/test_alignment_dp_formula.h
@@ -59,19 +59,19 @@ void testDPFormulaNoTraceLocalLinearDiagonalDirection(TBand const &)
 
     Score<int, Simple> scoringScheme(2, -2, -4);
 
-    TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+    TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                            scoringScheme, RecursionDirectionDiagonal(), TDPProfile());
 
-    SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+    SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
     SEQAN_ASSERT_EQ(activeCell._score, 4);
     SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
     SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
     SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-    traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+    traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                scoringScheme, RecursionDirectionDiagonal(), TDPProfile());
 
-    SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+    SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
     SEQAN_ASSERT_EQ(activeCell._score, 0);
     SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
     SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -98,19 +98,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_linear_diagonal_direction)
     Score<int, Simple> scoringScheme(2, -2, -4);
     TTraceValue traceValue;
     {
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL));
         SEQAN_ASSERT_EQ(activeCell._score, -8);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                    scoringScheme, RecursionDirectionDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL));
         SEQAN_ASSERT_EQ(activeCell._score, -8);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -118,19 +118,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_linear_diagonal_direction)
     }
 
     {
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                    scoringScheme, RecursionDirectionDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL));
         SEQAN_ASSERT_EQ(activeCell._score, -12);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                    scoringScheme, RecursionDirectionDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL));
         SEQAN_ASSERT_EQ(activeCell._score, -12);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -156,19 +156,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_linear_horizontal_direction)
 
     Score<int, Simple> scoringScheme(2, -2, -4);
 
-    TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+    TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                            scoringScheme, RecursionDirectionHorizontal(), TDPProfileSingleTrace());
 
-    SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX);
+    SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
     SEQAN_ASSERT_EQ(activeCell._score, 6);
     SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
     SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
     SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-    traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+    traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                            scoringScheme, RecursionDirectionHorizontal(), TDPProfileCompleteTrace());
 
-    SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX);
+    SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
     SEQAN_ASSERT_EQ(activeCell._score, 6);
     SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
     SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -193,16 +193,16 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_linear_vertical_direction)
 
     Score<int, Simple> scoringScheme(2, -2, -4);
 
-    TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+    TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                            scoringScheme, RecursionDirectionVertical(), TDPProfileSingleTrace());
 
-    SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX);
+    SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
     SEQAN_ASSERT_EQ(activeCell._score, 6);
 
-    traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+    traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                            scoringScheme, RecursionDirectionVertical(), TDPProfileCompleteTrace());
 
-    SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX);
+    SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
     SEQAN_ASSERT_EQ(activeCell._score, 6);
 }
 
@@ -225,19 +225,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_linear_upper_band_direction)
     Score<int, Simple> scoringScheme(2, -2, -4);
 
     {
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 6);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 6);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -246,19 +246,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_linear_upper_band_direction)
 
     {
         prevHorizontal._score = -10;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL));
         SEQAN_ASSERT_EQ(activeCell._score, -8);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, -10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL));
         SEQAN_ASSERT_EQ(activeCell._score, -8);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, -10);
@@ -267,7 +267,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_linear_upper_band_direction)
 
     {
         prevHorizontal._score = -4;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL));
@@ -276,7 +276,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_linear_upper_band_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, -4);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
@@ -306,19 +306,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_linear_lower_band_direction)
     Score<int, Simple> scoringScheme(2, -2, -4);
 
     {
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 6);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 6);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -327,19 +327,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_linear_lower_band_direction)
 
     {
         prevVertical._score = -10;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL));
         SEQAN_ASSERT_EQ(activeCell._score, -8);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, -10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL));
         SEQAN_ASSERT_EQ(activeCell._score, -8);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -348,7 +348,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_linear_lower_band_direction)
 
     {
         prevVertical._score = -8;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'C',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'C',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL));
@@ -357,7 +357,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_linear_lower_band_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, -8);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'C',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'C',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
@@ -387,19 +387,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_linear_all_direction)
     Score<int, Simple> scoringScheme(2, -2, -4);
 
     {
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 6);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL | +TraceBitMap_<>::HORIZONTAL |
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL | +TraceBitMap_<>::HORIZONTAL )|
                         TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX);
         SEQAN_ASSERT_EQ(activeCell._score, 6);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
@@ -409,19 +409,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_linear_all_direction)
 
     {
         prevHorizontal._score = 0;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 6);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 0);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 6);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 0);
@@ -430,19 +430,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_linear_all_direction)
 
     {
         prevVertical._score = -10;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, -4);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 0);
         SEQAN_ASSERT_EQ(prevVertical._score, -10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, -4);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 0);
@@ -451,7 +451,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_linear_all_direction)
 
     {
         prevHorizontal._score = -4;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL));
@@ -460,7 +460,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_linear_all_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, -4);
         SEQAN_ASSERT_EQ(prevVertical._score, -10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
@@ -472,19 +472,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_linear_all_direction)
 
     {
         prevHorizontal._score = -12;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL));
         SEQAN_ASSERT_EQ(activeCell._score, -8);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, -12);
         SEQAN_ASSERT_EQ(prevVertical._score, -10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL));
         SEQAN_ASSERT_EQ(activeCell._score, -8);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, -12);
@@ -493,7 +493,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_linear_all_direction)
 
     {
         prevVertical._score = -8;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'C',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'C',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL));
@@ -502,7 +502,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_linear_all_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, -12);
         SEQAN_ASSERT_EQ(prevVertical._score, -8);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'C',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'C',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
@@ -514,7 +514,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_linear_all_direction)
 
     {
         prevHorizontal._score = -8;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'C',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'C',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL));
@@ -523,7 +523,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_linear_all_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, -8);
         SEQAN_ASSERT_EQ(prevVertical._score, -8);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'C',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'C',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::VERTICAL | +TraceBitMap_<>::HORIZONTAL |
@@ -560,19 +560,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_diagonal_direction)
     Score<int, Simple> scoringScheme(2, -2, -4, -6);
 
     {
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL));
         SEQAN_ASSERT_EQ(activeCell._score, -8);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL));
         SEQAN_ASSERT_EQ(activeCell._score, -8);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -580,19 +580,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_diagonal_direction)
     }
 
     {
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'C',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'C',
                                                scoringScheme, RecursionDirectionDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL));
         SEQAN_ASSERT_EQ(activeCell._score, -12);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'C',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'C',
                                                scoringScheme, RecursionDirectionDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL));
         SEQAN_ASSERT_EQ(activeCell._score, -12);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -625,19 +625,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_horizontal_direction)
     Score<int, Simple> scoringScheme(2, -2, -4, -6);
 
     {
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionHorizontal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::HORIZONTAL_OPEN | +TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::HORIZONTAL_OPEN | +TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 4);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionHorizontal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::HORIZONTAL_OPEN | +TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::HORIZONTAL_OPEN | +TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 4);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -646,19 +646,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_horizontal_direction)
 
     {
         prevHorizontal._horizontalScore = 10;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionHorizontal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 6);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionHorizontal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 6);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -691,19 +691,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_vertical_direction)
     Score<int, Simple> scoringScheme(2, -2, -4, -6);
 
     {
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionVertical(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL_OPEN | +TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL_OPEN | +TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 4);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionVertical(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL_OPEN | +TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL_OPEN | +TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 4);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -712,19 +712,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_vertical_direction)
 
     {
         prevVertical._verticalScore = 10;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionVertical(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 6);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionVertical(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 6);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -757,19 +757,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_upper_band_direction)
     Score<int, Simple> scoringScheme(2, -2, -4, -6);
 
     {
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::HORIZONTAL_OPEN | +TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::HORIZONTAL_OPEN | +TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 4);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::HORIZONTAL_OPEN | +TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::HORIZONTAL_OPEN | +TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 4);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -778,19 +778,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_upper_band_direction)
 
     {
         prevDiagonal._score = 10;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::HORIZONTAL_OPEN);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::HORIZONTAL_OPEN));
         SEQAN_ASSERT_EQ(activeCell._score, 12);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::HORIZONTAL_OPEN);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::HORIZONTAL_OPEN));
         SEQAN_ASSERT_EQ(activeCell._score, 12);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -799,19 +799,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_upper_band_direction)
 
     {
         prevHorizontal._horizontalScore = 16;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'C',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'C',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 12);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'C',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'C',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 12);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -820,7 +820,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_upper_band_direction)
 
     {
         prevHorizontal._horizontalScore = 16;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::HORIZONTAL));
@@ -829,7 +829,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_upper_band_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::HORIZONTAL |
@@ -842,7 +842,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_upper_band_direction)
 
     {
         prevHorizontal._score = 18;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::HORIZONTAL));
@@ -851,7 +851,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_upper_band_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, 18);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX |
@@ -864,7 +864,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_upper_band_direction)
 
     {
         prevHorizontal._horizontalScore = -10;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::HORIZONTAL_OPEN));
@@ -873,7 +873,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_upper_band_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, 18);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::HORIZONTAL_OPEN |
@@ -910,19 +910,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_lower_band_direction)
     Score<int, Simple> scoringScheme(2, -2, -4, -6);
 
     {
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL_OPEN | +TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL_OPEN | +TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 4);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL_OPEN | +TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL_OPEN | +TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 4);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -931,19 +931,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_lower_band_direction)
 
     {
         prevDiagonal._score = 10;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::VERTICAL_OPEN);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::VERTICAL_OPEN));
         SEQAN_ASSERT_EQ(activeCell._score, 12);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::VERTICAL_OPEN);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::VERTICAL_OPEN));
         SEQAN_ASSERT_EQ(activeCell._score, 12);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -952,19 +952,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_lower_band_direction)
 
     {
         prevVertical._verticalScore = 16;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'C',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'C',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 12);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'C',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'C',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 12);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -973,7 +973,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_lower_band_direction)
 
     {
         prevVertical._verticalScore = 16;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::VERTICAL));
@@ -982,7 +982,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_lower_band_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
@@ -994,7 +994,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_lower_band_direction)
 
     {
         prevVertical._score = 18;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::VERTICAL));
@@ -1003,7 +1003,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_lower_band_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 18);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX |
@@ -1016,7 +1016,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_lower_band_direction)
 
     {
         prevVertical._verticalScore = -10;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::VERTICAL_OPEN));
@@ -1025,7 +1025,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_lower_band_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 18);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::VERTICAL_OPEN |
@@ -1063,19 +1063,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_all_direction)
     Score<int, Simple> scoringScheme(2, -2, -4, -6);
 
     {
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | +TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::HORIZONTAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | +TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::HORIZONTAL));
         SEQAN_ASSERT_EQ(activeCell._score, 4);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, -10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | +TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::HORIZONTAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | +TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::HORIZONTAL));
         SEQAN_ASSERT_EQ(activeCell._score, 4);
         SEQAN_ASSERT_EQ(prevDiagonal._score, -10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, -10);
@@ -1084,19 +1084,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_all_direction)
 
     {
         prevDiagonal._score = 10;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::HORIZONTAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::HORIZONTAL));
         SEQAN_ASSERT_EQ(activeCell._score, 12);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, -10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::HORIZONTAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::HORIZONTAL));
         SEQAN_ASSERT_EQ(activeCell._score, 12);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 10);
         SEQAN_ASSERT_EQ(prevHorizontal._score, -10);
@@ -1105,10 +1105,10 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_all_direction)
 
     {
         prevVertical._verticalScore = 16;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'C',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'C',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::HORIZONTAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::HORIZONTAL));
         SEQAN_ASSERT_EQ(activeCell._score, 12);
         SEQAN_ASSERT_EQ(activeCell._horizontalScore, -14);
         SEQAN_ASSERT_EQ(activeCell._verticalScore, 12);
@@ -1116,10 +1116,10 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_all_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, -10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'C',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'C',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::HORIZONTAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::HORIZONTAL));
         SEQAN_ASSERT_EQ(activeCell._score, 12);
         SEQAN_ASSERT_EQ(activeCell._horizontalScore, -14);
         SEQAN_ASSERT_EQ(activeCell._verticalScore, 12);
@@ -1130,7 +1130,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_all_direction)
 
     {
         prevVertical._verticalScore = 16;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::VERTICAL | TraceBitMap_<>::HORIZONTAL));
@@ -1141,7 +1141,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_all_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, -10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::VERTICAL |
@@ -1156,7 +1156,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_all_direction)
 
     {
         prevVertical._score = 18;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::VERTICAL | TraceBitMap_<>::HORIZONTAL));
@@ -1167,7 +1167,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_all_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, -10);
         SEQAN_ASSERT_EQ(prevVertical._score, 18);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::VERTICAL | TraceBitMap_<>::VERTICAL_OPEN |
@@ -1182,7 +1182,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_all_direction)
 
     {
         prevVertical._verticalScore = -10;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::VERTICAL_OPEN |
@@ -1194,7 +1194,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_all_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, -10);
         SEQAN_ASSERT_EQ(prevVertical._score, 18);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::VERTICAL_OPEN |
@@ -1209,7 +1209,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_all_direction)
 
     {
         prevHorizontal._horizontalScore = 20;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::HORIZONTAL | +TraceBitMap_<>::VERTICAL_OPEN |
@@ -1221,7 +1221,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_all_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, -10);
         SEQAN_ASSERT_EQ(prevVertical._score, 18);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::HORIZONTAL | +TraceBitMap_<>::VERTICAL_OPEN |
@@ -1236,7 +1236,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_all_direction)
 
     {
         prevHorizontal._score = 22;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX | +TraceBitMap_<>::HORIZONTAL |
@@ -1248,7 +1248,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_all_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, 22);
         SEQAN_ASSERT_EQ(prevVertical._score, 18);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX | +TraceBitMap_<>::HORIZONTAL |
@@ -1263,7 +1263,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_all_direction)
 
     {
         prevVertical._score = 22;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX |
@@ -1275,7 +1275,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_all_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, 22);
         SEQAN_ASSERT_EQ(prevVertical._score, 22);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX |
@@ -1290,7 +1290,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_all_direction)
 
     {
         prevVertical._verticalScore = 20;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::HORIZONTAL | +TraceBitMap_<>::VERTICAL |
@@ -1302,7 +1302,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_all_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, 22);
         SEQAN_ASSERT_EQ(prevVertical._score, 22);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::HORIZONTAL | +TraceBitMap_<>::VERTICAL |
@@ -1318,7 +1318,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_all_direction)
 
     {
         prevDiagonal._score = 14;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::HORIZONTAL | +TraceBitMap_<>::VERTICAL | TraceBitMap_<>::DIAGONAL));
@@ -1329,7 +1329,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_affine_all_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, 22);
         SEQAN_ASSERT_EQ(prevVertical._score, 22);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::HORIZONTAL | +TraceBitMap_<>::VERTICAL |
@@ -1364,19 +1364,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_diagonal_direction)
     Score<int, Simple> scoringScheme(2, -2, -4);
     TTraceValue traceValue;
     {
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL));
         SEQAN_ASSERT_EQ(_scoreOfCell(activeCell), -8);
         SEQAN_ASSERT_EQ(_scoreOfCell(prevDiagonal), -10);
         SEQAN_ASSERT_EQ(_scoreOfCell(prevHorizontal), 10);
         SEQAN_ASSERT_EQ(_scoreOfCell(prevVertical), 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                    scoringScheme, RecursionDirectionDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL));
         SEQAN_ASSERT_EQ(_scoreOfCell(activeCell), -8);
         SEQAN_ASSERT_EQ(_scoreOfCell(prevDiagonal), -10);
         SEQAN_ASSERT_EQ(_scoreOfCell(prevHorizontal), 10);
@@ -1384,19 +1384,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_diagonal_direction)
     }
 
     {
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                    scoringScheme, RecursionDirectionDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL));
         SEQAN_ASSERT_EQ(_scoreOfCell(activeCell), -12);
         SEQAN_ASSERT_EQ(_scoreOfCell(prevDiagonal), -10);
         SEQAN_ASSERT_EQ(_scoreOfCell(prevHorizontal), 10);
         SEQAN_ASSERT_EQ(_scoreOfCell(prevVertical), 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                    scoringScheme, RecursionDirectionDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL));
         SEQAN_ASSERT_EQ(_scoreOfCell(activeCell), -12);
         SEQAN_ASSERT_EQ(_scoreOfCell(prevDiagonal), -10);
         SEQAN_ASSERT_EQ(_scoreOfCell(prevHorizontal), 10);
@@ -1423,27 +1423,27 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_horizontal_direction)
 
     Score<int, Simple> scoringScheme(2, -2, -2, -4);
 
-    TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+    TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                            scoringScheme, RecursionDirectionHorizontal(), TDPProfileSingleTrace());
 
-    SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::HORIZONTAL_OPEN | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX);
+    SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::HORIZONTAL_OPEN | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
     SEQAN_ASSERT_EQ(_scoreOfCell(activeCell), 6);
     SEQAN_ASSERT_EQ(isGapExtension(activeCell, DynamicGapExtensionHorizontal()), true);
     SEQAN_ASSERT_EQ(isGapExtension(activeCell, DynamicGapExtensionVertical()), false);
 
-    traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'C',
+    traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'C',
                                            scoringScheme, RecursionDirectionHorizontal(), TDPProfileCompleteTrace());
 
-    SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::HORIZONTAL_OPEN | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX);
+    SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::HORIZONTAL_OPEN | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
     SEQAN_ASSERT_EQ(_scoreOfCell(activeCell), 6);
     SEQAN_ASSERT_EQ(isGapExtension(activeCell, DynamicGapExtensionHorizontal()), true);
     SEQAN_ASSERT_EQ(isGapExtension(activeCell, DynamicGapExtensionVertical()), false);
 
     _setBit(prevHorizontal, True(), DynamicGapExtensionHorizontal());
-    traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'C',
+    traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'C',
                                            scoringScheme, RecursionDirectionHorizontal(), TDPProfileCompleteTrace());
 
-    SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX);
+    SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
     SEQAN_ASSERT_EQ(_scoreOfCell(activeCell), 8);
     SEQAN_ASSERT_EQ(isGapExtension(activeCell, DynamicGapExtensionHorizontal()), true);
     SEQAN_ASSERT_EQ(isGapExtension(activeCell, DynamicGapExtensionVertical()), false);
@@ -1468,23 +1468,23 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_vertical_direction)
 
     Score<int, Simple> scoringScheme(2, -2, -2, -4);
 
-    TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+    TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                            scoringScheme, RecursionDirectionVertical(), TDPProfileSingleTrace());
 
-    SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX);
+    SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
     SEQAN_ASSERT_EQ(activeCell._score, 6);
 
-    traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+    traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                            scoringScheme, RecursionDirectionVertical(), TDPProfileCompleteTrace());
 
-    SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX);
+    SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
     SEQAN_ASSERT_EQ(activeCell._score, 6);
 
     _setBit(prevVertical, True(), DynamicGapExtensionVertical());
-    traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+    traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                            scoringScheme, RecursionDirectionVertical(), TDPProfileCompleteTrace());
 
-    SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX);
+    SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
     SEQAN_ASSERT_EQ(activeCell._score, 8);
 }
 
@@ -1508,57 +1508,57 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_upper_band_direction)
     Score<int, Simple> scoringScheme(2, -2, -2, -4);
 
     {
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::HORIZONTAL_OPEN | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::HORIZONTAL_OPEN | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 6);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::HORIZONTAL_OPEN | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::HORIZONTAL_OPEN | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 6);
 
         _setBit(prevHorizontal, True(), DynamicGapExtensionHorizontal());
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 8);
     }
 
     {
         prevHorizontal._score = -10;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::HORIZONTAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::HORIZONTAL));
         SEQAN_ASSERT_EQ(activeCell._score, -8);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::HORIZONTAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::HORIZONTAL));
         SEQAN_ASSERT_EQ(activeCell._score, -8);
     }
 
     {
         prevHorizontal._score = -4;
         _setBit(prevHorizontal, False(), DynamicGapExtensionHorizontal());
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::HORIZONTAL_OPEN);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::HORIZONTAL_OPEN));
         SEQAN_ASSERT_EQ(activeCell._score, -8);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'C',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'C',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::HORIZONTAL_OPEN | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::HORIZONTAL_OPEN | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, -8);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::HORIZONTAL_OPEN | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
@@ -1566,19 +1566,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_upper_band_direction)
 
         prevHorizontal._score = -6;
         _setBit(prevHorizontal, True(), DynamicGapExtensionHorizontal());
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                        scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::HORIZONTAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::HORIZONTAL));
         SEQAN_ASSERT_EQ(activeCell._score, -8);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'C',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'C',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, -8);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
@@ -1606,57 +1606,57 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_lower_band_direction)
     Score<int, Simple> scoringScheme(2, -2, -2, -4);
 
     {
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 6);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 6);
 
         _setBit(prevVertical, True(), DynamicGapExtensionVertical());
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 8);
     }
 
     {
         prevVertical._score = -10;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::VERTICAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::VERTICAL));
         SEQAN_ASSERT_EQ(activeCell._score, -8);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::VERTICAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::VERTICAL));
         SEQAN_ASSERT_EQ(activeCell._score, -8);
     }
 
     {
         prevVertical._score = -4;
         _setBit(prevVertical, False(), DynamicGapExtensionVertical());
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::VERTICAL_OPEN);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::VERTICAL_OPEN));
         SEQAN_ASSERT_EQ(activeCell._score, -8);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'C',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'C',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, -8);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
@@ -1664,19 +1664,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_lower_band_direction)
 
         prevVertical._score = -6;
         _setBit(prevVertical, True(), DynamicGapExtensionVertical());
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                        scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::VERTICAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::VERTICAL));
         SEQAN_ASSERT_EQ(activeCell._score, -8);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'C',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'C',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, -8);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
@@ -1705,81 +1705,81 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_all_direction)
 
     {  // From diagonal only.
         // Single trace.
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::HORIZONTAL_OPEN);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::HORIZONTAL_OPEN));
         SEQAN_ASSERT_EQ(activeCell._score, -8);
 
         // Complete trace.
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::HORIZONTAL_OPEN);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::HORIZONTAL_OPEN));
         SEQAN_ASSERT_EQ(activeCell._score, -8);
     }
 
     {  // From horizontal only.
         // Single Trace + horizontal open.
         prevHorizontal._score = 0;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::HORIZONTAL_OPEN | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX | TraceBitMap_<>::VERTICAL_OPEN);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::HORIZONTAL_OPEN | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX | TraceBitMap_<>::VERTICAL_OPEN));
         SEQAN_ASSERT_EQ(activeCell._score, -4);
 
         // Complete Trace + horizontal open.
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                    scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::HORIZONTAL_OPEN | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX | TraceBitMap_<>::VERTICAL_OPEN);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::HORIZONTAL_OPEN | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX | TraceBitMap_<>::VERTICAL_OPEN));
         SEQAN_ASSERT_EQ(activeCell._score, -4);
 
         // Single Trace + horizontal extend.
         _setBit(prevHorizontal, True(), DynamicGapExtensionHorizontal());
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                    scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX | TraceBitMap_<>::VERTICAL_OPEN);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX | TraceBitMap_<>::VERTICAL_OPEN));
         SEQAN_ASSERT_EQ(activeCell._score, -2);
 
         // Complete Trace + horizontal extend.
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                    scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX | TraceBitMap_<>::VERTICAL_OPEN);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX | TraceBitMap_<>::VERTICAL_OPEN));
         SEQAN_ASSERT_EQ(activeCell._score, -2);
     }
 
     {  // From vertical only.
         // Single Trace + vertical open.
         prevVertical._score = 4;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::HORIZONTAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::HORIZONTAL));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
 
         // Complete Trace + horizontal open.
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                    scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::HORIZONTAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::HORIZONTAL));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
 
         // Single Trace + horizontal extend.
         _setBit(prevVertical, True(), DynamicGapExtensionVertical());
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                    scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::HORIZONTAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::HORIZONTAL));
         SEQAN_ASSERT_EQ(activeCell._score, 2);
 
         // Complete Trace + horizontal extend.
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                    scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::HORIZONTAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::HORIZONTAL));
         SEQAN_ASSERT_EQ(activeCell._score, 2);
     }
 
@@ -1787,7 +1787,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_all_direction)
         // Single trace + horizontal extend.
         prevHorizontal._score = 6;
         prevDiagonal._score = 2;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::VERTICAL));
@@ -1796,7 +1796,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_all_direction)
         SEQAN_ASSERT_EQ(isGapExtension(activeCell, DynamicGapExtensionVertical()), false);
 
         // Complete trace + horizontal extend.
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                    scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX | TraceBitMap_<>::VERTICAL));
@@ -1807,7 +1807,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_all_direction)
         // Single Trace + horizontal open
         prevHorizontal._score = 8;
         _setBit(prevHorizontal, False(), DynamicGapExtensionHorizontal());
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                    scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::HORIZONTAL_OPEN | TraceBitMap_<>::VERTICAL));
@@ -1816,7 +1816,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_all_direction)
         SEQAN_ASSERT_EQ(isGapExtension(activeCell, DynamicGapExtensionVertical()), false);
 
         // Complete trace + horizontal extend.
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                    scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::HORIZONTAL_OPEN | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX | TraceBitMap_<>::VERTICAL));
@@ -1828,7 +1828,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_all_direction)
     {  // From horziontal + vertical.
         // Single trace + vertical extend + horizontal open.
         prevVertical._score = 6;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'C',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'C',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::HORIZONTAL_OPEN));
@@ -1837,7 +1837,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_all_direction)
         SEQAN_ASSERT_EQ(isGapExtension(activeCell, DynamicGapExtensionVertical()), true);
 
         // Complete trace + vertical extend + horizontal open.
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'C',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'C',
                                    scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::HORIZONTAL_OPEN | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
@@ -1848,7 +1848,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_all_direction)
         // Single trace + vertical open + horizontal open.
         _setBit(prevVertical, False(), DynamicGapExtensionVertical());
         prevVertical._score = 8;
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'C',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'C',
                                    scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::HORIZONTAL_OPEN));
@@ -1857,7 +1857,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_all_direction)
         SEQAN_ASSERT_EQ(isGapExtension(activeCell, DynamicGapExtensionVertical()), true);
 
         // Complete trace + vertical open + horizontal open.
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'C',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'C',
                                    scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::HORIZONTAL_OPEN | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
@@ -1868,7 +1868,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_all_direction)
         // Single trace + vertical open + horizontal extend.
         _setBit(prevHorizontal, True(), DynamicGapExtensionHorizontal());
         prevHorizontal._score = 6;
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'C',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'C',
                                    scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::HORIZONTAL));
@@ -1877,7 +1877,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_all_direction)
         SEQAN_ASSERT_EQ(isGapExtension(activeCell, DynamicGapExtensionVertical()), true);
 
         // Complete trace + vertical open + horizontal extend.
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'C',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'C',
                                    scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
@@ -1888,7 +1888,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_all_direction)
         // Single trace + vertical extend + horizontal extend.
         _setBit(prevVertical, True(), DynamicGapExtensionVertical());
         prevVertical._score = 6;
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'C',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'C',
                                    scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::HORIZONTAL));
@@ -1897,7 +1897,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_all_direction)
         SEQAN_ASSERT_EQ(isGapExtension(activeCell, DynamicGapExtensionVertical()), true);
 
         // Complete trace + vertical extend + horizontal extend.
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'C',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'C',
                                    scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
@@ -1910,7 +1910,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_all_direction)
         // Single trace + vertical extend.
         prevHorizontal._score = 0;
         prevDiagonal._score = 2;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::VERTICAL));
@@ -1919,7 +1919,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_all_direction)
         SEQAN_ASSERT_EQ(isGapExtension(activeCell, DynamicGapExtensionVertical()), false);
 
         // Complete trace + horizontal extend.
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                    scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::VERTICAL));
@@ -1930,7 +1930,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_all_direction)
         // Single Trace + vertical open
         prevVertical._score = 8;
         _setBit(prevVertical, False(), DynamicGapExtensionVertical());
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                    scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::HORIZONTAL));
@@ -1939,7 +1939,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_all_direction)
         SEQAN_ASSERT_EQ(isGapExtension(activeCell, DynamicGapExtensionVertical()), false);
 
         // Complete trace + vertical extend.
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                    scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::VERTICAL_OPEN));
@@ -1951,7 +1951,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_all_direction)
     {  // From horizontal + vertical + diagonal.
         // Single trace + vertical open + horizontal extend.
         prevHorizontal._score = 6;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::HORIZONTAL));
@@ -1960,7 +1960,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_all_direction)
         SEQAN_ASSERT_EQ(isGapExtension(activeCell, DynamicGapExtensionVertical()), false);
 
         // Complete trace + vertical open + horizontal extend.
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                    scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
@@ -1971,7 +1971,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_all_direction)
         // Single trace + vertical open + horizontal open.
         _setBit(prevHorizontal, False(), DynamicGapExtensionHorizontal());
         prevHorizontal._score = 8;
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                    scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::HORIZONTAL_OPEN));
@@ -1980,7 +1980,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_all_direction)
         SEQAN_ASSERT_EQ(isGapExtension(activeCell, DynamicGapExtensionVertical()), false);
 
         // Complete trace + vertical open + horizontal open.
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                    scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::HORIZONTAL_OPEN | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
@@ -1991,7 +1991,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_all_direction)
         // Single trace + vertical extend + horizontal open.
         _setBit(prevVertical, True(), DynamicGapExtensionVertical());
         prevVertical._score = 6;
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                    scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::VERTICAL | TraceBitMap_<>::HORIZONTAL_OPEN));
@@ -2000,7 +2000,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_all_direction)
         SEQAN_ASSERT_EQ(isGapExtension(activeCell, DynamicGapExtensionVertical()), false);
 
         // Complete trace + vertical open + horizontal extend.
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                    scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::HORIZONTAL_OPEN | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
@@ -2011,7 +2011,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_all_direction)
         // Single trace + vertical extend + horizontal extend.
         _setBit(prevHorizontal, True(), DynamicGapExtensionHorizontal());
         prevHorizontal._score = 6;
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                    scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::VERTICAL | TraceBitMap_<>::HORIZONTAL));
@@ -2020,7 +2020,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_global_dynamic_all_direction)
         SEQAN_ASSERT_EQ(isGapExtension(activeCell, DynamicGapExtensionVertical()), false);
 
         // Complete trace + vertical extend + horizontal extend.
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                    scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
@@ -2048,37 +2048,37 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_linear_diagonal_direction)
 
     Score<int, Simple> scoringScheme(2, -2, -4);
 
-    TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+    TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                            scoringScheme, RecursionDirectionDiagonal(), TDPProfileSingleTrace());
 
-    SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL);
+    SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL));
     SEQAN_ASSERT_EQ(activeCell._score, 4);
     SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
     SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
     SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-    traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+    traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                scoringScheme, RecursionDirectionDiagonal(), TDPProfileCompleteTrace());
 
-    SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL);
+    SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL));
     SEQAN_ASSERT_EQ(activeCell._score, 4);
     SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
     SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
     SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-    traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+    traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                scoringScheme, RecursionDirectionDiagonal(), TDPProfileSingleTrace());
 
-    SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+    SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
     SEQAN_ASSERT_EQ(activeCell._score, 0);
     SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
     SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
     SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-    traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+    traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                scoringScheme, RecursionDirectionDiagonal(), TDPProfileCompleteTrace());
 
-    SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+    SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
     SEQAN_ASSERT_EQ(activeCell._score, 0);
     SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
     SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -2104,19 +2104,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_linear_horizontal_direction)
     Score<int, Simple> scoringScheme(2, -2, -4);
 
     {
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionHorizontal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 6);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionHorizontal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 6);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -2124,19 +2124,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_linear_horizontal_direction)
     }
     {
         prevHorizontal._score = 2;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                                scoringScheme, RecursionDirectionHorizontal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 2);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                                scoringScheme, RecursionDirectionHorizontal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 2);
@@ -2162,19 +2162,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_linear_vertical_direction)
     Score<int, Simple> scoringScheme(2, -2, -4);
 
     {
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionVertical(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 6);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionVertical(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
         SEQAN_ASSERT_EQ(activeCell._score, 6);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -2182,19 +2182,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_linear_vertical_direction)
     }
     {
         prevVertical._score = 2;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                                scoringScheme, RecursionDirectionVertical(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 2);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                                scoringScheme, RecursionDirectionVertical(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -2220,7 +2220,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_linear_upper_band_direction)
     Score<int, Simple> scoringScheme(2, -2, -4);
 
     {
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL));
@@ -2229,7 +2229,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_linear_upper_band_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, 8);
         SEQAN_ASSERT_EQ(prevVertical._score, 2);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
@@ -2240,19 +2240,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_linear_upper_band_direction)
     }
     {
         prevHorizontal._score = 2;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                                scoringScheme, RecursionDirectionVertical(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 2);
         SEQAN_ASSERT_EQ(prevVertical._score, 2);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                                scoringScheme, RecursionDirectionVertical(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 2);
@@ -2278,7 +2278,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_linear_lower_band_direction)
     Score<int, Simple> scoringScheme(2, -2, -4);
 
     {
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL));
@@ -2287,7 +2287,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_linear_lower_band_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, 2);
         SEQAN_ASSERT_EQ(prevVertical._score, 8);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::VERTICAL | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
@@ -2298,19 +2298,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_linear_lower_band_direction)
     }
     {
         prevVertical._score = 2;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 2);
         SEQAN_ASSERT_EQ(prevVertical._score, 2);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 2);
@@ -2337,7 +2337,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_linear_all_direction)
     Score<int, Simple> scoringScheme(2, -2, -4);
 
     {
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL));
@@ -2346,7 +2346,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_linear_all_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, 8);
         SEQAN_ASSERT_EQ(prevVertical._score, 8);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::HORIZONTAL | +TraceBitMap_<>::VERTICAL |
@@ -2360,19 +2360,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_linear_all_direction)
         prevDiagonal._score = 0;
         prevVertical._score = 2;
         prevHorizontal._score = 2;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 0);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 2);
         SEQAN_ASSERT_EQ(prevVertical._score, 2);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 0);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 2);
@@ -2406,10 +2406,10 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_affine_diagonal_direction)
     int inf = DPCellDefaultInfinity<DPCell_<int, AffineGaps> >::VALUE;
 
     {
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL));
         SEQAN_ASSERT_EQ(activeCell._score, 4);
         SEQAN_ASSERT_EQ(activeCell._verticalScore, inf);
         SEQAN_ASSERT_EQ(activeCell._horizontalScore, inf);
@@ -2417,10 +2417,10 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_affine_diagonal_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::DIAGONAL);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::DIAGONAL));
         SEQAN_ASSERT_EQ(activeCell._score, 4);
         SEQAN_ASSERT_EQ(activeCell._verticalScore, inf);
         SEQAN_ASSERT_EQ(activeCell._horizontalScore, inf);
@@ -2433,24 +2433,24 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_affine_diagonal_direction)
     {
         prevDiagonal._horizontalScore = 2;
         prevDiagonal._verticalScore = 2;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                                scoringScheme, RecursionDirectionDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
-        SEQAN_ASSERT_EQ(activeCell._verticalScore, 0);
-        SEQAN_ASSERT_EQ(activeCell._horizontalScore, 0);
+        SEQAN_ASSERT_EQ(activeCell._verticalScore, inf);
+        SEQAN_ASSERT_EQ(activeCell._horizontalScore, inf);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                                scoringScheme, RecursionDirectionDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
-        SEQAN_ASSERT_EQ(activeCell._verticalScore, 0);
-        SEQAN_ASSERT_EQ(activeCell._horizontalScore, 0);
+        SEQAN_ASSERT_EQ(activeCell._verticalScore, inf);
+        SEQAN_ASSERT_EQ(activeCell._horizontalScore, inf);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
@@ -2484,7 +2484,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_affine_horizontal_direction)
     int inf = DPCellDefaultInfinity<DPCell_<int, AffineGaps> >::VALUE;
 
     {
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionHorizontal(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::HORIZONTAL | +TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
@@ -2495,7 +2495,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_affine_horizontal_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                    scoringScheme, RecursionDirectionHorizontal(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::HORIZONTAL_OPEN | +TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX));
@@ -2510,24 +2510,24 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_affine_horizontal_direction)
     {
         prevHorizontal._score = 1;
         prevHorizontal._horizontalScore = 1;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                                scoringScheme, RecursionDirectionHorizontal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
-        SEQAN_ASSERT_EQ(activeCell._verticalScore, 0);
-        SEQAN_ASSERT_EQ(activeCell._horizontalScore, 0);
+        SEQAN_ASSERT_EQ(activeCell._verticalScore, inf);
+        SEQAN_ASSERT_EQ(activeCell._horizontalScore, -3);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 1);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                                scoringScheme, RecursionDirectionHorizontal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
-        SEQAN_ASSERT_EQ(activeCell._verticalScore, 0);
-        SEQAN_ASSERT_EQ(activeCell._horizontalScore, 0);
+        SEQAN_ASSERT_EQ(activeCell._verticalScore, inf);
+        SEQAN_ASSERT_EQ(activeCell._horizontalScore, -3);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 1);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
@@ -2560,7 +2560,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_affine_vertical_direction)
     int inf = DPCellDefaultInfinity<DPCell_<int, AffineGaps> >::VALUE;
 
     {
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionVertical(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::VERTICAL | +TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
@@ -2571,7 +2571,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_affine_vertical_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                    scoringScheme, RecursionDirectionVertical(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::VERTICAL | +TraceBitMap_<>::VERTICAL_OPEN | +TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX));
@@ -2586,24 +2586,24 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_affine_vertical_direction)
     {
         prevVertical._score = 1;
         prevVertical._verticalScore = 1;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                                scoringScheme, RecursionDirectionVertical(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
-        SEQAN_ASSERT_EQ(activeCell._verticalScore, 0);
-        SEQAN_ASSERT_EQ(activeCell._horizontalScore, 0);
+        SEQAN_ASSERT_EQ(activeCell._verticalScore, -3);
+        SEQAN_ASSERT_EQ(activeCell._horizontalScore, inf);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 1);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                                scoringScheme, RecursionDirectionVertical(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
-        SEQAN_ASSERT_EQ(activeCell._verticalScore, 0);
-        SEQAN_ASSERT_EQ(activeCell._horizontalScore, 0);
+        SEQAN_ASSERT_EQ(activeCell._verticalScore, -3);
+        SEQAN_ASSERT_EQ(activeCell._horizontalScore, inf);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 1);
@@ -2636,7 +2636,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_affine_upper_band_direction)
     int inf = DPCellDefaultInfinity<DPCell_<int, AffineGaps> >::VALUE;
 
     {
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::DIAGONAL));
@@ -2647,7 +2647,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_affine_upper_band_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                    scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::HORIZONTAL | +TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX |
@@ -2663,24 +2663,24 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_affine_upper_band_direction)
     {
         prevHorizontal._score = 1;
         prevHorizontal._horizontalScore = 1;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                                scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
-        SEQAN_ASSERT_EQ(activeCell._verticalScore, 0);
-        SEQAN_ASSERT_EQ(activeCell._horizontalScore, 0);
+        SEQAN_ASSERT_EQ(activeCell._verticalScore, inf);
+        SEQAN_ASSERT_EQ(activeCell._horizontalScore, -3);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 1);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                    scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
-        SEQAN_ASSERT_EQ(activeCell._verticalScore, 0);
-        SEQAN_ASSERT_EQ(activeCell._horizontalScore, 0);
+        SEQAN_ASSERT_EQ(activeCell._verticalScore, inf);
+        SEQAN_ASSERT_EQ(activeCell._horizontalScore, -3);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 1);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
@@ -2713,7 +2713,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_affine_lower_band_direction)
     int inf = DPCellDefaultInfinity<DPCell_<int, AffineGaps> >::VALUE;
 
     {
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::VERTICAL | TraceBitMap_<>::DIAGONAL));
@@ -2724,7 +2724,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_affine_lower_band_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                    scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::VERTICAL | +TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX |
@@ -2740,24 +2740,24 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_affine_lower_band_direction)
     {
         prevVertical._score = 1;
         prevVertical._verticalScore = 1;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
-        SEQAN_ASSERT_EQ(activeCell._horizontalScore, 0);
-        SEQAN_ASSERT_EQ(activeCell._verticalScore, 0);
+        SEQAN_ASSERT_EQ(activeCell._horizontalScore, inf);
+        SEQAN_ASSERT_EQ(activeCell._verticalScore, -3);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 1);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                    scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
-        SEQAN_ASSERT_EQ(activeCell._horizontalScore, 0);
-        SEQAN_ASSERT_EQ(activeCell._verticalScore, 0);
+        SEQAN_ASSERT_EQ(activeCell._horizontalScore, inf);
+        SEQAN_ASSERT_EQ(activeCell._verticalScore, -3);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 1);
@@ -2789,7 +2789,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_affine_all_direction)
     Score<int, Simple> scoringScheme(2, -2, -4, -6);
 
     {
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                                scoringScheme, RecursionDirectionAll(), TDPProfileSingleTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::VERTICAL | TraceBitMap_<>::DIAGONAL));
@@ -2800,7 +2800,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_affine_all_direction)
         SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
         SEQAN_ASSERT_EQ(prevVertical._score, 10);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                    scoringScheme, RecursionDirectionAll(), TDPProfileCompleteTrace());
 
         SEQAN_ASSERT_EQ(traceValue, (+TraceBitMap_<>::HORIZONTAL | +TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX |
@@ -2820,19 +2820,19 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_affine_all_direction)
         prevHorizontal._horizontalScore = 1;
         prevVertical._score = 1;
         prevVertical._verticalScore = 1;
-        TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+        TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileSingleTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 1);
         SEQAN_ASSERT_EQ(prevVertical._score, 1);
 
-        traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
+        traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'C', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 1);
@@ -2857,10 +2857,10 @@ SEQAN_DEFINE_TEST(test_dp_formula_notrace_diagonal_direction)
 
     Score<int, Simple> scoringScheme(2, -2, -4);
 
-    TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+    TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                            scoringScheme, RecursionDirectionDiagonal(), TDPProfile());
 
-    SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+    SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
     SEQAN_ASSERT_EQ(activeCell._score, 4);
     SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
     SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -2884,10 +2884,10 @@ SEQAN_DEFINE_TEST(test_dp_formula_notrace_horizontal_direction)
 
     Score<int, Simple> scoringScheme(2, -2, -4);
 
-    TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+    TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                            scoringScheme, RecursionDirectionHorizontal(), TDPProfile());
 
-    SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+    SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
     SEQAN_ASSERT_EQ(activeCell._score, 6);
     SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
     SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -2911,10 +2911,10 @@ SEQAN_DEFINE_TEST(test_dp_formula_notrace_vertical_direction)
 
     Score<int, Simple> scoringScheme(2, -2, -4);
 
-    TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+    TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                            scoringScheme, RecursionDirectionVertical(), TDPProfile());
 
-    SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+    SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
     SEQAN_ASSERT_EQ(activeCell._score, 6);
     SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
     SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -2938,10 +2938,10 @@ SEQAN_DEFINE_TEST(test_dp_formula_notrace_upper_band_direction)
 
     Score<int, Simple> scoringScheme(2, -2, -4);
 
-    TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+    TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                            scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfile());
 
-    SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+    SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
     SEQAN_ASSERT_EQ(activeCell._score, 6);
     SEQAN_ASSERT_EQ(prevDiagonal._score, 4);
     SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -2965,10 +2965,10 @@ SEQAN_DEFINE_TEST(test_dp_formula_notrace_lower_band_direction)
 
     Score<int, Simple> scoringScheme(2, -2, -4);
 
-    TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+    TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                            scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfile());
 
-    SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+    SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
     SEQAN_ASSERT_EQ(activeCell._score, 6);
     SEQAN_ASSERT_EQ(prevDiagonal._score, 4);
     SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -2992,10 +2992,10 @@ SEQAN_DEFINE_TEST(test_dp_formula_notrace_all_direction)
 
     Score<int, Simple> scoringScheme(2, -2, -4);
 
-    TTraceValue traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'A', 'A',
+    TTraceValue traceValue = _computeScore(std::forward_as_tuple(activeCell, prevDiagonal, prevHorizontal, prevVertical), 'A', 'A',
                                            scoringScheme, RecursionDirectionAll(), TDPProfile());
 
-    SEQAN_ASSERT_EQ(traceValue, +TraceBitMap_<>::NONE);
+    SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(+TraceBitMap_<>::NONE));
     SEQAN_ASSERT_EQ(activeCell._score, 6);
     SEQAN_ASSERT_EQ(prevDiagonal._score, 4);
     SEQAN_ASSERT_EQ(prevHorizontal._score, 10);

--- a/tests/align/test_alignment_dp_matrix_navigator.h
+++ b/tests/align/test_alignment_dp_matrix_navigator.h
@@ -35,50 +35,18 @@
 #ifndef SANDBOX_RMAERKER_TESTS_ALIGN2_TEST_ALIGNMENT_DP_MATRIX_NAVIGATOR_H_
 #define SANDBOX_RMAERKER_TESTS_ALIGN2_TEST_ALIGNMENT_DP_MATRIX_NAVIGATOR_H_
 
-#include <seqan/basic.h>
+#include <algorithm>
 
+#include <seqan/basic.h>
 #include <seqan/align.h>
 
-
-template <typename TSpec>
-void testAlignmentDPMatrixScoreNavigatorConstructorDefault(TSpec const &)
-{
-    using namespace seqan;
-
-    typedef DPMatrix_<int, TSpec> TDPMatrix;
-    typedef typename Value<TDPMatrix>::Type TDPCell;
-    typedef typename Iterator<TDPMatrix, Standard>::Type TIterator;
-
-    DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise> dpScoreMatrixNavigator;
-
-    // Test if default constructor sets NULL pointer
-    bool resultPointer = true;
-    if (dpScoreMatrixNavigator._ptrDataContainer)
-        resultPointer = false;
-
-    bool resultPrevColIter = true;
-    if (dpScoreMatrixNavigator._prevColIterator != TIterator())
-        resultPrevColIter = false;
-
-    bool resultActiveColIter = true;
-    if (dpScoreMatrixNavigator._activeColIterator != TIterator())
-        resultActiveColIter = false;
-
-    SEQAN_ASSERT_EQ(resultPointer, true);
-    SEQAN_ASSERT_EQ(resultPrevColIter, true);
-    SEQAN_ASSERT_EQ(resultActiveColIter, true);
-    SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 0);
-    SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-    SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-    SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, TDPCell());
-}
 
 template <typename TSpec>
 void testAlignmentDPMatrixTraceNavigatorConstructorDefault(TSpec const &)
 {
     using namespace seqan;
 
-    typedef DPMatrix_<int, FullDPMatrix> TDPMatrix;
+    typedef DPMatrix_<DPCell_<int, LinearGaps>, FullDPMatrix> TDPMatrix;
     typedef typename Iterator<TDPMatrix, Standard>::Type TIterator;
 
     DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TSpec>, NavigateColumnWise> dpTraceMatrixNavigator;
@@ -97,116 +65,79 @@ void testAlignmentDPMatrixTraceNavigatorConstructorDefault(TSpec const &)
     SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 0);
 }
 
-void testAlignmentDPMatrixNavigatorScoreMarixSparseContructor()
-{
-    using namespace seqan;
-
-    typedef DPMatrix_<int, SparseDPMatrix> TDPMatrix;
-    typedef Value<TDPMatrix>::Type TDPCell;
-    typedef Iterator<TDPMatrix, Standard>::Type TIterator;
-
-    DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise> dpScoreMatrixNavigator;
-
-    // Test if default constructor sets NULL pointer
-    bool resultPointer = true;
-    if (dpScoreMatrixNavigator._ptrDataContainer)
-        resultPointer = false;
-
-    bool resultActiveColIter = true;
-    if (dpScoreMatrixNavigator._activeColIterator != TIterator())
-        resultActiveColIter = false;
-
-    bool resultPrevColIter = true;
-    if (dpScoreMatrixNavigator._prevColIterator != TIterator())
-        resultPrevColIter = false;
-
-    SEQAN_ASSERT_EQ(resultPointer, true);
-    SEQAN_ASSERT_EQ(resultActiveColIter, true);
-    SEQAN_ASSERT_EQ(resultPrevColIter, true);
-    SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 0);
-    SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-    SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-    SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, TDPCell());
-}
-
-
 void testAlignmentDPMatrixNavigatorScoreMarixInitUnbanded()
 {
     using namespace seqan;
 
-    typedef DPMatrix_<int, FullDPMatrix> TDPMatrix;
+    typedef DPMatrix_<DPCell_<int, LinearGaps>, FullDPMatrix> TDPMatrix;
     typedef Value<TDPMatrix>::Type TDPCell;
-
-    DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise> dpScoreMatrixNavigator;
 
     TDPMatrix dpMatrix;
     setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 10);
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
-    resize(dpMatrix, 0);
+    resize(dpMatrix, TDPCell{});
 
-    _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
+    DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise>
+        dpScoreMatrixNavigator{dpMatrix, DPBandConfig<BandOff>{}};
 
     SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
     SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), -10);
     SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-    SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-    SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-    SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, TDPCell());
+    SEQAN_ASSERT(dpScoreMatrixNavigator._prevCellDiagonal == nullptr);
+    SEQAN_ASSERT(dpScoreMatrixNavigator._prevCellHorizontal == nullptr);
+    SEQAN_ASSERT(dpScoreMatrixNavigator._prevCellVertical == nullptr);
 }
 
 void testAlignmentDPMatrixNavigatorScoreMarixSparseInitUnbanded()
 {
     using namespace seqan;
 
-    typedef DPMatrix_<int, SparseDPMatrix> TDPMatrix;
+    typedef DPMatrix_<DPCell_<int, LinearGaps>, SparseDPMatrix> TDPMatrix;
     typedef Value<TDPMatrix>::Type TDPCell;
     typedef DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise> TDPMatrixNavigator;
-
-    TDPMatrixNavigator dpScoreMatrixNavigator;
 
     TDPMatrix dpMatrix;
     setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 10);
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
-    resize(dpMatrix, 0);
+    resize(dpMatrix, TDPCell{});
 
-    _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
+    TDPMatrixNavigator dpScoreMatrixNavigator{dpMatrix, DPBandConfig<BandOff>{}};
 
     SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
     SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
     SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 0);
-    SEQAN_ASSERT_EQ(value(dpScoreMatrixNavigator._activeColIterator), 0);
-    SEQAN_ASSERT_EQ(value(dpScoreMatrixNavigator._prevColIterator), 0);
+    SEQAN_ASSERT_EQ(value(dpScoreMatrixNavigator._activeColIterator), TDPCell{});
+    SEQAN_ASSERT_EQ(value(dpScoreMatrixNavigator._prevColIterator), TDPCell{});
     SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -9);
-    SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-    SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-    SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, TDPCell());
+    SEQAN_ASSERT(dpScoreMatrixNavigator._prevCellDiagonal == nullptr);
+    SEQAN_ASSERT(dpScoreMatrixNavigator._prevCellHorizontal == nullptr);
+    SEQAN_ASSERT(dpScoreMatrixNavigator._prevCellVertical == nullptr);
 }
 
 void testAlignmentDPMatrixNavigatorScoreMarixInitBanded()
 {
     using namespace seqan;
 
-    typedef DPMatrix_<int, FullDPMatrix> TDPMatrix;
+    typedef DPMatrix_<DPCell_<int, LinearGaps>, FullDPMatrix> TDPMatrix;
     typedef Value<TDPMatrix>::Type TDPCell;
-    typedef DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise> TDPMatrixNavigator;
+    typedef DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWiseBanded> TDPMatrixNavigator;
 
-    TDPMatrixNavigator dpScoreMatrixNavigator;
 
     { // Case1: Band intersects with poit of origin.
         TDPMatrix dpMatrix;
         setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 10);
         setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 8);
-        resize(dpMatrix, 0);
+        resize(dpMatrix, TDPCell{});
 
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOn>(-4, 3));
+        TDPMatrixNavigator dpScoreMatrixNavigator{dpMatrix, DPBandConfig<BandOn>{-4, 3}};
 
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 3);
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), -5);
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 4);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, TDPCell());
+        SEQAN_ASSERT(dpScoreMatrixNavigator._prevCellDiagonal == nullptr);
+        SEQAN_ASSERT(dpScoreMatrixNavigator._prevCellHorizontal == nullptr);
+        SEQAN_ASSERT(dpScoreMatrixNavigator._prevCellVertical == nullptr);
     }
 
     {
@@ -216,15 +147,16 @@ void testAlignmentDPMatrixNavigatorScoreMarixInitBanded()
         resize(dpMatrix2);
 
         value(host(dpMatrix2), 0) = 10;
-        _init(dpScoreMatrixNavigator, dpMatrix2, DPBandConfig<BandOn>(0, 7));
+
+        TDPMatrixNavigator dpScoreMatrixNavigator{dpMatrix2, DPBandConfig<BandOn>{0, 7}};
 
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix2);
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix2, Standard()), 7);
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix2, Standard()), -1);
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 8);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, TDPCell());
+        SEQAN_ASSERT(dpScoreMatrixNavigator._prevCellDiagonal == nullptr);
+        SEQAN_ASSERT(dpScoreMatrixNavigator._prevCellHorizontal == nullptr);
+        SEQAN_ASSERT(dpScoreMatrixNavigator._prevCellVertical == nullptr);
     }
 
     {
@@ -233,45 +165,41 @@ void testAlignmentDPMatrixNavigatorScoreMarixInitBanded()
         setLength(dpMatrix3, DPMatrixDimension_::VERTICAL, 8);
         resize(dpMatrix3);
 
-
-        _init(dpScoreMatrixNavigator, dpMatrix3, DPBandConfig<BandOn>(-7, 0));
+        TDPMatrixNavigator dpScoreMatrixNavigator{dpMatrix3, DPBandConfig<BandOn>{-7, 0}};
 
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix3);
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix3, Standard()), 0);
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix3, Standard()), -8);
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, TDPCell());
+        SEQAN_ASSERT(dpScoreMatrixNavigator._prevCellDiagonal == nullptr);
+        SEQAN_ASSERT(dpScoreMatrixNavigator._prevCellHorizontal == nullptr);
+        SEQAN_ASSERT(dpScoreMatrixNavigator._prevCellVertical == nullptr);
     }
-
 }
 
 void testAlignmentDPMatrixNavigatorScoreMarixSparseInitBanded()
 {
     using namespace seqan;
 
-    typedef DPMatrix_<int, SparseDPMatrix> TDPMatrix;
+    typedef DPMatrix_<DPCell_<int, LinearGaps>, SparseDPMatrix> TDPMatrix;
     typedef Value<TDPMatrix>::Type TDPCell;
-    typedef DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise> TDPMatrixNavigator;
-
-    TDPMatrixNavigator dpScoreMatrixNavigator;
+    typedef DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWiseBanded> TDPMatrixNavigator;
 
     {
         TDPMatrix dpMatrix;
         setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 10);
         setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 8);
-        resize(dpMatrix, 0);
+        resize(dpMatrix, TDPCell{});
 
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOn>(-4, 3));
+        TDPMatrixNavigator dpScoreMatrixNavigator{dpMatrix, DPBandConfig<BandOn>{-4, 3}};
 
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 3);
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 3);
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -4);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, TDPCell());
+        SEQAN_ASSERT(dpScoreMatrixNavigator._prevCellDiagonal == nullptr);
+        SEQAN_ASSERT(dpScoreMatrixNavigator._prevCellHorizontal == nullptr);
+        SEQAN_ASSERT(dpScoreMatrixNavigator._prevCellVertical == nullptr);
     }
 
     {
@@ -280,15 +208,15 @@ void testAlignmentDPMatrixNavigatorScoreMarixSparseInitBanded()
         setLength(dpMatrix2, DPMatrixDimension_::VERTICAL, 8);
         resize(dpMatrix2);
 
-        _init(dpScoreMatrixNavigator, dpMatrix2, DPBandConfig<BandOn>(0, 7));
+        TDPMatrixNavigator dpScoreMatrixNavigator{dpMatrix2, DPBandConfig<BandOn>{0, 7}};
 
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix2);
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix2, Standard()), 7);
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix2, Standard()), 7);  // Behind the last cell.
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, TDPCell());
+        SEQAN_ASSERT(dpScoreMatrixNavigator._prevCellDiagonal == nullptr);
+        SEQAN_ASSERT(dpScoreMatrixNavigator._prevCellHorizontal == nullptr);
+        SEQAN_ASSERT(dpScoreMatrixNavigator._prevCellVertical == nullptr);
     }
 
     {
@@ -297,15 +225,15 @@ void testAlignmentDPMatrixNavigatorScoreMarixSparseInitBanded()
         setLength(dpMatrix3, DPMatrixDimension_::VERTICAL, 8);
         resize(dpMatrix3);
 
-        _init(dpScoreMatrixNavigator, dpMatrix3, DPBandConfig<BandOn>(-7, 0));
+        TDPMatrixNavigator dpScoreMatrixNavigator{dpMatrix3, DPBandConfig<BandOn>{-7, 0}};
 
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix3);
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix3, Standard()), 0);
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix3, Standard()), 0);
         SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -7);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, TDPCell());
+        SEQAN_ASSERT(dpScoreMatrixNavigator._prevCellDiagonal == nullptr);
+        SEQAN_ASSERT(dpScoreMatrixNavigator._prevCellHorizontal == nullptr);
+        SEQAN_ASSERT(dpScoreMatrixNavigator._prevCellVertical == nullptr);
     }
 }
 
@@ -313,846 +241,170 @@ void testAlignmentDPMatrixNavigatorScoreMarixGoNextCell()
 {
     using namespace seqan;
 
-    typedef DPMatrix_<int, FullDPMatrix> TDPMatrix;
+    typedef DPMatrix_<DPCell_<int, LinearGaps>, FullDPMatrix> TDPMatrix;
     typedef Value<TDPMatrix>::Type TDPCell;
 
-    DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise> dpScoreMatrixNavigator;
-
     TDPMatrix dpMatrix;
-    setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 10);
-    setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 3);
-    resize(dpMatrix, 0);
-    host(dpMatrix)[0] = 0;
-    host(dpMatrix)[1] = 1;
-    host(dpMatrix)[2] = 2;
-    host(dpMatrix)[3] = 3;
-    host(dpMatrix)[4] = 4;
-    host(dpMatrix)[5] = 5;
+    setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 4);
+    setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 4);
+    resize(dpMatrix, TDPCell{});
 
+    int score = 0;
+    auto generator = [&score]()
     {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
+        TDPCell cell;
+        cell = score++;
+        return cell;
+    };
 
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), FirstCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), -3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
+    std::generate(begin(host(dpMatrix), Standard()), end(host(dpMatrix), Standard()), generator);
 
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), InnerCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
+    DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise>
+        navi{dpMatrix, DPBandConfig<BandOff>{}};
 
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), LastCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), -1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
+    TDPCell prevDiag{};
+    TDPCell prevVert{};
+    TDPCell prevHori{};
+    setCachedCells(navi, prevDiag, prevHori, prevVert);
+
+    // Initialize with 0.
+    _setScoreOfCell(value(navi), 0);
+    // Move along initial column.
+    _goNextCell(navi, MetaColumnDescriptor<DPInitialColumn, FullColumn>{}, FirstCell{});
+    SEQAN_ASSERT_EQ(_scoreOfCell(value(navi)), 0);
+    for (int v_pos = 1; v_pos < 3; ++v_pos)
+    {
+        _goNextCell(navi, MetaColumnDescriptor<DPInitialColumn, FullColumn>{}, InnerCell{});
+        SEQAN_ASSERT_EQ(_scoreOfCell(value(navi)), v_pos);
+        SEQAN_ASSERT_EQ(_scoreOfCell(previousCellVertical(navi)), v_pos - 1);
+    }
+    _goNextCell(navi, MetaColumnDescriptor<DPInitialColumn, FullColumn>{}, LastCell{});
+    SEQAN_ASSERT_EQ(_scoreOfCell(value(navi)), 3);
+    SEQAN_ASSERT_EQ(_scoreOfCell(previousCellVertical(navi)), 2);
+
+    // Move along inner columns.
+    for (int h_pos = 1; h_pos < 3; ++h_pos)
+    {
+        _goNextCell(navi, MetaColumnDescriptor<DPInnerColumn, FullColumn>{}, FirstCell{});
+        SEQAN_ASSERT_EQ(_scoreOfCell(value(navi)), h_pos * 4);
+        SEQAN_ASSERT_EQ(_scoreOfCell(previousCellHorizontal(navi)), (h_pos - 1) * 4);
+        for (int v_pos = 1; v_pos < 3; ++v_pos)
+        {
+            _goNextCell(navi, MetaColumnDescriptor<DPInnerColumn, FullColumn>{}, InnerCell{});
+            SEQAN_ASSERT_EQ(_scoreOfCell(value(navi)), h_pos * 4 + v_pos);
+            SEQAN_ASSERT_EQ(_scoreOfCell(previousCellDiagonal(navi)), (h_pos - 1) * 4 + (v_pos - 1));
+            SEQAN_ASSERT_EQ(_scoreOfCell(previousCellHorizontal(navi)), (h_pos - 1) * 4 + v_pos);
+            SEQAN_ASSERT_EQ(_scoreOfCell(previousCellVertical(navi)), (h_pos) * 4 + (v_pos - 1));
+        }
+        _goNextCell(navi, MetaColumnDescriptor<DPInnerColumn, FullColumn>{}, LastCell{});
+        SEQAN_ASSERT_EQ(_scoreOfCell(value(navi)), h_pos * 4 + 3);
+        SEQAN_ASSERT_EQ(_scoreOfCell(previousCellDiagonal(navi)), (h_pos - 1) * 4 + 2);
+        SEQAN_ASSERT_EQ(_scoreOfCell(previousCellHorizontal(navi)), (h_pos - 1) * 4 + 3);
+        SEQAN_ASSERT_EQ(_scoreOfCell(previousCellVertical(navi)), (h_pos) * 4 + 2);
     }
 
+    // Move along last column.
+    _goNextCell(navi, MetaColumnDescriptor<DPFinalColumn, FullColumn>{}, FirstCell{});
+    SEQAN_ASSERT_EQ(_scoreOfCell(value(navi)), 12);
+    SEQAN_ASSERT_EQ(_scoreOfCell(previousCellHorizontal(navi)), 8);
+    for (int v_pos = 1; v_pos < 3; ++v_pos)
     {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnMiddle>(), FirstCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), -3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnMiddle>(), InnerCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnMiddle>(), LastCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), -1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
+        _goNextCell(navi, MetaColumnDescriptor<DPFinalColumn, FullColumn>{}, InnerCell{});
+        SEQAN_ASSERT_EQ(_scoreOfCell(value(navi)), 12 + v_pos);
+        SEQAN_ASSERT_EQ(_scoreOfCell(previousCellDiagonal(navi)), 8 + (v_pos - 1));
+        SEQAN_ASSERT_EQ(_scoreOfCell(previousCellHorizontal(navi)), 8 + v_pos);
+        SEQAN_ASSERT_EQ(_scoreOfCell(previousCellVertical(navi)), 12 + (v_pos - 1));
     }
-
-    {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom>(), FirstCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), -3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom>(), InnerCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom>(), LastCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), -1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-    }
-
-    {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, FullColumn>(), FirstCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), -3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, FullColumn>(), InnerCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, FullColumn>(), LastCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), -1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-    }
-
-    {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        dpScoreMatrixNavigator._activeColIterator += 2;
-        dpScoreMatrixNavigator._prevColIterator += 2;
-        ++dpScoreMatrixNavigator._laneLeap;  // For the test we simulate as if we were in a band.
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnTop>(), FirstCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnTop>(), InnerCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 4);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnTop>(), LastCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 5);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 4);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-    }
-
-    {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        dpScoreMatrixNavigator._activeColIterator += 2;
-        dpScoreMatrixNavigator._prevColIterator += 2;
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnMiddle>(), FirstCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 4);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnMiddle>(), InnerCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 4);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnMiddle>(), LastCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 5);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 4);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-    }
-
-    {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        dpScoreMatrixNavigator._activeColIterator += 2;
-        dpScoreMatrixNavigator._prevColIterator += 2;
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnBottom>(), FirstCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 4);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnBottom>(), InnerCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 4);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnBottom>(), LastCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 5);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 4);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 2);
-    }
-
-    {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        dpScoreMatrixNavigator._activeColIterator += 2;
-        dpScoreMatrixNavigator._prevColIterator += 2;
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, FullColumn>(), FirstCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 4);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, FullColumn>(), InnerCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 4);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, FullColumn>(), LastCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 5);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 4);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-    }
-
-    {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        dpScoreMatrixNavigator._activeColIterator += 2;
-        dpScoreMatrixNavigator._prevColIterator += 2;
-        ++dpScoreMatrixNavigator._laneLeap;
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnTop>(), FirstCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 4);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnTop>(), InnerCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 4);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnTop>(), LastCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 5);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 4);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-    }
-
-    {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        dpScoreMatrixNavigator._activeColIterator += 2;
-        dpScoreMatrixNavigator._prevColIterator += 2;
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnMiddle>(), FirstCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 4);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnMiddle>(), InnerCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 4);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnMiddle>(), LastCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 5);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 4);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-    }
-
-    {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        dpScoreMatrixNavigator._activeColIterator += 2;
-        dpScoreMatrixNavigator._prevColIterator += 2;
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnBottom>(), FirstCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 4);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnBottom>(), InnerCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 4);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnBottom>(), LastCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 5);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 4);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 2);
-    }
-
-    {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        dpScoreMatrixNavigator._activeColIterator += 2;
-        dpScoreMatrixNavigator._prevColIterator += 2;
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, FullColumn>(), FirstCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 4);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, FullColumn>(), InnerCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 4);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, FullColumn>(), LastCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 5);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 4);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, 1);
-    }
+    _goNextCell(navi, MetaColumnDescriptor<DPFinalColumn, FullColumn>{}, LastCell{});
+    SEQAN_ASSERT_EQ(_scoreOfCell(value(navi)), 15);
+    SEQAN_ASSERT_EQ(_scoreOfCell(previousCellDiagonal(navi)), 10);
+    SEQAN_ASSERT_EQ(_scoreOfCell(previousCellHorizontal(navi)), 11);
+    SEQAN_ASSERT_EQ(_scoreOfCell(previousCellVertical(navi)), 14);
 }
 
-void testAlignmentDPMatrixNavigatorScoreMarixSparseGoNext()
+void testAlignmentDPMatrixNavigatorScoreMarixSparseGoNextCell()
 {
     using namespace seqan;
 
-    typedef DPMatrix_<int, SparseDPMatrix> TDPMatrix;
+    typedef DPMatrix_<DPCell_<int, LinearGaps>, SparseDPMatrix> TDPMatrix;
     typedef Value<TDPMatrix>::Type TDPCell;
 
-    DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise> dpScoreMatrixNavigator;
-
     TDPMatrix dpMatrix;
-    setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 3);
-    setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 3);
-    resize(dpMatrix, 3);
+    setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 4);
+    setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 4);
+    resize(dpMatrix, TDPCell{});
 
-    host(dpMatrix)[1] = 1;
-    host(dpMatrix)[2] = 2;
-
+    int score = 0;
+    auto generator = [&score]()
     {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        assignValue(dpScoreMatrixNavigator._activeColIterator, 0);
+        TDPCell cell;
+        cell = score++;
+        return cell;
+    };
 
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, TDPCell());
+    std::generate(begin(host(dpMatrix), Standard()), end(host(dpMatrix), Standard()), generator);
 
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), FirstCell());
+    DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise>
+        navi{dpMatrix, DPBandConfig<BandOff>()};
 
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, TDPCell());
+    TDPCell prevDiag{};
+    TDPCell prevVert{};
+    TDPCell prevHori{};
+    setCachedCells(navi, prevDiag, prevHori, prevVert);
 
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), InnerCell());
+    // Initialize with 0.
+    _setScoreOfCell(value(navi), 0);
+    // Move along initial column.
+    _goNextCell(navi, MetaColumnDescriptor<DPInitialColumn, FullColumn>{}, FirstCell{});
+    SEQAN_ASSERT_EQ(_scoreOfCell(value(navi)), 0);
+    for (int v_pos = 1; v_pos < 3; ++v_pos)
+    {
+        _goNextCell(navi, MetaColumnDescriptor<DPInitialColumn, FullColumn>{}, InnerCell{});
+        SEQAN_ASSERT_EQ(_scoreOfCell(value(navi)), v_pos);
+        SEQAN_ASSERT_EQ(_scoreOfCell(previousCellVertical(navi)), v_pos - 1);
+    }
+    _goNextCell(navi, MetaColumnDescriptor<DPInitialColumn, FullColumn>{}, LastCell{});
+    SEQAN_ASSERT_EQ(_scoreOfCell(value(navi)), 3);
+    SEQAN_ASSERT_EQ(_scoreOfCell(previousCellVertical(navi)), 2);
 
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 0);     // Was never set to 0.
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), LastCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
+    // Move along inner columns.
+    for (int h_pos = 1; h_pos < 3; ++h_pos)
+    {
+        _goNextCell(navi, MetaColumnDescriptor<DPInnerColumn, FullColumn>{}, FirstCell{});
+        SEQAN_ASSERT_EQ(_scoreOfCell(value(navi)), 0);
+        SEQAN_ASSERT_EQ(_scoreOfCell(previousCellHorizontal(navi)), 0);
+        for (int v_pos = 1; v_pos < 3; ++v_pos)
+        {
+            _goNextCell(navi, MetaColumnDescriptor<DPInnerColumn, FullColumn>{}, InnerCell{});
+            SEQAN_ASSERT_EQ(_scoreOfCell(value(navi)), v_pos);
+            SEQAN_ASSERT_EQ(_scoreOfCell(previousCellDiagonal(navi)), v_pos - 1);
+            SEQAN_ASSERT_EQ(_scoreOfCell(previousCellHorizontal(navi)), v_pos);
+            SEQAN_ASSERT_EQ(_scoreOfCell(previousCellVertical(navi)), v_pos - 1);
+        }
+        _goNextCell(navi, MetaColumnDescriptor<DPInnerColumn, FullColumn>{}, LastCell{});
+        SEQAN_ASSERT_EQ(_scoreOfCell(value(navi)), 3);
+        SEQAN_ASSERT_EQ(_scoreOfCell(previousCellDiagonal(navi)), 2);
+        SEQAN_ASSERT_EQ(_scoreOfCell(previousCellHorizontal(navi)), 3);
+        SEQAN_ASSERT_EQ(_scoreOfCell(previousCellVertical(navi)), 2);
     }
 
+    // Move along last column.
+    _goNextCell(navi, MetaColumnDescriptor<DPFinalColumn, FullColumn>{}, FirstCell{});
+    SEQAN_ASSERT_EQ(_scoreOfCell(value(navi)), 0);
+    SEQAN_ASSERT_EQ(_scoreOfCell(previousCellHorizontal(navi)), 0);
+    for (int v_pos = 1; v_pos < 3; ++v_pos)
     {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        assignValue(dpScoreMatrixNavigator._activeColIterator, 0);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnMiddle>(), FirstCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnMiddle>(), InnerCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 0);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnMiddle>(), LastCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
+        _goNextCell(navi, MetaColumnDescriptor<DPFinalColumn, FullColumn>{}, InnerCell{});
+        SEQAN_ASSERT_EQ(_scoreOfCell(value(navi)), v_pos);
+        SEQAN_ASSERT_EQ(_scoreOfCell(previousCellDiagonal(navi)), v_pos - 1);
+        SEQAN_ASSERT_EQ(_scoreOfCell(previousCellHorizontal(navi)), v_pos);
+        SEQAN_ASSERT_EQ(_scoreOfCell(previousCellVertical(navi)), v_pos - 1);
     }
-
-    {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        assignValue(dpScoreMatrixNavigator._activeColIterator, 0);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom>(), FirstCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom>(), InnerCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 0);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom>(), LastCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-    }
-
-    {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        assignValue(dpScoreMatrixNavigator._activeColIterator, 0);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, FullColumn>(), FirstCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, FullColumn>(), InnerCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 0);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, FullColumn>(), LastCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-    }
-
-    {
-
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        assignValue(dpScoreMatrixNavigator._activeColIterator, 0);
-
-        // Need to update iterator just for the test.
-        dpScoreMatrixNavigator._activeColIterator += 3;
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnTop>(), FirstCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnTop>(), InnerCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 0);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnTop>(), LastCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-    }
-
-    {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        assignValue(dpScoreMatrixNavigator._activeColIterator, 0);
-
-        // Need to update Iterator just for the test.
-        dpScoreMatrixNavigator._activeColIterator += 2;
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnMiddle>(), FirstCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnMiddle>(), InnerCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 0);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnMiddle>(), LastCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-    }
-
-    {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        assignValue(dpScoreMatrixNavigator._activeColIterator, 0);
-
-        // Need to update Iterator just for the test.
-        dpScoreMatrixNavigator._activeColIterator += 2;
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnBottom>(), FirstCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnBottom>(), InnerCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 0);
-
-        // Need to set iterator to correct position just for the test.
-        --dpScoreMatrixNavigator._prevColIterator;
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnBottom>(), LastCell());
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-    }
-
-    {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        assignValue(dpScoreMatrixNavigator._activeColIterator, 0);
-
-        dpScoreMatrixNavigator._activeColIterator += 2;
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, FullColumn>(), FirstCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, FullColumn>(), InnerCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 0);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, FullColumn>(), LastCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-    }
-
-    {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        assignValue(dpScoreMatrixNavigator._activeColIterator, 0);
-
-        dpScoreMatrixNavigator._activeColIterator += 3;
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnTop>(), FirstCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnTop>(), InnerCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 0);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnTop>(), LastCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -3);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-    }
-
-    {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        assignValue(dpScoreMatrixNavigator._activeColIterator, 0);
-
-        dpScoreMatrixNavigator._activeColIterator += 2;
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnMiddle>(), FirstCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnMiddle>(), InnerCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 0);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnMiddle>(), LastCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-
-    }
-
-    {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        assignValue(dpScoreMatrixNavigator._activeColIterator, 0);
-
-        dpScoreMatrixNavigator._activeColIterator += 2;
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnBottom>(), FirstCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnBottom>(), InnerCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 0);
-
-        --dpScoreMatrixNavigator._prevColIterator;
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnBottom>(), LastCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-    }
-
-    {
-        _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        assignValue(dpScoreMatrixNavigator._activeColIterator, 0);
-
-        dpScoreMatrixNavigator._activeColIterator += 2;
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, FullColumn>(), FirstCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, FullColumn>(), InnerCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 0);
-
-        _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, FullColumn>(), LastCell());
-
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._ptrDataContainer, &dpMatrix);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._laneLeap, -2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, 1);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, 2);
-        SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, 1);
-    }
+    _goNextCell(navi, MetaColumnDescriptor<DPFinalColumn, FullColumn>{}, LastCell{});
+    SEQAN_ASSERT_EQ(_scoreOfCell(value(navi)), 3);
+    SEQAN_ASSERT_EQ(_scoreOfCell(previousCellDiagonal(navi)), 2);
+    SEQAN_ASSERT_EQ(_scoreOfCell(previousCellHorizontal(navi)), 3);
+    SEQAN_ASSERT_EQ(_scoreOfCell(previousCellVertical(navi)), 2);
 }
 
 template <typename TDPMatrixSpec>
@@ -1160,19 +412,21 @@ void testAlignmentDPScoreMatrixNavigatorAssignValue(TDPMatrixSpec const)
 {
     using namespace seqan;
 
-    typedef DPMatrix_<int, TDPMatrixSpec> TDPMatrix;
-
-    DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise> dpScoreMatrixNavigator;
+    typedef DPMatrix_<DPCell_<int, LinearGaps>, TDPMatrixSpec> TDPMatrix;
+    typedef typename Value<TDPMatrix>::Type TDPCell;
 
     TDPMatrix dpMatrix;
     setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 10);
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
-    resize(dpMatrix, 3);
+    resize(dpMatrix, TDPCell{});
 
-    _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
+    DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise>
+        dpScoreMatrixNavigator{dpMatrix, DPBandConfig<BandOff>{}};
+    TDPCell tmp;
+    tmp = 20;
 
-    assignValue(dpScoreMatrixNavigator, 20);
-    SEQAN_ASSERT_EQ(value(dpScoreMatrixNavigator._activeColIterator), 20);
+    assignValue(dpScoreMatrixNavigator, tmp);
+    SEQAN_ASSERT_EQ(_scoreOfCell(value(dpScoreMatrixNavigator._activeColIterator)), 20);
 }
 
 template <typename TDPMatrixSpec>
@@ -1180,22 +434,26 @@ void testAlignmentDPScoreMatrixNavigatorValue(TDPMatrixSpec const)
 {
     using namespace seqan;
 
-    typedef DPMatrix_<int, TDPMatrixSpec> TDPMatrix;
-
-    DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise> dpScoreMatrixNavigator;
+    typedef DPMatrix_<DPCell_<int, LinearGaps>, TDPMatrixSpec> TDPMatrix;
+    typedef typename Value<TDPMatrix>::Type TDPCell;
 
     TDPMatrix dpMatrix;
     setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 10);
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
-    resize(dpMatrix, 3);
+    resize(dpMatrix, TDPCell{});
 
-    _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
+    DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise>
+        dpScoreMatrixNavigator{dpMatrix, DPBandConfig<BandOff>{}};
 
-    assignValue(dpScoreMatrixNavigator, 20);
-    SEQAN_ASSERT_EQ(value(dpScoreMatrixNavigator), 20);
+    TDPCell tmp;
+    tmp = 20;
 
-    const DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise> dpScoreMatrixNavigatorConst(dpScoreMatrixNavigator);
-    SEQAN_ASSERT_EQ(value(dpScoreMatrixNavigatorConst), 20);
+    assignValue(dpScoreMatrixNavigator, tmp);
+    SEQAN_ASSERT_EQ(_scoreOfCell(value(dpScoreMatrixNavigator)), 20);
+
+    const DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise>
+        dpScoreMatrixNavigatorConst(dpScoreMatrixNavigator);
+    SEQAN_ASSERT_EQ(_scoreOfCell(value(dpScoreMatrixNavigatorConst)), 20);
 }
 
 template <typename TDPMatrixSpec>
@@ -1203,24 +461,31 @@ void testAlignmentDPScoreMatrixNavigatorPreviousCellDiagonal(TDPMatrixSpec const
 {
     using namespace seqan;
 
-    typedef DPMatrix_<int, TDPMatrixSpec> TDPMatrix;
+    typedef DPMatrix_<DPCell_<int, LinearGaps>, TDPMatrixSpec> TDPMatrix;
     typedef typename Value<TDPMatrix>::Type TDPCell;
-
-    DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise> dpScoreMatrixNavigator;
 
     TDPMatrix dpMatrix;
     setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 10);
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
-    resize(dpMatrix, 3);
+    resize(dpMatrix, TDPCell{});
 
-    _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-    SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellDiagonal, TDPCell());
+    DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise>
+        dpScoreMatrixNavigator{dpMatrix, DPBandConfig<BandOff>{}};
 
-    dpScoreMatrixNavigator._prevCellDiagonal = 20;
-    SEQAN_ASSERT_EQ(previousCellDiagonal(dpScoreMatrixNavigator), 20);
+    TDPCell prevDiag{};
+    TDPCell prevHori{};
+    TDPCell prevVert{};
 
-    const DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise> dpScoreMatrixNavigatorConst(dpScoreMatrixNavigator);
-    SEQAN_ASSERT_EQ(previousCellDiagonal(dpScoreMatrixNavigatorConst), 20);
+    setCachedCells(dpScoreMatrixNavigator, prevDiag, prevHori, prevVert);
+
+    SEQAN_ASSERT_EQ(*dpScoreMatrixNavigator._prevCellDiagonal, TDPCell{});
+
+    *dpScoreMatrixNavigator._prevCellDiagonal = 20;
+    SEQAN_ASSERT_EQ(_scoreOfCell(previousCellDiagonal(dpScoreMatrixNavigator)), 20);
+
+    const DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise>
+        dpScoreMatrixNavigatorConst(dpScoreMatrixNavigator);
+    SEQAN_ASSERT_EQ(_scoreOfCell(previousCellDiagonal(dpScoreMatrixNavigatorConst)), 20);
 }
 
 template <typename TDPMatrixSpec>
@@ -1228,24 +493,33 @@ void testAlignmentDPScoreMatrixNavigatorPreviousCellHorizontal(TDPMatrixSpec con
 {
     using namespace seqan;
 
-    typedef DPMatrix_<int, TDPMatrixSpec> TDPMatrix;
+    typedef DPMatrix_<DPCell_<int, LinearGaps>, TDPMatrixSpec> TDPMatrix;
     typedef typename Value<TDPMatrix>::Type TDPCell;
-
-    DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise> dpScoreMatrixNavigator;
 
     TDPMatrix dpMatrix;
     setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 10);
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
-    resize(dpMatrix, 3);
+    resize(dpMatrix, TDPCell{});
 
-    _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-    SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellHorizontal, TDPCell());
+    DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise>
+        dpScoreMatrixNavigator{dpMatrix, DPBandConfig<BandOff>{}};
 
-    dpScoreMatrixNavigator._prevCellHorizontal = 20;
-    SEQAN_ASSERT_EQ(previousCellHorizontal(dpScoreMatrixNavigator), 20);
+    TDPCell prevDiag{};
+    TDPCell prevHori{};
+    TDPCell prevVert{};
 
-    const DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise> dpScoreMatrixNavigatorConst(dpScoreMatrixNavigator);
-    SEQAN_ASSERT_EQ(previousCellHorizontal(dpScoreMatrixNavigatorConst), 20);
+    setCachedCells(dpScoreMatrixNavigator, prevDiag, prevHori, prevVert);
+
+    SEQAN_ASSERT_EQ(*dpScoreMatrixNavigator._prevCellHorizontal, TDPCell{});
+
+    // A hacky way to test the previous cell function.
+    dpScoreMatrixNavigator._prevColIterator = dpScoreMatrixNavigator._activeColIterator;
+    *dpScoreMatrixNavigator._activeColIterator = 20;
+    SEQAN_ASSERT_EQ(_scoreOfCell(previousCellHorizontal(dpScoreMatrixNavigator)), 20);
+
+    const DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise>
+        dpScoreMatrixNavigatorConst(dpScoreMatrixNavigator);
+    SEQAN_ASSERT_EQ(_scoreOfCell(previousCellHorizontal(dpScoreMatrixNavigatorConst)), 20);
 }
 
 template <typename TDPMatrixSpec>
@@ -1253,24 +527,31 @@ void testAlignmentDPScoreMatrixNavigatorPreviousCellVertical(TDPMatrixSpec const
 {
     using namespace seqan;
 
-    typedef DPMatrix_<int, TDPMatrixSpec> TDPMatrix;
+    typedef DPMatrix_<DPCell_<int, LinearGaps>, TDPMatrixSpec> TDPMatrix;
     typedef typename Value<TDPMatrix>::Type TDPCell;
-
-    DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise> dpScoreMatrixNavigator;
 
     TDPMatrix dpMatrix;
     setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 10);
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
-    resize(dpMatrix, 3);
+    resize(dpMatrix, TDPCell{});
 
-    _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-    SEQAN_ASSERT_EQ(dpScoreMatrixNavigator._prevCellVertical, TDPCell());
+    DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise>
+        dpScoreMatrixNavigator{dpMatrix, DPBandConfig<BandOff>{}};
 
-    dpScoreMatrixNavigator._prevCellVertical = 20;
-    SEQAN_ASSERT_EQ(previousCellVertical(dpScoreMatrixNavigator), 20);
+    TDPCell prevDiag{};
+    TDPCell prevHori{};
+    TDPCell prevVert{};
 
-    const DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise> dpScoreMatrixNavigatorConst(dpScoreMatrixNavigator);
-    SEQAN_ASSERT_EQ(previousCellVertical(dpScoreMatrixNavigatorConst), 20);
+    setCachedCells(dpScoreMatrixNavigator, prevDiag, prevHori, prevVert);
+
+    SEQAN_ASSERT_EQ(*dpScoreMatrixNavigator._prevCellVertical, TDPCell{});
+
+    prevVert = 20;
+    SEQAN_ASSERT_EQ(_scoreOfCell(previousCellVertical(dpScoreMatrixNavigator)), 20);
+
+    const DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise>
+        dpScoreMatrixNavigatorConst(dpScoreMatrixNavigator);
+    SEQAN_ASSERT_EQ(_scoreOfCell(previousCellVertical(dpScoreMatrixNavigatorConst)), 20);
 }
 
 template <typename TDPMatrixSpec>
@@ -1278,16 +559,16 @@ void testAlignmentDPScoreMatrixNavigatorCoordinate(TDPMatrixSpec const)
 {
     using namespace seqan;
 
-    typedef DPMatrix_<int, TDPMatrixSpec> TDPMatrix;
-
-    DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise> dpScoreMatrixNavigator;
+    typedef DPMatrix_<DPCell_<int, LinearGaps>, TDPMatrixSpec> TDPMatrix;
+    typedef typename Value<TDPMatrix>::Type TDPCell;
 
     TDPMatrix dpMatrix;
     setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 10);
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
-    resize(dpMatrix, 3);
+    resize(dpMatrix, TDPCell{});
 
-    _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
+    DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise>
+        dpScoreMatrixNavigator{dpMatrix, DPBandConfig<BandOff>{}};
 
     dpScoreMatrixNavigator._activeColIterator += 7;
     dpScoreMatrixNavigator._prevColIterator += 7;
@@ -1301,35 +582,27 @@ void testAlignmentDPScoreMatrixNavigatorContainer(TDPMatrixSpec const)
 {
     using namespace seqan;
 
-    typedef DPMatrix_<int, TDPMatrixSpec> TDPMatrix;
-
-    DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise> dpScoreMatrixNavigator;
+    typedef DPMatrix_<DPCell_<int, LinearGaps>, TDPMatrixSpec> TDPMatrix;
+    typedef typename Value<TDPMatrix>::Type TDPCell;
 
     TDPMatrix dpMatrix;
     setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 10);
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
-    resize(dpMatrix, 3);
+    resize(dpMatrix, TDPCell{});
 
-    _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
+    DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise>
+        dpScoreMatrixNavigator{dpMatrix, DPBandConfig<BandOff>{}};
 
     SEQAN_ASSERT_EQ(&container(dpScoreMatrixNavigator), &dpMatrix);
 
-    const DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise> dpScoreMatrixNavigatorConst(dpScoreMatrixNavigator);
+    const DPMatrixNavigator_<TDPMatrix, DPScoreMatrix, NavigateColumnWise>
+        dpScoreMatrixNavigatorConst(dpScoreMatrixNavigator);
     SEQAN_ASSERT_EQ(&container(dpScoreMatrixNavigatorConst), &dpMatrix);
 }
 
 
 // ----------------------------------------------------------------------------
 // Test constructor                                  [DPScoreMatrix, FullDPMatrix]
-// ----------------------------------------------------------------------------
-
-SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_score_matrix_full_constructor)
-{
-    testAlignmentDPMatrixScoreNavigatorConstructorDefault(seqan::FullDPMatrix());
-}
-
-// ----------------------------------------------------------------------------
-// Test functions                                  [DPScoreMatrix, FullDPMatrix]
 // ----------------------------------------------------------------------------
 
 SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_score_matrix_full_init_unbanded)
@@ -1342,15 +615,9 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_score_matrix_full_init_band
     testAlignmentDPMatrixNavigatorScoreMarixInitBanded();
 }
 
-SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_score_matrix_full_go_next_cell)
-{
-    testAlignmentDPMatrixNavigatorScoreMarixGoNextCell();
-}
-
-SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_score_matrix_full_assign_value)
-{
-    testAlignmentDPScoreMatrixNavigatorAssignValue(seqan::FullDPMatrix());
-}
+// ----------------------------------------------------------------------------
+// Test functions                                  [DPScoreMatrix, FullDPMatrix]
+// ----------------------------------------------------------------------------
 
 SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_score_matrix_full_value)
 {
@@ -1372,6 +639,16 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_score_matrix_full_previous_
     testAlignmentDPScoreMatrixNavigatorPreviousCellVertical(seqan::FullDPMatrix());
 }
 
+SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_score_matrix_full_go_next_cell)
+{
+    testAlignmentDPMatrixNavigatorScoreMarixGoNextCell();
+}
+
+SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_score_matrix_full_assign_value)
+{
+    testAlignmentDPScoreMatrixNavigatorAssignValue(seqan::FullDPMatrix());
+}
+
 SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_score_matrix_full_coordinate)
 {
     testAlignmentDPScoreMatrixNavigatorCoordinate(seqan::FullDPMatrix());
@@ -1386,15 +663,6 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_score_matrix_full_container
 // Test constructor                                [DPScoreMatrix, SparseDPMatrix]
 // ----------------------------------------------------------------------------
 
-SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_score_matrix_sparse_constructor)
-{
-    testAlignmentDPMatrixScoreNavigatorConstructorDefault(seqan::SparseDPMatrix());
-}
-
-// ----------------------------------------------------------------------------
-// Test functions                                [DPScoreMatrix, SparseDPMatrix]
-// ----------------------------------------------------------------------------
-
 SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_score_matrix_sparse_init_unbanded)
 {
     testAlignmentDPMatrixNavigatorScoreMarixSparseInitUnbanded();
@@ -1405,15 +673,9 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_score_matrix_sparse_init_ba
     testAlignmentDPMatrixNavigatorScoreMarixSparseInitBanded();
 }
 
-SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_score_matrix_sparse_go_next)
-{
-    testAlignmentDPMatrixNavigatorScoreMarixSparseGoNext();
-}
-
-SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_score_matrix_sparse_assign_value)
-{
-    testAlignmentDPScoreMatrixNavigatorAssignValue(seqan::SparseDPMatrix());
-}
+// ----------------------------------------------------------------------------
+// Test functions                                [DPScoreMatrix, SparseDPMatrix]
+// ----------------------------------------------------------------------------
 
 SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_score_matrix_sparse_value)
 {
@@ -1435,6 +697,16 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_score_matrix_sparse_previou
     testAlignmentDPScoreMatrixNavigatorPreviousCellVertical(seqan::SparseDPMatrix());
 }
 
+SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_score_matrix_sparse_go_next)
+{
+    testAlignmentDPMatrixNavigatorScoreMarixSparseGoNextCell();
+}
+
+SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_score_matrix_sparse_assign_value)
+{
+    testAlignmentDPScoreMatrixNavigatorAssignValue(seqan::SparseDPMatrix());
+}
+
 SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_score_matrix_sparse_coordinate)
 {
     testAlignmentDPScoreMatrixNavigatorCoordinate(seqan::SparseDPMatrix());
@@ -1443,16 +715,6 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_score_matrix_sparse_coordin
 SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_score_matrix_sparse_container)
 {
     testAlignmentDPScoreMatrixNavigatorContainer(seqan::SparseDPMatrix());
-}
-
-// ----------------------------------------------------------------------------
-// Test constructor                                  [DPTraceMatrix, FullDPMatrix]
-// ----------------------------------------------------------------------------
-
-SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_constructor)
-{
-    testAlignmentDPMatrixTraceNavigatorConstructorDefault(seqan::TracebackOn<seqan::GapsLeft>());
-    testAlignmentDPMatrixTraceNavigatorConstructorDefault(seqan::TracebackOff());
 }
 
 // ----------------------------------------------------------------------------
@@ -1465,14 +727,13 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_init_u
 
     typedef DPMatrix_<int, FullDPMatrix> TDPMatrix;
 
-    DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TracebackOn<> >, NavigateColumnWise> dpTraceMatrixNavigator;
-
     TDPMatrix dpMatrix;
     setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 10);
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
     resize(dpMatrix);
 
-    _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
+    DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TracebackOn<> >, NavigateColumnWise>
+        dpTraceMatrixNavigator{dpMatrix, DPBandConfig<BandOff>{}};
 
     SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._ptrDataContainer, &dpMatrix);
     SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
@@ -1485,14 +746,13 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_disabled_init_
 
     typedef DPMatrix_<int, FullDPMatrix> TDPMatrix;
 
-    DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TracebackOff>, NavigateColumnWise> dpTraceMatrixNavigator;
-
     TDPMatrix dpMatrix;
     setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 10);
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
     resize(dpMatrix);
 
-    _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
+    DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TracebackOff>, NavigateColumnWise>
+        dpTraceMatrixNavigator{dpMatrix, DPBandConfig<BandOff>{}};
 
     SEQAN_ASSERT_NEQ(dpTraceMatrixNavigator._ptrDataContainer, &dpMatrix);
     SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 0);
@@ -1504,15 +764,14 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_init_b
 
     typedef DPMatrix_<int, FullDPMatrix> TDPMatrix;
 
-    DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TracebackOn<> >, NavigateColumnWise> dpTraceMatrixNavigator;
-
     { // Case1: Band intersects with poit of origin.
         TDPMatrix dpMatrix;
         setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 10);
         setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 8);
         resize(dpMatrix);
 
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOn>(-4, 3));
+        DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TracebackOn<> >, NavigateColumnWiseBanded>
+            dpTraceMatrixNavigator{dpMatrix, DPBandConfig<BandOn>{-4, 3}};
 
         SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._ptrDataContainer, &dpMatrix);
         SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 3);
@@ -1526,7 +785,8 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_init_b
         resize(dpMatrix2);
 
         value(host(dpMatrix2), 0) = 10;
-        _init(dpTraceMatrixNavigator, dpMatrix2, DPBandConfig<BandOn>(0, 7));
+        DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TracebackOn<> >, NavigateColumnWiseBanded>
+            dpTraceMatrixNavigator{dpMatrix2, DPBandConfig<BandOn>{0, 7}};
 
         SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._ptrDataContainer, &dpMatrix2);
         SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix2, Standard()), 7);
@@ -1540,7 +800,8 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_init_b
         resize(dpMatrix3);
 
 
-        _init(dpTraceMatrixNavigator, dpMatrix3, DPBandConfig<BandOn>(-7, 0));
+        DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TracebackOn<> >, NavigateColumnWiseBanded>
+            dpTraceMatrixNavigator{dpMatrix3, DPBandConfig<BandOn>{-7, 0}};
 
         SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._ptrDataContainer, &dpMatrix3);
         SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix3, Standard()), 0);
@@ -1554,15 +815,14 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_disabled_init_
 
     typedef DPMatrix_<int, FullDPMatrix> TDPMatrix;
 
-    DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TracebackOff>, NavigateColumnWise> dpTraceMatrixNavigator;
-
     { // Case1: Band intersects with poit of origin.
         TDPMatrix dpMatrix;
         setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 10);
         setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 8);
         resize(dpMatrix);
 
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOn>(-4, 3));
+        DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TracebackOff>, NavigateColumnWiseBanded>
+            dpTraceMatrixNavigator{dpMatrix, DPBandConfig<BandOn>{-4, 3}};
 
         SEQAN_ASSERT_NEQ(dpTraceMatrixNavigator._ptrDataContainer, &dpMatrix);
         SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 0);
@@ -1575,7 +835,8 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_disabled_init_
         resize(dpMatrix2);
 
         value(host(dpMatrix2), 0) = 10;
-        _init(dpTraceMatrixNavigator, dpMatrix2, DPBandConfig<BandOn>(0, 7));
+        DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TracebackOff>, NavigateColumnWiseBanded>
+            dpTraceMatrixNavigator{dpMatrix2, DPBandConfig<BandOn>{0, 7}};
 
         SEQAN_ASSERT_NEQ(dpTraceMatrixNavigator._ptrDataContainer, &dpMatrix2);
         SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 0);
@@ -1588,7 +849,8 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_disabled_init_
         resize(dpMatrix3);
 
 
-        _init(dpTraceMatrixNavigator, dpMatrix3, DPBandConfig<BandOn>(-7, 0));
+        DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TracebackOff>, NavigateColumnWiseBanded>
+            dpTraceMatrixNavigator{dpMatrix3, DPBandConfig<BandOn>{-7, 0}};
 
         SEQAN_ASSERT_NEQ(dpTraceMatrixNavigator._ptrDataContainer, &dpMatrix3);
         SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 0);
@@ -1601,345 +863,51 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_go_nex
 
     typedef DPMatrix_<int, FullDPMatrix> TDPMatrix;
 
-    DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TracebackOn<> >, NavigateColumnWise> dpTraceMatrixNavigator;
-
     TDPMatrix dpMatrix;
-    setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 10);
-    setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 3);
-    resize(dpMatrix, 0);
-    host(dpMatrix)[0] = 0;
-    host(dpMatrix)[1] = 1;
-    host(dpMatrix)[2] = 2;
-    host(dpMatrix)[3] = 3;
-    host(dpMatrix)[4] = 4;
-    host(dpMatrix)[5] = 5;
+    setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 4);
+    setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 4);
+    resize(dpMatrix);
 
+    std::iota(begin(host(dpMatrix), Standard()), end(host(dpMatrix), Standard()), 0);
+
+    DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TracebackOn<> >, NavigateColumnWise>
+        navi{dpMatrix, DPBandConfig<BandOff>()};
+
+    // Move along initial column.
+    _goNextCell(navi, MetaColumnDescriptor<DPInitialColumn, FullColumn>{}, FirstCell{});
+    SEQAN_ASSERT_EQ(value(navi), 0);
+    for (int v_pos = 1; v_pos < 3; ++v_pos)
     {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
+        _goNextCell(navi, MetaColumnDescriptor<DPInitialColumn, FullColumn>{}, InnerCell{});
+        SEQAN_ASSERT_EQ(value(navi), v_pos);
+    }
+    _goNextCell(navi, MetaColumnDescriptor<DPInitialColumn, FullColumn>{}, LastCell{});
+    SEQAN_ASSERT_EQ(value(navi), 3);
 
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), FirstCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), InnerCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), LastCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-
+    // Move along inner columns.
+    for (int h_pos = 1; h_pos < 3; ++h_pos)
+    {
+        _goNextCell(navi, MetaColumnDescriptor<DPInnerColumn, FullColumn>{}, FirstCell{});
+        SEQAN_ASSERT_EQ(value(navi), h_pos * 4);
+        for (int v_pos = 1; v_pos < 3; ++v_pos)
+        {
+            _goNextCell(navi, MetaColumnDescriptor<DPInnerColumn, FullColumn>{}, InnerCell{});
+            SEQAN_ASSERT_EQ(value(navi), h_pos * 4 + v_pos);
+        }
+        _goNextCell(navi, MetaColumnDescriptor<DPInnerColumn, FullColumn>{}, LastCell{});
+        SEQAN_ASSERT_EQ(value(navi), h_pos * 4 + 3);
     }
 
+    // Move along last column.
+    _goNextCell(navi, MetaColumnDescriptor<DPFinalColumn, FullColumn>{}, FirstCell{});
+    SEQAN_ASSERT_EQ(value(navi), 12);
+    for (int v_pos = 1; v_pos < 3; ++v_pos)
     {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnMiddle>(), FirstCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnMiddle>(), InnerCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnMiddle>(), LastCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
+        _goNextCell(navi, MetaColumnDescriptor<DPFinalColumn, FullColumn>{}, InnerCell{});
+        SEQAN_ASSERT_EQ(value(navi), 12 + v_pos);
     }
-
-    {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom>(), FirstCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom>(), InnerCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom>(), LastCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-    }
-
-    {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, FullColumn>(), FirstCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 0);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, FullColumn>(), InnerCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 1);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, FullColumn>(), LastCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 2);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-    }
-
-    {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        dpTraceMatrixNavigator._activeColIterator += 2;
-        ++dpTraceMatrixNavigator._laneLeap;  // For the test we simulate as if we were in a band.
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnTop>(), FirstCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 3);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnTop>(), InnerCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 4);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnTop>(), LastCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 5);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-    }
-
-    {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        dpTraceMatrixNavigator._activeColIterator += 2;
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnMiddle>(), FirstCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 3);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnMiddle>(), InnerCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 4);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnMiddle>(), LastCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 5);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-    }
-
-    {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        dpTraceMatrixNavigator._activeColIterator += 2;
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnBottom>(), FirstCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 3);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnBottom>(), InnerCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 4);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnBottom>(), LastCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 5);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 2);
-    }
-
-    {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        dpTraceMatrixNavigator._activeColIterator += 2;
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, FullColumn>(), FirstCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 3);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, FullColumn>(), InnerCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 4);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, FullColumn>(), LastCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 5);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-    }
-
-    {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        dpTraceMatrixNavigator._activeColIterator += 2;
-        ++dpTraceMatrixNavigator._laneLeap;
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnTop>(), FirstCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 3);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnTop>(), InnerCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 4);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnTop>(), LastCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 5);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-    }
-
-    {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        dpTraceMatrixNavigator._activeColIterator += 2;
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnMiddle>(), FirstCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 3);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnMiddle>(), InnerCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 4);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnMiddle>(), LastCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 5);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-    }
-
-    {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        dpTraceMatrixNavigator._activeColIterator += 2;
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnBottom>(), FirstCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 3);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnBottom>(), InnerCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 4);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnBottom>(), LastCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 5);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 2);
-    }
-
-    {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        dpTraceMatrixNavigator._activeColIterator += 2;
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, FullColumn>(), FirstCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 3);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, FullColumn>(), InnerCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 4);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-
-        _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, FullColumn>(), LastCell());
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._activeColIterator - begin(dpMatrix, Standard()), 5);
-        SEQAN_ASSERT_EQ(dpTraceMatrixNavigator._laneLeap, 1);
-    }
-}
-
-template <typename TNavigator, typename TMetaDescriptor, typename TCell>
-void _testGoNextCell(TNavigator & navi, TMetaDescriptor const &, TCell const &)
-{
-    using namespace seqan;
-
-    _goNextCell(navi, TMetaDescriptor(), TCell());
-    SEQAN_ASSERT_EQ(navi._laneLeap, 0);
-}
-
-SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_disabled_go_next)
-{
-    using namespace seqan;
-
-    typedef DPMatrix_<int, FullDPMatrix> TDPMatrix;
-
-    DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TracebackOff>, NavigateColumnWise> dpTraceMatrixNavigator;
-
-    TDPMatrix dpMatrix;
-    setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 10);
-    setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 3);
-    resize(dpMatrix, 0);
-    host(dpMatrix)[0] = 0;
-    host(dpMatrix)[1] = 1;
-    host(dpMatrix)[2] = 2;
-    host(dpMatrix)[3] = 3;
-    host(dpMatrix)[4] = 4;
-    host(dpMatrix)[5] = 5;
-
-    {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), FirstCell());
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), InnerCell());
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), LastCell());
-    }
-
-    {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnMiddle>(), FirstCell());
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnMiddle>(), InnerCell());
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnMiddle>(), LastCell());
-    }
-
-    {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom>(), FirstCell());
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom>(), InnerCell());
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom>(), LastCell());
-    }
-
-    {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, FullColumn>(), FirstCell());
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, FullColumn>(), InnerCell());
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, FullColumn>(), LastCell());
-    }
-
-    {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        dpTraceMatrixNavigator._activeColIterator += 2;
-
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnTop>(), FirstCell());
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnTop>(), InnerCell());
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnTop>(), LastCell());
-    }
-
-    {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnMiddle>(), FirstCell());
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnMiddle>(), InnerCell());
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnMiddle>(), LastCell());
-    }
-
-    {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnBottom>(), FirstCell());
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnBottom>(), InnerCell());
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, PartialColumnBottom>(), LastCell());
-    }
-
-    {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, FullColumn>(), FirstCell());
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, FullColumn>(), InnerCell());
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, FullColumn>(), LastCell());
-    }
-
-    {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnTop>(), FirstCell());
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnTop>(), InnerCell());
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnTop>(), LastCell());
-    }
-
-    {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnMiddle>(), FirstCell());
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnMiddle>(), InnerCell());
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnMiddle>(), LastCell());
-    }
-
-    {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnBottom>(), FirstCell());
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnBottom>(), InnerCell());
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, PartialColumnBottom>(), LastCell());
-    }
-
-    {
-        _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, FullColumn>(), FirstCell());
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, FullColumn>(), InnerCell());
-        _testGoNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPFinalColumn, FullColumn>(), LastCell());
-    }
+    _goNextCell(navi, MetaColumnDescriptor<DPFinalColumn, FullColumn>{}, LastCell{});
+    SEQAN_ASSERT_EQ(value(navi), 15);
 }
 
 SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_assign_value)
@@ -1948,17 +916,16 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_assign
 
     typedef DPMatrix_<int, FullDPMatrix> TDPMatrix;
 
-    DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TracebackOn<> >, NavigateColumnWise> dpScoreMatrixNavigator;
-
     TDPMatrix dpMatrix;
     setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 10);
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
     resize(dpMatrix, 3);
 
-    _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
+    DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TracebackOn<> >, NavigateColumnWise>
+        dpTraceMatrixNavigator{dpMatrix, DPBandConfig<BandOff>{}};
 
-    assignValue(dpScoreMatrixNavigator, 20);
-    SEQAN_ASSERT_EQ(value(dpScoreMatrixNavigator._activeColIterator), 20);
+    assignValue(dpTraceMatrixNavigator, 20);
+    SEQAN_ASSERT_EQ(value(dpTraceMatrixNavigator._activeColIterator), 20);
 }
 
 
@@ -1968,19 +935,18 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_value)
 
     typedef DPMatrix_<int, FullDPMatrix> TDPMatrix;
 
-    DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TracebackOn<> >, NavigateColumnWise> dpTraceMatrixNavigator;
-
     TDPMatrix dpMatrix;
     setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 10);
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
     resize(dpMatrix, 3);
 
-    _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
+    DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TracebackOn<> >, NavigateColumnWise>
+        dpTraceMatrixNavigator{dpMatrix, DPBandConfig<BandOff>{}};
 
     assignValue(dpTraceMatrixNavigator, 20);
     SEQAN_ASSERT_EQ(value(dpTraceMatrixNavigator), 20);
-
-    const DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TracebackOn<> >, NavigateColumnWise> dpTraceMatrixNavigatorConst(dpTraceMatrixNavigator);
+    DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TracebackOn<> >, NavigateColumnWise> const
+        dpTraceMatrixNavigatorConst(dpTraceMatrixNavigator);
     SEQAN_ASSERT_EQ(value(dpTraceMatrixNavigatorConst), 20);
 }
 
@@ -1991,19 +957,18 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_coordi
 
     typedef DPMatrix_<int, FullDPMatrix> TDPMatrix;
 
-    DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TracebackOn<> >, NavigateColumnWise> dpScoreMatrixNavigator;
-
     TDPMatrix dpMatrix;
     setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 10);
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
     resize(dpMatrix, 3);
 
-    _init(dpScoreMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
+    DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TracebackOn<> >, NavigateColumnWise>
+        dpTraceMatrixNavigator{dpMatrix, DPBandConfig<BandOff>{}};
 
-    dpScoreMatrixNavigator._activeColIterator += 7;
+    dpTraceMatrixNavigator._activeColIterator += 7;
 
-    SEQAN_ASSERT_EQ(coordinate(dpScoreMatrixNavigator, +DPMatrixDimension_::HORIZONTAL), 0u);
-    SEQAN_ASSERT_EQ(coordinate(dpScoreMatrixNavigator, +DPMatrixDimension_::VERTICAL), 7u);
+    SEQAN_ASSERT_EQ(coordinate(dpTraceMatrixNavigator, +DPMatrixDimension_::HORIZONTAL), 0u);
+    SEQAN_ASSERT_EQ(coordinate(dpTraceMatrixNavigator, +DPMatrixDimension_::VERTICAL), 7u);
 }
 
 SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_container)
@@ -2012,14 +977,13 @@ SEQAN_DEFINE_TEST(test_alignment_dp_matrix_navigator_trace_matrix_enabled_contai
 
     typedef DPMatrix_<int, FullDPMatrix> TDPMatrix;
 
-    DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TracebackOn<> >, NavigateColumnWise> dpTraceMatrixNavigator;
-
     TDPMatrix dpMatrix;
     setLength(dpMatrix, DPMatrixDimension_::HORIZONTAL, 10);
     setLength(dpMatrix, DPMatrixDimension_::VERTICAL, 10);
     resize(dpMatrix, 3);
 
-    _init(dpTraceMatrixNavigator, dpMatrix, DPBandConfig<BandOff>());
+    DPMatrixNavigator_<TDPMatrix, DPTraceMatrix<TracebackOn<> >, NavigateColumnWise>
+        dpTraceMatrixNavigator{dpMatrix, DPBandConfig<BandOff>{}};
 
     SEQAN_ASSERT_EQ(&container(dpTraceMatrixNavigator), &dpMatrix);
 

--- a/tests/align/test_alignment_dp_traceback.h
+++ b/tests/align/test_alignment_dp_traceback.h
@@ -77,8 +77,7 @@ SEQAN_DEFINE_TEST(test_align2_traceback_affine)
     value(traceMatrix, 2, 3) = +TraceBitMap_<>::HORIZONTAL | TraceBitMap_<>::MAX_FROM_HORIZONTAL_MATRIX;
     value(traceMatrix, 3, 3) = +TraceBitMap_<>::DIAGONAL;
 
-    TDPTraceNavigator navigator;
-    _init(navigator, traceMatrix, DPBandConfig<BandOff>());
+    TDPTraceNavigator navigator{traceMatrix, DPBandConfig<BandOff>()};
 
     DnaString str0 = "ACG";
     DnaString str1 = "ACG";
@@ -177,8 +176,7 @@ SEQAN_DEFINE_TEST(test_align2_traceback_linear_unbanded_alignment)
     value(traceMatrix, 2, 3) = +TraceBitMap_<>::NONE;
     value(traceMatrix, 3, 3) = +TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::VERTICAL  | +TraceBitMap_<>::HORIZONTAL;
 
-    TDPTraceNavigator navigator;
-    _init(navigator, traceMatrix, DPBandConfig<BandOff>());
+    TDPTraceNavigator navigator{traceMatrix, DPBandConfig<BandOff>{}};
 
     DnaString str0 = "ACG";
     DnaString str1 = "ACG";
@@ -202,7 +200,7 @@ SEQAN_DEFINE_TEST(test_align2_traceback_linear_normal_banded_alignment)
     typedef typename TraceBitMap_<>::Type TTraceValue;
     typedef DPMatrix_<TTraceValue, FullDPMatrix> TTraceMatrix;
 
-    typedef DPMatrixNavigator_<TTraceMatrix, DPTraceMatrix<TracebackOn<> >, NavigateColumnWise> TDPTraceNavigator;
+    typedef DPMatrixNavigator_<TTraceMatrix, DPTraceMatrix<TracebackOn<> >, NavigateColumnWiseBanded> TDPTraceNavigator;
 
     String<TTraceSegment> target;
     TTraceMatrix traceMatrix;
@@ -233,8 +231,7 @@ SEQAN_DEFINE_TEST(test_align2_traceback_linear_normal_banded_alignment)
     value(traceMatrix, 2, 4) = +TraceBitMap_<>::NONE;
 
 
-    TDPTraceNavigator navigator;
-    _init(navigator, traceMatrix, DPBandConfig<BandOn>(-1, 1));
+    TDPTraceNavigator navigator{traceMatrix, DPBandConfig<BandOn>{-1, 1}};
 
     DnaString str0 = "ACGT";
     DnaString str1 = "ACGT";
@@ -259,7 +256,7 @@ SEQAN_DEFINE_TEST(test_align2_traceback_linear_wide_banded_alignment)
     typedef typename TraceBitMap_<>::Type TTraceValue;
     typedef DPMatrix_<TTraceValue, FullDPMatrix> TTraceMatrix;
 
-    typedef DPMatrixNavigator_<TTraceMatrix, DPTraceMatrix<TracebackOn<> >, NavigateColumnWise> TDPTraceNavigator;
+    typedef DPMatrixNavigator_<TTraceMatrix, DPTraceMatrix<TracebackOn<> >, NavigateColumnWiseBanded> TDPTraceNavigator;
 
     String<TTraceSegment> target;
     TTraceMatrix traceMatrix;
@@ -325,8 +322,7 @@ SEQAN_DEFINE_TEST(test_align2_traceback_linear_wide_banded_alignment)
     value(traceMatrix, 5, 6) = +TraceBitMap_<>::NONE;
     value(traceMatrix, 6, 6) = +TraceBitMap_<>::NONE;
 
-    TDPTraceNavigator navigator;
-    _init(navigator, traceMatrix, DPBandConfig<BandOn>(-4, 4));
+    TDPTraceNavigator navigator{traceMatrix, DPBandConfig<BandOn>{-4, 4}};
 
     DnaString str0 = "ACGTAC";
     DnaString str1 = "ACGTAC";
@@ -350,7 +346,7 @@ SEQAN_DEFINE_TEST(test_align2_traceback_linear_small_banded_alignment)
     typedef typename TraceBitMap_<>::Type TTraceValue;
     typedef DPMatrix_<TTraceValue, FullDPMatrix> TTraceMatrix;
 
-    typedef DPMatrixNavigator_<TTraceMatrix, DPTraceMatrix<TracebackOn<> >, NavigateColumnWise> TDPTraceNavigator;
+    typedef DPMatrixNavigator_<TTraceMatrix, DPTraceMatrix<TracebackOn<> >, NavigateColumnWiseBanded> TDPTraceNavigator;
 
     String<TTraceSegment> target;
     TTraceMatrix traceMatrix;
@@ -368,8 +364,7 @@ SEQAN_DEFINE_TEST(test_align2_traceback_linear_small_banded_alignment)
 
     value(traceMatrix, 0, 3) = +TraceBitMap_<>::DIAGONAL;
 
-    TDPTraceNavigator navigator;
-    _init(navigator, traceMatrix, DPBandConfig<BandOn>(0, 0));
+    TDPTraceNavigator navigator{traceMatrix, DPBandConfig<BandOn>{0, 0}};
 
     DnaString str0 = "ACG";
     DnaString str1 = "ACG";
@@ -416,8 +411,7 @@ SEQAN_DEFINE_TEST(test_align2_traceback_gaps_left_linear_gaps)
     value(traceMatrix, 3, 2) = +TraceBitMap_<>::VERTICAL | +TraceBitMap_<>::DIAGONAL;
 
 
-    TDPTraceNavigator navigator;
-    _init(navigator, traceMatrix, DPBandConfig<BandOff>());
+    TDPTraceNavigator navigator{traceMatrix, DPBandConfig<BandOff>()};
 
     DnaString str0 = "AC";
     DnaString str1 = "CCC";
@@ -465,8 +459,7 @@ SEQAN_DEFINE_TEST(test_align2_traceback_gaps_right_linear_gaps)
     value(traceMatrix, 3, 2) = +TraceBitMap_<>::VERTICAL | +TraceBitMap_<>::DIAGONAL | +TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX;
 
 
-    TDPTraceNavigator navigator;
-    _init(navigator, traceMatrix, DPBandConfig<BandOff>());
+    TDPTraceNavigator navigator{traceMatrix, DPBandConfig<BandOff>()};
 
     DnaString str0 = "AC";
     DnaString str1 = "CCC";
@@ -516,8 +509,7 @@ SEQAN_DEFINE_TEST(test_align2_traceback_gaps_left_affine_gaps)
         value(traceMatrix, 3, 2) = TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::DIAGONAL;
 
 
-        TDPTraceNavigator navigator;
-        _init(navigator, traceMatrix, DPBandConfig<BandOff>());
+        TDPTraceNavigator navigator{traceMatrix, DPBandConfig<BandOff>()};
 
         DnaString str0 = "AC";
         DnaString str1 = "CCC";
@@ -563,8 +555,7 @@ SEQAN_DEFINE_TEST(test_align2_traceback_gaps_left_affine_gaps)
         value(traceMatrix, 2, 4) = TraceBitMap_<>::NONE;
         value(traceMatrix, 3, 4) = TraceBitMap_<>::DIAGONAL;
 
-        TDPTraceNavigator navigator;
-        _init(navigator, traceMatrix, DPBandConfig<BandOff>());
+        TDPTraceNavigator navigator{traceMatrix, DPBandConfig<BandOff>()};
 
         DnaString str0 = "ACCA";
         DnaString str1 = "ACA";
@@ -617,8 +608,7 @@ SEQAN_DEFINE_TEST(test_align2_traceback_gaps_right_affine_gaps)
         value(traceMatrix, 3, 2) = TraceBitMap_<>::VERTICAL_OPEN | TraceBitMap_<>::MAX_FROM_VERTICAL_MATRIX | TraceBitMap_<>::DIAGONAL;
 
 
-        TDPTraceNavigator navigator;
-        _init(navigator, traceMatrix, DPBandConfig<BandOff>());
+        TDPTraceNavigator navigator{traceMatrix, DPBandConfig<BandOff>()};
 
         DnaString str0 = "AC";
         DnaString str1 = "CCC";
@@ -663,8 +653,7 @@ SEQAN_DEFINE_TEST(test_align2_traceback_gaps_right_affine_gaps)
         value(traceMatrix, 2, 4) = TraceBitMap_<>::NONE;
         value(traceMatrix, 3, 4) = TraceBitMap_<>::DIAGONAL;
 
-        TDPTraceNavigator navigator;
-        _init(navigator, traceMatrix, DPBandConfig<BandOff>());
+        TDPTraceNavigator navigator{traceMatrix, DPBandConfig<BandOff>()};
 
         DnaString str0 = "ACCA";
         DnaString str1 = "ACA";


### PR DESCRIPTION
Refactors lots of internal structures of the DP algorithm to gain speedups for the alignment code.

## Overview

- Refactors the dp matrix navigator implementations by reducing lots of copied code.
- Adds cache cells from outside to gain higher performance.
- Refactors the recursion implementations for affine and linear gaps.
- Changes the internal `_computeUnbanded...` and `_computeBanded...` to a common interface via tag dispatching
- Adapts all tests
- Fixes all overloads of `_computeCell...` or `_computeScore...` functions to new interface.