### PR TITLE
Disable simd for gcc4.9

### DIFF
--- a/include/seqan/simd.h
+++ b/include/seqan/simd.h
@@ -86,6 +86,18 @@
     #error SEQAN::SIMD (vector extension) is not supported by msvc and windows intel compiler, try compiling with -DSEQAN_UMESIMD_ENABLED
 #endif
 
+// SIMD operations have severe performance issues on <= gcc4.9
+#if defined(SEQAN_SEQANSIMD_ENABLED) && defined(COMPILER_GCC) && (__GNUC__ <= 4)
+    // TODO(marehr): If we switch to jenkins, filter out these warnings
+    #if !(defined(NDEBUG) || defined(SEQAN_ENABLE_TESTING))
+        #pragma message("SIMD acceleration was disabled for <=gcc4.9, because of known performance issues " \
+                        "https://github.com/seqan/seqan/issues/2017. Use a more recent gcc compiler.")
+    #endif
+    #undef SEQAN_SIMD_ENABLED
+    #undef SEQAN_SEQANSIMD_ENABLED
+    #undef SEQAN_UMESIMD_ENABLED
+#endif // defined(COMPILER_GCC) && __GNUC__ <= 4
+
 // Define maximal size of vector in byte.
 #if defined(SEQAN_SEQANSIMD_ENABLED) && defined(__AVX512F__)
     // TODO(marehr): If we switch to jenkins, filter out these warnings

--- a/util/cmake/SeqAnSimdUtility.cmake
+++ b/util/cmake/SeqAnSimdUtility.cmake
@@ -206,6 +206,7 @@ set(SEQAN_SIMD_AVX512_CNL_SOURCE "${SEQAN_SIMD_AVX512_KNL_SOURCE}")
 
 set(SEQAN_SIMD_SEQANSIMD_SOURCE
 "#include <cstdint>
+#include <iostream>
 using int32x4_t = int32_t __attribute__ ((__vector_size__(4 * sizeof(int32_t)))); // SSE4 = 128bit
 using int32x8_t = int32_t __attribute__ ((__vector_size__(8 * sizeof(int32_t)))); // AVX2 = 256bit
 
@@ -266,7 +267,12 @@ int main() {
   auto z = x + y;
 
   // gcc 4.9 bug
-  constexpr auto length = LENGTH<int32x8_t>::VALUE;
+  constexpr auto length1 = LENGTH<int32x4_t>::VALUE;
+  constexpr auto length2 = LENGTH<int32x8_t>::VALUE;
+  static_assert(length1 == 4u, \"\");
+  static_assert(length2 == 8u, \"\");
+  std::cout << \"length1: \" << length1 << std::endl;
+  std::cout << \"length2: \" << length2 << std::endl;
 
   // icc 16.0.0, 16.0.1 bug
   assign(a, 0, 4);


### PR DESCRIPTION
Fixes #2017 and current >1000 build-errors on cdash fo gcc 4.9.

Errors:
> /.../Linux-3.16.0-4-amd64_g++-4.9_64/tests/simd/test_simd_vector.h:122:7: error: 'constexpr SimdVectorTestCommon<__vector(32) signed char>::SimdVectorTestCommon()' conflicts with a previous declaration
>
> class SimdVectorTestCommon : public seqan::Test
>       ^
