### PR TITLE
[FIX] Force python2.7 in SeqAnBuildSystem

### DIFF
--- a/dox/CMakeLists.txt
+++ b/dox/CMakeLists.txt
@@ -9,55 +9,17 @@
 cmake_minimum_required (VERSION 3.0.0)
 project (seqan_dox CXX)
 
+# require python 2.7, not python3
+set(PythonInterp_FIND_VERSION 2.7)
+set(PythonInterp_FIND_VERSION_MAJOR 2)
+set(PythonInterp_FIND_VERSION_MINOR 7)
+set(PythonInterp_FIND_VERSION_COUNT 2)
+
 find_package (PythonInterp)
-if (NOT PYTHONINTERP_FOUND)
-    message (STATUS "  Python not found, not building dox as a tests.")
+if (NOT PYTHONINTERP_FOUND OR NOT(${PYTHON_VERSION_MAJOR} MATCHES "2"))
+    message (STATUS "  You need Python 2.x for building dox. (skip the tests)")
     return ()
 endif ()
-
-# find python 2.x
-if(NOT(${PYTHON_VERSION_MAJOR} MATCHES "2"))
-    set(_PYTHON2_VERSIONS 2.7 2.6 2.5 2.4 2.3 2.2 2.1 2.0)
-    unset(_Python_NAMES)
-    foreach(_CURRENT_VERSION IN LISTS _PYTHON2_VERSIONS)
-        list(APPEND _Python_NAMES "python${_CURRENT_VERSION}")
-    endforeach()
-    unset(_PYTHON2_VERSIONS)
-
-    find_program(PYTHON2_EXECUTABLE NAMES ${_Python_NAMES})
-    if(PYTHON2_EXECUTABLE MATCHES "PYTHON2_EXECUTABLE-NOTFOUND")
-        message (STATUS "You need Python 2.x for building dox. (skip the tests)")
-        return()
-    endif()
-    set(PYTHON_EXECUTABLE "${PYTHON2_EXECUTABLE}")
-    message (STATUS "Found Python 2.x: ${PYTHON_EXECUTABLE}") 
-endif()
-
-# find python 2.x
-if(NOT(${PYTHON_VERSION_MAJOR} MATCHES "2"))
-    set(_PYTHON2_VERSIONS 2.7 2.6 2.5 2.4 2.3 2.2 2.1 2.0)
-    unset(_Python_NAMES)
-    foreach(_CURRENT_VERSION IN LISTS _PYTHON2_VERSIONS)
-        list(APPEND _Python_NAMES "python${_CURRENT_VERSION}")
-    endforeach()
-    unset(_PYTHON2_VERSIONS)
-
-    find_program(PYTHON2_EXECUTABLE NAMES ${_Python_NAMES})
-    if(PYTHON2_EXECUTABLE MATCHES "PYTHON2_EXECUTABLE-NOTFOUND")
-        message (STATUS "You need Python 2.x for building dox. (skip the tests)")
-        return()
-    endif()
-    set(PYTHON_EXECUTABLE "${PYTHON2_EXECUTABLE}")
-    message (STATUS "Found Python 2.x: ${PYTHON_EXECUTABLE}")
-
-    # change shell scripts for building dox
-    file(READ "${CMAKE_CURRENT_SOURCE_DIR}/../dox/run.sh.in" run_content)
-    file(READ "${CMAKE_CURRENT_SOURCE_DIR}/../dox/dox_only.sh.in" dox_only_content)
-    string(REPLACE "python2 ../" "${PYTHON_EXECUTABLE} ../" run_content "${run_content}")
-    string(REPLACE "python2 ../" "${PYTHON_EXECUTABLE} ../" dox_only_content "${dox_only_content}")
-    file(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/../dox/run.sh" "${run_content}")
-    file(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/../dox/dox_only.sh" "${dox_only_content}")
-endif()
 
 # Add building the documentation as a test.
 add_test (build_dox

--- a/util/cmake/SeqAnBuildSystem.cmake
+++ b/util/cmake/SeqAnBuildSystem.cmake
@@ -44,6 +44,12 @@
 # SEQAN_RELEASE_LIBRARY
 # APP:${app_name}
 
+# require python 2.7, not python3
+set(PythonInterp_FIND_VERSION 2.7)
+set(PythonInterp_FIND_VERSION_MAJOR 2)
+set(PythonInterp_FIND_VERSION_MINOR 7)
+set(PythonInterp_FIND_VERSION_COUNT 2)
+
 include (SeqAnUsabilityAnalyzer)
 include (CheckCXXCompilerFlag)
 

--- a/util/py_lib/CMakeLists.txt
+++ b/util/py_lib/CMakeLists.txt
@@ -9,6 +9,11 @@
 # ===========================================================================
 
 # Look for Python and stop if it could not be found.
+# require python 2.7, not python3
+set(PythonInterp_FIND_VERSION 2.7)
+set(PythonInterp_FIND_VERSION_MAJOR 2)
+set(PythonInterp_FIND_VERSION_MINOR 7)
+set(PythonInterp_FIND_VERSION_COUNT 2)
 find_package (PythonInterp)
 
 if (NOT PYTHONINTERP_FOUND)


### PR DESCRIPTION
One cmake python call to rule them all

#1482 (issue that had python as symlink to python3)
#1916 (@xenigmax fixed this for dox)
#1969 (@xenigmax another fix for dox?)
#2003 (@xenigmax another fix #1992 for dox)