### PR TITLE
Revert "[FIX] SIMD: Fixes createVector truncated value type issue."

### DIFF
--- a/include/seqan/simd/simd_base.h
+++ b/include/seqan/simd/simd_base.h
@@ -195,9 +195,9 @@ clearVector(TSimdVector & vector);
  *     c[i] = a;
  * ```
  */
-template <typename TSimdVector>
+template <typename TSimdVector, typename TValue>
 inline SEQAN_FUNC_ENABLE_IF(Is<SimdVectorConcept<TSimdVector> >, TSimdVector)
-createVector(typename Value<TSimdVector>::Type const x);
+createVector(TValue const x);
 
 /**
  * ```

--- a/include/seqan/simd/simd_base_seqan_interface.h
+++ b/include/seqan/simd/simd_base_seqan_interface.h
@@ -89,9 +89,9 @@ clearVector(TSimdVector & vector)
 // Function createVector()
 // --------------------------------------------------------------------------
 
-template <typename TSimdVector>
+template <typename TSimdVector, typename TValue>
 inline SEQAN_FUNC_ENABLE_IF(Is<SimdVectorConcept<TSimdVector> >, TSimdVector)
-createVector(typename Value<TSimdVector>::Type const x)
+createVector(TValue const x)
 {
     typedef typename Value<TSimdVector>::Type TIVal;
     return _createVector<TSimdVector>(x, SimdParams_<sizeof(TSimdVector), sizeof(TSimdVector) / sizeof(TIVal)>());

--- a/include/seqan/simd/simd_base_umesimd_impl.h
+++ b/include/seqan/simd/simd_base_umesimd_impl.h
@@ -352,9 +352,21 @@ clearVector(TSimdVector & vector)
 // Function createVector()
 // --------------------------------------------------------------------------
 
-template <typename TSimdVector>
+template <typename TSimdVector, typename TValue>
+inline SEQAN_FUNC_ENABLE_IF(And<Is<SimdMaskVectorConcept<TSimdVector>>,
+                                Not<Is<SimdVectorConcept<TSimdVector>>>>, TSimdVector)
+createVector(TValue const x)
+{
+    return TSimdVector(static_cast<bool>(x));
+}
+
+// --------------------------------------------------------------------------
+// Function createVector()
+// --------------------------------------------------------------------------
+
+template <typename TSimdVector, typename TValue>
 inline SEQAN_FUNC_ENABLE_IF(Is<SimdVectorConcept<TSimdVector> >, TSimdVector)
-createVector(typename Value<TSimdVector>::Type const x)
+createVector(TValue const x)
 {
     return TSimdVector(x);
 }


### PR DESCRIPTION
This reverts commit 6df610cdf93d82efd631790d3dc799ab956d17f7.

It broke UME Simd and I could not reproduce the error after reverting it.