### PR TITLE
Fix/icpc align simd test

### DIFF
--- a/tests/align/test_align_simd_base.h
+++ b/tests/align/test_align_simd_base.h
@@ -178,9 +178,14 @@ void testAlignSimd(TFunctor const &,
     SEQAN_ASSERT_EQ(length(scores), length(alignments));
 
     // Check correctness of alignments using sequential alignment.
-    auto zipRes = makeZipView(scores, alignments);
-    for (auto res : zipRes)
+    // NOTE(rrahn): There seems to be a bug with the intel compiler and the zipView.
+    // The following works without running into the problem, but we need to investigate the issue at some point.
+    auto itBeg = makeZipIterator(begin(scores, seqan::Standard()), begin(alignments, seqan::Standard()));
+    auto itEnd = makeZipIterator(end(scores, seqan::Standard()), end(alignments, seqan::Standard()));
+
+    for (auto it = itBeg; it != itEnd; ++it)
     {
+        auto res = *it;
         typename std::decay<decltype(std::get<1>(res))>::type goldAlign;
         resize(rows(goldAlign), 2);
         assignSource(row(goldAlign, 0), source(row(std::get<1>(res), 0)));

--- a/tests/simd/test_simd_vector.h
+++ b/tests/simd/test_simd_vector.h
@@ -76,7 +76,9 @@ inline void test_matrix_transpose()
 //    std::cout << std::endl;
 //    for(int i=0;i<DIM;++i)
 //        print(std::cout, tmp[i]) << std::endl;
-
+#if defined(__x86_64__)
+    _mm_empty();  // Fixes icpc warning #13203: No EMMS instruction before call to function
+#endif 
     for (int i = 0; i < ROWS; ++i)
         for (int j = 0; j < COLS; ++j)
             SEQAN_ASSERT_EQ(tmp[i][j], random[j * ROWS + i]);

--- a/tests/simd/test_simd_vector.h
+++ b/tests/simd/test_simd_vector.h
@@ -76,9 +76,9 @@ inline void test_matrix_transpose()
 //    std::cout << std::endl;
 //    for(int i=0;i<DIM;++i)
 //        print(std::cout, tmp[i]) << std::endl;
-#if defined(__x86_64__)
+#if defined(__x86_64__) || defined(__amd64__)
     _mm_empty();  // Fixes icpc warning #13203: No EMMS instruction before call to function
-#endif 
+#endif // defined(__x86_64__) || defined(__amd64__)
     for (int i = 0; i < ROWS; ++i)
         for (int j = 0; j < COLS; ++j)
             SEQAN_ASSERT_EQ(tmp[i][j], random[j * ROWS + i]);

--- a/util/cmake/SeqAnSimdUtility.cmake
+++ b/util/cmake/SeqAnSimdUtility.cmake
@@ -576,21 +576,6 @@ macro(add_simd_platform_tests target)
             simd_list_version_greater(seqansimd_test_blacklist sse4)
             set(reason_for_disabled_test "Clang 3.7.x produces executables that fail the basic vector test `test_simd_vector`")
         endif()
-    elseif (COMPILER_LINTEL)
-        # icc >=17.0.0, <=17.0.4
-        if (NOT (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 17.0.0) AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 17.0.5)
-            ## seqan-simd:
-            # all: icc 17.0.x fails test cases [test_align_simd_*]:
-            #       SimdAlignTestCommon_Linear_Align type parameter [...] FAILED
-            #       SimdAlignTestCommon_Linear_Score type parameter [...] FAILED
-            if (NOT ("${target}" MATCHES "test_simd_vector"))
-                set(seqansimd_test_blacklist ${SEQAN_SIMD_SUPPORTED_EXTENSIONS})
-                set(reason_for_disabled_test "Intel compiler 17.0.{0-4} produces executables that fail complex tests like `[test_align_simd_*]`")
-            endif()
-        # icc >=17.0.5
-        elseif (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 17.0.4)
-            message(AUTHOR_WARNING "Intel compiler >=17.0.5 reevaluate if [test_align_simd_*] can be compiled.")
-        endif()
     endif()
 
     if(COMPILER_GCC AND DEFINED ENV{TRAVIS} AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0.0)


### PR DESCRIPTION
Fixes #2199
Reenables the simd align test for the intel compiler.
It seems there is some compiler issue with the use of the ZipView.
So the error was actually not related to the simd implementation.