### PR TITLE
[FIX] deactivate manual, if dox is deactivated, because of dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,8 +135,10 @@ if ("${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP")
     message (STATUS "Configuring demos")
     add_subdirectory (demos)
 
-    message (STATUS "Configuring manual")
-    add_subdirectory (manual)
+    if (NOT SEQAN_NO_DOX)
+        message (STATUS "Configuring manual")
+        add_subdirectory (manual)
+    endif ()
 endif ()
 
 if ((("${SEQAN_BUILD_SYSTEM}" STREQUAL "DEVELOP") OR


### PR DESCRIPTION
If dox are not built, it makes no sense to attempt a manual build.

This test is not covered by unit tests so you can ignore the test results, but instead please review extra carefully!