### PR TITLE
[FIX] Fixes alignment of arguments in text-tool-doc if no argument description is present.

### DIFF
--- a/include/seqan/arg_parse/tool_doc.h
+++ b/include/seqan/arg_parse/tool_doc.h
@@ -444,6 +444,13 @@ public:
         std::fill_n(out, _layout.leftPadding, ' ');
         stream << _toText(listItem._term);
         unsigned pos = _layout.leftPadding + length(listItem._term);
+
+        if (empty(listItem._description))
+        {
+            stream << '\n';
+            return;
+        }
+
         if (pos + _layout.centerPadding > _layout.rightColumnTab)
         {
             stream << '\n';


### PR DESCRIPTION
When multiple arguments are present, the tool doc displays the arguments `1..n` indented by `10` spaces, if no description to the list item is present.