### PR TITLE
[FIX] Fixes BAM jumpToRegion functionality.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,14 @@ SeqAn Changelog
 
 This file summarizes the changes to the SeqAn library and apps.
 
+Release 2.4.0
+~~~~~~~~~~~~~
+
+Selected Bug Fixes
+^^^^^^^^^^^^^^^^^^
+- BAM I/O
+    - Fix of jumpToRegion() functionality to start at the desired region instead of the index block.
+
 Release 2.3.2
 ~~~~~~~~~~~~~
 
@@ -16,8 +24,8 @@ Selected Bug Fixes
    - reintroduce ``FindSeqAn.cmake`` for projects that rely on cmake's module mode
    - fix the pkgconfig file
 - Platform related
-   - improved compliance with warning levels of soon-to-be-released gcc7 and clang4 
-   - because of unresolved bugs we now recommend gcc5 as minimum gcc version when using static linking 
+   - improved compliance with warning levels of soon-to-be-released gcc7 and clang4
+   - because of unresolved bugs we now recommend gcc5 as minimum gcc version when using static linking
 
 Release 2.3.1
 ~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes #2213 

Some explanation, because this bug seems to exist for quite a while:

Goal: Jump to the beginning of a region `[regionStart, regionEnd]`

In the current master branch (seqan 2.3) the `jumpToRegion()` jumps to highest candidate offset (candidate offset of bam index blocks) whose position is still smaller than `regionStart`. Reaching this index block, it sets the bam file stream to the first record it finds. This is most of the time not even near the actual `regionStart` and the information of `hasAlignments` was also wrong, since it has no knowledge about the actual region `[regionStart, regionEnd]`.

In the current develop branch, were the issue in master was reported by #1944, the `hasAlignment` parameter was partially fixed by PR #2098 to only be set to true: IF the very first record, that appears in the right most index block still smaller than `regionStart`, already lies inside the region. This only works if the region `[regionStart, regionEnd]` starts at the beginning of an bam index block which is often not the case.

What this PR therefore introduces, is that having found the highest candidate offset still smaller than `regionStart`, we now search with an additional while loop through the sorted records and set the bam file stream position to the first alignment overlapping the region (and `hasAlignments` to true).

A small benchmark on NA12878 chromosome 21 reveals the following read counts:
(The seqan cpp program jumps to "the start" of the region, and if `hasAlignments` is true it extracts all reads until `regionEnd` is reached, samtools was used to compare the behaviour) 
```console
    310828 samtools.sam
    314697 seqan_current_fix.sam
   2119086 seqan_master.sam
      7229 seqan_develop.sam
```

The now small difference in the current fix to samtools is that we only jump to the first read that overlaps the region, and cannot check for the following reads if the same holds. This has to be done by the user. I added a note in the documentation.