### PR TITLE
Infrastructure adds automatic testing of correct ctd export of our tools

### DIFF
--- a/apps/alf/CMakeLists.txt
+++ b/apps/alf/CMakeLists.txt
@@ -79,6 +79,9 @@ install (FILES example/small.fasta
 # Include executable seqan_tcoffee in CTD structure.
 set (SEQAN_CTD_EXECUTABLES ${SEQAN_CTD_EXECUTABLES} alf CACHE INTERNAL "")
 
+#Add test to check correct ctd generation.
+seqan_add_ctd_test (alf)
+
 # ----------------------------------------------------------------------------
 # CPack Install
 # ----------------------------------------------------------------------------

--- a/apps/bs_tools/CMakeLists.txt
+++ b/apps/bs_tools/CMakeLists.txt
@@ -88,6 +88,11 @@ set (SEQAN_CTD_EXECUTABLES ${SEQAN_CTD_EXECUTABLES}
         four2three
         CACHE INTERNAL "")
 
+#Add test to check correct ctd generation.
+seqan_add_ctd_test (bisar)
+seqan_add_ctd_test (casbar)
+seqan_add_ctd_test (four2three)
+
 # ----------------------------------------------------------------------------
 # Installation
 # ----------------------------------------------------------------------------

--- a/apps/dfi/CMakeLists.txt
+++ b/apps/dfi/CMakeLists.txt
@@ -80,6 +80,9 @@ seqan_add_app_test (dfi)
 # Include executable razers in CTD structure.
 set (SEQAN_CTD_EXECUTABLES ${SEQAN_CTD_EXECUTABLES} dfi CACHE INTERNAL "")
 
+#Add test to check correct ctd generation.
+seqan_add_ctd_test (dfi)
+
 # ----------------------------------------------------------------------------
 # CPack Install
 # ----------------------------------------------------------------------------

--- a/apps/fiona/CMakeLists.txt
+++ b/apps/fiona/CMakeLists.txt
@@ -106,6 +106,11 @@ seqan_add_app_test (fiona)
 # Include executable fiona in CTD structure.
 set (SEQAN_CTD_EXECUTABLES ${SEQAN_CTD_EXECUTABLES} fiona fiona_illumina compute_gain CACHE INTERNAL "")
 
+#Add test to check correct ctd generation.
+seqan_add_ctd_test (fiona)
+seqan_add_ctd_test (fiona_illumina)
+seqan_add_ctd_test (compute_gain)
+
 # ----------------------------------------------------------------------------
 # CPack Install
 # ----------------------------------------------------------------------------

--- a/apps/fx_tools/CMakeLists.txt
+++ b/apps/fx_tools/CMakeLists.txt
@@ -79,6 +79,10 @@ install (FILES LICENSE
 # Include executable razers in CTD structure.
 set (SEQAN_CTD_EXECUTABLES ${SEQAN_CTD_EXECUTABLES} fx_fastq_stats fx_bam_coverage CACHE INTERNAL "")
 
+#Add test to check correct ctd generation.
+seqan_add_ctd_test (fx_fastq_stats)
+seqan_add_ctd_test (fx_bam_coverage)
+
 # ----------------------------------------------------------------------------
 # CPack Install
 # ----------------------------------------------------------------------------

--- a/apps/insegt/CMakeLists.txt
+++ b/apps/insegt/CMakeLists.txt
@@ -94,6 +94,9 @@ seqan_add_app_test (insegt)
 # Include executable razers in CTD structure.
 set (SEQAN_CTD_EXECUTABLES ${SEQAN_CTD_EXECUTABLES} insegt CACHE INTERNAL "")
 
+#Add test to check correct ctd generation.
+seqan_add_ctd_test (insegt)
+
 # ----------------------------------------------------------------------------
 # CPack Install
 # ----------------------------------------------------------------------------

--- a/apps/mason2/CMakeLists.txt
+++ b/apps/mason2/CMakeLists.txt
@@ -126,6 +126,13 @@ set (SEQAN_CTD_EXECUTABLES
     mason_simulator
     CACHE INTERNAL "")
 
+#Add test to check correct ctd generation.
+seqan_add_ctd_test (mason_genome)
+seqan_add_ctd_test (mason_frag_sequencing)
+seqan_add_ctd_test (mason_variator)
+seqan_add_ctd_test (mason_materializer)
+seqan_add_ctd_test (mason_simulator)
+
 # ----------------------------------------------------------------------------
 # Installation
 # ----------------------------------------------------------------------------

--- a/apps/rabema/CMakeLists.txt
+++ b/apps/rabema/CMakeLists.txt
@@ -116,6 +116,11 @@ seqan_add_app_test (rabema)
 # Include executable razers in CTD structure.
 set (SEQAN_CTD_EXECUTABLES ${SEQAN_CTD_EXECUTABLES} rabema_prepare_sam rabema_build_gold_standard rabema_evaluate CACHE INTERNAL "")
 
+#Add test to check correct ctd generation.
+seqan_add_ctd_test (rabema_prepare_sam)
+seqan_add_ctd_test (rabema_build_gold_standard)
+seqan_add_ctd_test (rabema_evaluate)
+
 # ----------------------------------------------------------------------------
 # CPack Install
 # ----------------------------------------------------------------------------

--- a/apps/razers3/CMakeLists.txt
+++ b/apps/razers3/CMakeLists.txt
@@ -119,6 +119,9 @@ seqan_add_app_test (razers3 _sequential)
 # Include executable razers in CTD structure.
 set (SEQAN_CTD_EXECUTABLES ${SEQAN_CTD_EXECUTABLES} razers3 CACHE INTERNAL "")
 
+#Add test to check correct ctd generation.
+seqan_add_ctd_test (razers3)
+
 # ----------------------------------------------------------------------------
 # CPack Install
 # ----------------------------------------------------------------------------

--- a/apps/sak/CMakeLists.txt
+++ b/apps/sak/CMakeLists.txt
@@ -92,6 +92,9 @@ seqan_add_app_test (sak)
 # Include executable seqan_tcoffee in CTD structure.
 set (SEQAN_CTD_EXECUTABLES ${SEQAN_CTD_EXECUTABLES} sak CACHE INTERNAL "")
 
+#Add test to check correct ctd generation.
+seqan_add_ctd_test (sak)
+
 # ----------------------------------------------------------------------------
 # CPack Install
 # ----------------------------------------------------------------------------

--- a/apps/sam2matrix/CMakeLists.txt
+++ b/apps/sam2matrix/CMakeLists.txt
@@ -80,6 +80,9 @@ seqan_add_app_test (sam2matrix)
 # Include executable razers in CTD structure.
 set (SEQAN_CTD_EXECUTABLES ${SEQAN_CTD_EXECUTABLES} sam2matrix CACHE INTERNAL "")
 
+#Add test to check correct ctd generation.
+seqan_add_ctd_test (sam2matrix)
+
 # ----------------------------------------------------------------------------
 # CPack Install
 # ----------------------------------------------------------------------------

--- a/apps/samcat/CMakeLists.txt
+++ b/apps/samcat/CMakeLists.txt
@@ -87,6 +87,9 @@ seqan_add_app_test (samcat)
 # Include executable razers in CTD structure.
 set (SEQAN_CTD_EXECUTABLES ${SEQAN_CTD_EXECUTABLES} samcat CACHE INTERNAL "")
 
+#Add test to check correct ctd generation.
+seqan_add_ctd_test (samcat)
+
 # ----------------------------------------------------------------------------
 # CPack Install
 # ----------------------------------------------------------------------------

--- a/apps/seqan_tcoffee/CMakeLists.txt
+++ b/apps/seqan_tcoffee/CMakeLists.txt
@@ -79,6 +79,9 @@ seqan_add_app_test (seqan_tcoffee)
 # Include executable seqan_tcoffee in CTD structure.
 set (SEQAN_CTD_EXECUTABLES ${SEQAN_CTD_EXECUTABLES} seqan_tcoffee CACHE INTERNAL "")
 
+#Add test to check correct ctd generation.
+seqan_add_ctd_test (seqan_tcoffee)
+
 # ----------------------------------------------------------------------------
 # CPack Install
 # ----------------------------------------------------------------------------

--- a/apps/snp_store/CMakeLists.txt
+++ b/apps/snp_store/CMakeLists.txt
@@ -60,6 +60,9 @@ set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SEQAN_CXX_FLAGS}")
 # Include executable snp_store in CTD structure.
 set (SEQAN_CTD_EXECUTABLES ${SEQAN_CTD_EXECUTABLES} snp_store CACHE INTERNAL "")
 
+#Add test to check correct ctd generation.
+seqan_add_ctd_test (snp_store)
+
 # ----------------------------------------------------------------------------
 # Installation
 # ----------------------------------------------------------------------------

--- a/apps/stellar/CMakeLists.txt
+++ b/apps/stellar/CMakeLists.txt
@@ -85,6 +85,9 @@ seqan_add_app_test (stellar)
 # Include executable stellar in CTD structure.
 set (SEQAN_CTD_EXECUTABLES ${SEQAN_CTD_EXECUTABLES} stellar CACHE INTERNAL "")
 
+#Add test to check correct ctd generation.
+seqan_add_ctd_test (stellar)
+
 # ----------------------------------------------------------------------------
 # CPack Install
 # ----------------------------------------------------------------------------

--- a/apps/tree_recon/CMakeLists.txt
+++ b/apps/tree_recon/CMakeLists.txt
@@ -79,6 +79,9 @@ seqan_add_app_test (tree_recon)
 # Include executable seqan_tcoffee in CTD structure.
 set (SEQAN_CTD_EXECUTABLES ${SEQAN_CTD_EXECUTABLES} tree_recon CACHE INTERNAL "")
 
+#Add test to check correct ctd generation.
+seqan_add_ctd_test (tree_recon)
+
 # ----------------------------------------------------------------------------
 # CPack Install
 # ----------------------------------------------------------------------------

--- a/apps/yara/CMakeLists.txt
+++ b/apps/yara/CMakeLists.txt
@@ -157,6 +157,10 @@ seqan_add_app_test (yara)
 set (SEQAN_CTD_EXECUTABLES ${SEQAN_CTD_EXECUTABLES}
                            yara_indexer yara_mapper CACHE INTERNAL "")
 
+#Add test to check correct ctd generation.
+seqan_add_ctd_test (yara_indexer)
+seqan_add_ctd_test (yara_mapper)
+
 # ----------------------------------------------------------------------------
 # CPack Install
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
Adds automatic testing for the CTD exporter of the SeqAn apps, in order to detect downstream errors as by #2280 earlier in the pipeline.
Especially, if the CTD schema is updated.
This will break the builds but #2285 will fix it.
So after merging this, #2285  can be rebased and should fix all errors.