### PR TITLE
More cmake fixes

### DIFF
--- a/apps/alf/CMakeLists.txt
+++ b/apps/alf/CMakeLists.txt
@@ -60,8 +60,7 @@ install (TARGETS alf
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/alf for SeqAn release builds.
-install (FILES LICENSE
-               README
+install (FILES README
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 install (FILES example/small.fasta
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC}/example)

--- a/apps/bs_tools/CMakeLists.txt
+++ b/apps/bs_tools/CMakeLists.txt
@@ -103,8 +103,7 @@ install (TARGETS bisar casbar four2three
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/bs_tools for SeqAn release builds.
-install (FILES LICENSE
-               README
+install (FILES README
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 #install (FILES example/fasta1.fa
 #               example/fasta2.fa

--- a/apps/dfi/CMakeLists.txt
+++ b/apps/dfi/CMakeLists.txt
@@ -60,8 +60,7 @@ install (TARGETS dfi
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/dfi for SeqAn release builds.
-install (FILES LICENSE
-               README
+install (FILES README
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 install (FILES example/fasta1.fa
                example/fasta2.fa

--- a/apps/fiona/CMakeLists.txt
+++ b/apps/fiona/CMakeLists.txt
@@ -87,8 +87,7 @@ install (TARGETS fiona compute_gain DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/fiona for SeqAn release builds.
-install (FILES LICENSE
-               README
+install (FILES README
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 install (FILES example/reads.fa
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC}/example)

--- a/apps/fx_tools/CMakeLists.txt
+++ b/apps/fx_tools/CMakeLists.txt
@@ -59,8 +59,7 @@ install (TARGETS fx_bam_coverage
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/fx_tools for SeqAn release builds.
-install (FILES LICENSE
-               README
+install (FILES README
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 #install (FILES example/fasta1.fa
 #               example/fasta2.fa

--- a/apps/gustaf/CMakeLists.txt
+++ b/apps/gustaf/CMakeLists.txt
@@ -81,8 +81,7 @@ install (TARGETS gustaf gustaf_mate_joining
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/gustaf for SeqAn release builds.
-install (FILES LICENSE
-               README
+install (FILES README
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 install (FILES example/adeno.fa
                example/adeno_modified.fa

--- a/apps/insegt/CMakeLists.txt
+++ b/apps/insegt/CMakeLists.txt
@@ -65,8 +65,7 @@ install (TARGETS insegt
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/insegt for SeqAn release builds.
-install (FILES LICENSE
-               README
+install (FILES README
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 install (FILES example/annoOutput.gff
                example/annotations.gff

--- a/apps/mason2/CMakeLists.txt
+++ b/apps/mason2/CMakeLists.txt
@@ -147,8 +147,7 @@ install (TARGETS mason_frag_sequencing
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/mason2 for SeqAn release builds.
-install (FILES LICENSE
-               README
+install (FILES README
                README.mason_frag_sequencing
                README.mason_genome
                README.mason_materializer

--- a/apps/micro_razers/CMakeLists.txt
+++ b/apps/micro_razers/CMakeLists.txt
@@ -66,8 +66,7 @@ install (TARGETS micro_razers
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/micro_razers for SeqAn release builds.
-install (FILES LICENSE
-               README
+install (FILES README
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 install (FILES example/genome.fa
                example/reads.fa

--- a/apps/ngs_roi/CMakeLists.txt
+++ b/apps/ngs_roi/CMakeLists.txt
@@ -92,8 +92,7 @@ install (FILES # Scripts for sorting.
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/ngs_roi for SeqAn release builds.
-install (FILES LICENSE
-               README
+install (FILES README
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 
 # Example files.

--- a/apps/pair_align/CMakeLists.txt
+++ b/apps/pair_align/CMakeLists.txt
@@ -69,8 +69,7 @@ install (TARGETS pair_align
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/pair_align for SeqAn release builds.
-install (FILES LICENSE
-               README
+install (FILES README
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 
 # ----------------------------------------------------------------------------

--- a/apps/param_chooser/CMakeLists.txt
+++ b/apps/param_chooser/CMakeLists.txt
@@ -66,8 +66,7 @@ install (TARGETS param_chooser
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/param_chooser for SeqAn release builds.
-install (FILES LICENSE
-               README
+install (FILES README
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 #install (FILES
 #         DESTINATION ${SEQAN_PREFIX_SHARE_DOC}/example)

--- a/apps/rabema/CMakeLists.txt
+++ b/apps/rabema/CMakeLists.txt
@@ -99,8 +99,7 @@ install (TARGETS rabema_prepare_sam rabema_build_gold_standard rabema_evaluate
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/pair_align for SeqAn release builds.
-install (FILES LICENSE
-               README
+install (FILES README
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 
 # ----------------------------------------------------------------------------

--- a/apps/razers/CMakeLists.txt
+++ b/apps/razers/CMakeLists.txt
@@ -75,8 +75,7 @@ install (TARGETS razers
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/razers for SeqAn release builds.
-install (FILES LICENSE
-               README
+install (FILES README
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 install (FILES example/genome.fa
                example/reads.fa

--- a/apps/razers3/CMakeLists.txt
+++ b/apps/razers3/CMakeLists.txt
@@ -96,8 +96,7 @@ install (TARGETS razers3
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/razers3 for SeqAn release builds.
-install (FILES LICENSE
-               README
+install (FILES README
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 install (FILES example/genome.fa
                example/reads.fa

--- a/apps/rep_sep/CMakeLists.txt
+++ b/apps/rep_sep/CMakeLists.txt
@@ -68,8 +68,7 @@ install (TARGETS rep_sep
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/rep_sep for SeqAn release builds.
-install (FILES LICENSE
-               README
+install (FILES README
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 #install (FILES
 #         DESTINATION ${SEQAN_PREFIX_SHARE_DOC}/example)

--- a/apps/sak/CMakeLists.txt
+++ b/apps/sak/CMakeLists.txt
@@ -72,8 +72,7 @@ install (TARGETS sak
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/sak for SeqAn release builds.
-install (FILES LICENSE
-               README
+install (FILES README
                ${CMAKE_CURRENT_BINARY_DIR}/README.sak.txt
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 install (FILES ${CMAKE_CURRENT_BINARY_DIR}/sak.1

--- a/apps/sam2matrix/CMakeLists.txt
+++ b/apps/sam2matrix/CMakeLists.txt
@@ -60,8 +60,7 @@ install (TARGETS sam2matrix
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/sam2matrix for SeqAn release builds.
-install (FILES LICENSE
-               README
+install (FILES README
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 #install (FILES example/fasta1.fa
 #               example/fasta2.fa

--- a/apps/samcat/CMakeLists.txt
+++ b/apps/samcat/CMakeLists.txt
@@ -67,8 +67,7 @@ install (TARGETS samcat
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/samcat for SeqAn release builds.
-install (FILES LICENSE
-               README
+install (FILES README
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 #install (FILES example/fasta1.fa
 #               example/fasta2.fa

--- a/apps/searchjoin/CMakeLists.txt
+++ b/apps/searchjoin/CMakeLists.txt
@@ -68,8 +68,7 @@ install (TARGETS s4_search s4_join
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/searchjoin for SeqAn release builds.
-install (FILES LICENSE
-               README
+install (FILES README
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 
 # ----------------------------------------------------------------------------

--- a/apps/seqan_tcoffee/CMakeLists.txt
+++ b/apps/seqan_tcoffee/CMakeLists.txt
@@ -60,8 +60,7 @@ install (TARGETS seqan_tcoffee
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/seqan_tcoffee for SeqAn release builds.
-install (FILES LICENSE
-               README
+install (FILES README
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 install (FILES example/seq.fa
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC}/example)

--- a/apps/seqcons2/CMakeLists.txt
+++ b/apps/seqcons2/CMakeLists.txt
@@ -66,8 +66,7 @@ install (TARGETS seqcons2
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/seqcons2 for SeqAn release builds.
-install (FILES LICENSE
-               README
+install (FILES README
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 #install (FILES example/fasta1.fa
 #               example/fasta2.fa

--- a/apps/sgip/CMakeLists.txt
+++ b/apps/sgip/CMakeLists.txt
@@ -60,8 +60,7 @@ install (TARGETS sgip
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/sgip for SeqAn release builds.
-install (FILES LICENSE
-               README
+install (FILES README
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 install (FILES example/Iso_Data/iso_m2D_m196.A01
                example/r01/iso_r01_m200.A00

--- a/apps/snp_store/CMakeLists.txt
+++ b/apps/snp_store/CMakeLists.txt
@@ -75,8 +75,7 @@ install (TARGETS snp_store
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/snp_store for SeqAn release builds.
-install (FILES LICENSE
-               README
+install (FILES README
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 install (FILES example/exampleGenome.fa
                example/exampleReads.gff

--- a/apps/splazers/CMakeLists.txt
+++ b/apps/splazers/CMakeLists.txt
@@ -72,8 +72,7 @@ install (TARGETS splazers
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/splazers for SeqAn release builds.
-install (FILES LICENSE
-               README
+install (FILES README
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 install (FILES example/genome.fa
                example/reads.fa

--- a/apps/stellar/CMakeLists.txt
+++ b/apps/stellar/CMakeLists.txt
@@ -64,8 +64,7 @@ install (TARGETS stellar
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/stellar for SeqAn release builds.
-install (FILES LICENSE
-               README
+install (FILES README
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 install (FILES example/NC_001474.fasta
                example/NC_001477.fasta

--- a/apps/tree_recon/CMakeLists.txt
+++ b/apps/tree_recon/CMakeLists.txt
@@ -60,8 +60,7 @@ install (TARGETS tree_recon
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/tree_recon for SeqAn release builds.
-install (FILES LICENSE
-               README
+install (FILES README
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 install (FILES example/example.dist
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC}/example)

--- a/apps/yara/CMakeLists.txt
+++ b/apps/yara/CMakeLists.txt
@@ -140,7 +140,7 @@ install (TARGETS yara_indexer yara_mapper
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/yara for SeqAn release builds.
-install (FILES LICENSE README.rst
+install (FILES README.rst
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 
 # ----------------------------------------------------------------------------

--- a/util/cmake/SeqAnBuildSystem.cmake
+++ b/util/cmake/SeqAnBuildSystem.cmake
@@ -400,8 +400,7 @@ macro (seqan_setup_library)
     if (("${SEQAN_BUILD_SYSTEM}" STREQUAL "SEQAN_RELEASE_LIBRARY"))
 
         # Install SeqAn LICENSE, README.rst, CHANGELOG.rst files.
-        install (FILES LICENSE
-                       README.rst
+        install (FILES README.rst
                        CHANGELOG.rst
                  DESTINATION ${CMAKE_INSTALL_DOCDIR})
         # Install pkg-config file, except on Windows.

--- a/util/cmake/seqan-config.cmake
+++ b/util/cmake/seqan-config.cmake
@@ -307,7 +307,8 @@ endif ()
 
 # some OSes don't link pthread fully when building statically so we explicitly include whole archive
 if (UNIX AND NOT APPLE)
-    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--whole-archive -lpthread -Wl,--no-whole-archive")
+    find_package (Threads)
+    set (SEQAN_LIBRARIES ${SEQAN_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 endif ()
 
 if ((${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD") OR (${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD"))

--- a/util/skel/app_template/CMakeLists.txt
+++ b/util/skel/app_template/CMakeLists.txt
@@ -52,8 +52,7 @@ install (TARGETS %(NAME)s
 
 # Install non-binary files for the package to "." for app builds and
 # ${PREFIX}/share/doc/%(NAME)s for SeqAn release builds.
-install (FILES LICENSE
-               README
+install (FILES README
          DESTINATION ${SEQAN_PREFIX_SHARE_DOC})
 #install (FILES example/fasta1.fa
 #               example/fasta2.fa


### PR DESCRIPTION
@h-2 I've found two niggles whilst packaging SeqAn 2.4.0 for Gentoo: https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=3155495650f555369e58b58f54fc6766e9691f20

1. Fix pthread linking. Using `CMAKE_EXE_LINKER_FLAGS` is the wrong variable for specifying `-lpthread` due to the fact that it comes before the object files. One of the reasons this is a problem for Gentoo is that we build with `-Wl,--as-needed` globally to reduce overlinking, which then causes build failures, as you're specifying a dependency before the linker encounters a consumer of said dependency.
2. Do not install individual `LICENSE` files. A software is licensed because you clearly state what license it falls under, not because you install a `LICENSE` file with it. Imagine if every package in a distro installed the GPL/BSD/MIT licenses, you would needlessly be adding redundant files.