### PR TITLE
[ENHANCEMENT,TEST] directory argument/option now also accept trailing whitespaces

### DIFF
--- a/include/seqan/arg_parse/arg_parse_argument.h
+++ b/include/seqan/arg_parse/arg_parse_argument.h
@@ -438,6 +438,28 @@ inline bool isOutputFileArgument(ArgParseArgument const & me)
 }
 
 // ----------------------------------------------------------------------------
+// Function isDirectoryArgument()
+// ----------------------------------------------------------------------------
+
+/*!
+ * @fn ArgParseArgument#isDirectoryArgument
+ * @headerfile <seqan/arg_parse.h>
+ * @brief Returns whether the argument is a directorz argument.
+ *
+ * @signature bool isDirectoryArgument(arg);
+ *
+ * @param[in] arg The ArgParseArgument to query.
+ *
+ * @return bool <tt>true</tt> if it is a directory argument, <tt>false</tt> otherwise.
+ */
+
+inline bool isDirectoryArgument(ArgParseArgument const & me)
+{
+    return me._argumentType == ArgParseArgument::INPUT_DIRECTORY ||
+           me._argumentType == ArgParseArgument::OUTPUT_DIRECTORY;
+}
+
+// ----------------------------------------------------------------------------
 // Function isOutputPrefixArgument()
 // ----------------------------------------------------------------------------
 
@@ -923,7 +945,15 @@ inline void _checkValue(ArgParseArgument const & me)
 {
     unsigned i = 0;
     for (std::vector<std::string>::const_iterator it = me.value.begin(); it != me.value.end(); ++it, ++i)
-        _checkValue(me, *it, i);
+    {
+        auto val = *it;
+
+        if (isDirectoryArgument(me)) // strip trailing slash for directories
+            if (val[length(val) - 1] == '/')
+                val.resize(length(val) - 1);
+
+        _checkValue(me, val, i);
+    }
 }
 
 // ----------------------------------------------------------------------------
@@ -1137,6 +1167,10 @@ inline std::string getFileExtension(ArgParseArgument const & me, unsigned pos = 
     std::string value = getArgumentValue(me, pos);
     if (value.empty())
         return "";
+
+    if (isDirectoryArgument(me)) // strip trailing slash for directories
+        if (value[length(value) - 1] == '/')
+            value.resize(length(value) - 1);
 
     // If there is a list of valid values then we look for each of these in the path.
     if (!me.validValues.empty())

--- a/tests/arg_parse/test_arg_parse.cpp
+++ b/tests/arg_parse/test_arg_parse.cpp
@@ -144,6 +144,7 @@ SEQAN_BEGIN_TESTSUITE(test_arg_parse)
     SEQAN_CALL_TEST(test_argument_invalid_cast);
     SEQAN_CALL_TEST(test_argument_min_max_boundaries);
     SEQAN_CALL_TEST(test_argument_valid_values);
+    SEQAN_CALL_TEST(test_argument_valid_values_directories);
 
     SEQAN_CALL_TEST(test_argument_parser);
     SEQAN_CALL_TEST(test_parse_non_const_cstring);

--- a/tests/arg_parse/test_arg_parse_argument.h
+++ b/tests/arg_parse/test_arg_parse_argument.h
@@ -223,4 +223,32 @@ SEQAN_DEFINE_TEST(test_argument_valid_values)
                          "the given path 'not-a-validfile.qxt' does not have one of the valid file extensions [*.txt, *.fasta]; the file extension was overridden to be '.fa'");
 }
 
+SEQAN_DEFINE_TEST(test_argument_valid_values_directories)
+{
+    ArgParseArgument dirarg(ArgParseArgument::INPUT_DIRECTORY);
+    setValidValues(dirarg, ".dir1 .dir2");
+
+    _assignArgumentValue(dirarg, "directory.dir1");
+    SEQAN_ASSERT_EQ(value(dirarg.value, 0), "directory.dir1");
+
+    // Test getFileExtension() function.
+    SEQAN_ASSERT_EQ(getFileExtension(dirarg), ".dir1");
+
+    // different case should also work
+    _assignArgumentValue(dirarg, "directory.DIR1");
+    SEQAN_ASSERT_EQ(value(dirarg.value, 0), "directory.DIR1");
+
+    // also accept a trailing '/'
+    _assignArgumentValue(dirarg, "directory.dir2/");
+    SEQAN_ASSERT_EQ(value(dirarg.value, 0), "directory.dir2/");
+
+    // Test getFileExtension() function.
+    SEQAN_ASSERT_EQ(getFileExtension(dirarg), ".dir2");
+
+    // different case should also work
+    _assignArgumentValue(dirarg, "directory.DIR2/");
+    SEQAN_ASSERT_EQ(value(dirarg.value, 0), "directory.DIR2/");
+
+}
+
 #endif // SEQAN_TESTS_ARG_PARSE_TEST_ARG_PARSE_ARGUMENT_H_


### PR DESCRIPTION
Fixes #1988 

@h-2 Can you maybe try this on real use cases before merging? It seams to work fine but just to be sure since I think no app (in the seqan repo) uses this functionality.