### PR TITLE
Fix order of gap open and gap extend parameters, and some typos, in tutorials

### DIFF
--- a/manual/source/Infrastructure/Contribute/GitWorkflow.rst
+++ b/manual/source/Infrastructure/Contribute/GitWorkflow.rst
@@ -69,7 +69,7 @@ The git history of your contribution should be concise. Please follow the follow
 
 * A single commit should be a logical unit; don't split a logical change over multiple commits and don't address different issues in one commit.
 * Do not include revisions to your changes in your history, i.e. if you receive comments on your PR, change your previous commits via ``git commit --amend`` or ``git rebase``, don't just push more changes onto the history.
-* Always split functional changes and style changes, including whitespace changes, into seperate commits.
+* Always split functional changes and style changes, including whitespace changes, into separate commits.
 * Follow our style for `commit messages <infra-contribute-git-commits>`_.
 * If you don't follow these rules your contribution will be squashed into a single commit by the project member doing the merge.
 

--- a/manual/source/Infrastructure/Manage/Releases.rst
+++ b/manual/source/Infrastructure/Manage/Releases.rst
@@ -75,5 +75,5 @@ They have the advantage of not requiring any build steps, simply copy the ``incl
 Application Package(s)
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Beyond that package maintainers have the choice to create either a single package called **seqan-apps** that contains all the applications *or* a seperate package per application (with the respective name of that app). Based on the above instructions this should be fairly easy to accomplish.
+Beyond that package maintainers have the choice to create either a single package called **seqan-apps** that contains all the applications *or* a separate package per application (with the respective name of that app). Based on the above instructions this should be fairly easy to accomplish.
 

--- a/manual/source/Tutorial/Algorithms/Alignment/MultipleSequenceAlignment.rst
+++ b/manual/source/Tutorial/Algorithms/Alignment/MultipleSequenceAlignment.rst
@@ -20,14 +20,14 @@ Prerequisites
   :ref:`tutorial-datastructures-sequences`, :ref:`tutorial-datastructures-alignment`
 
 Alignments are at the core of biological sequence analysis and part of the "bread and butter" tasks in this area.
-As you have learned in the :ref:`pairwise alignment tutorial <tutorial-algorithms-alignment-pairwise-sequence-alignment>`, SeqAn offers powerful and flexible functionality for coputing such pairwise alignments.
+As you have learned in the :ref:`pairwise alignment tutorial <tutorial-algorithms-alignment-pairwise-sequence-alignment>`, SeqAn offers powerful and flexible functionality for computing such pairwise alignments.
 This tutorial shows how to compute multiple sequence alignments (MSAs) using SeqAn.
 First, some background on MSA will be given and the tutorial will then explain how to create multiple sequence alignments.
 
-Note that this tutorial focuses on the ``<seqan/graph_msa.h>`` module whose purpose is the computation of **global** MSAs, i.e. similar to SeqAn::T-Coffe :cite:`Rausch2008` or ClustalW :cite:`Thompson1994`.
+Note that this tutorial focuses on the ``<seqan/graph_msa.h>`` module whose purpose is the computation of **global** MSAs, i.e. similar to SeqAn::T-Coffee :cite:`Rausch2008` or ClustalW :cite:`Thompson1994`.
 If you are interested in computing consensus sequences of multiple overlapping sequences (e.g. NGS reads), similar to assembly after the layouting step, then have a look at the :ref:`tutorial-algorithms-consensus-alignment` tutorial.
 
-While the pairwise alignment of sequences can be computed exactly in quadratic time usind dynamic programming, the computation of exact MSAs is harder.
+While the pairwise alignment of sequences can be computed exactly in quadratic time using dynamic programming, the computation of exact MSAs is harder.
 Given :math:`n` sequences of length :math:`\ell`, the exact computation of an MSA is only feasible in time :math:`\mathcal{O}(\ell^n)`.
 Thus, global MSAs are usually computed using a heuristic called **progressive alignment**.
 For an introduction to MSAs, see the `Wikipedia Article on Multiple Sequence Aligment <http://en.wikipedia.org/wiki/Multiple_sequence_alignment>`_.
@@ -37,14 +37,14 @@ Computing MSAs with SeqAn
 
 The SeqAn library gives you access to the engine of SeqAn::T-Coffee :cite:`Rausch2008`, a powerful and efficient MSA algorithm based on the progressive alignment strategy.
 The easiest way to compute multiple sequence alignments is using the function :dox:`globalMsaAlignment`.
-The following example shows how to compute a global multiple sequence alignment of proteins using the :dox:`Blosum62` scoring matrix with gap extension penalty ``-11`` and gap open penalty ``-1``.
+The following example shows how to compute a global multiple sequence alignment of proteins using the :dox:`Blosum62` scoring matrix with gap open penalty ``-11`` and gap extension penalty ``-1``.
 
 First, we include the necessary headers and begin the ``main`` function by declaring our strings as a char array.
 
 .. includefrags:: demos/tutorial/multiple_sequence_alignment/msa.cpp
    :fragment: main
 
-Next, we build a :dox:`Align` object with underling :dox:`String SeqAn Strings` over the :dox:`AminoAcid` alphabet.
+Next, we build a :dox:`Align` object with underlying :dox:`String SeqAn Strings` over the :dox:`AminoAcid` alphabet.
 We create four rows and assign the previously defined amino acid strings into the rows.
 
 .. includefrags:: demos/tutorial/multiple_sequence_alignment/msa.cpp
@@ -56,7 +56,7 @@ We use the :dox:`Blosum62` score matrix with the penalties from above.
 .. includefrags:: demos/tutorial/multiple_sequence_alignment/msa.cpp
    :fragment: alignment
 
-The output of the program look as follows.
+The output of the program looks as follows.
 
 .. includefrags:: demos/tutorial/multiple_sequence_alignment/msa.cpp.stdout
 
@@ -73,7 +73,7 @@ Assignment 1
      Review
 
    Objective
-     Compute a multiple sequence alignments between the four protein sequences from above using a :dox:`Align` object and the :dox:`Blosum80` score matrix.
+     Compute a multiple sequence alignment between the four protein sequences from above using a :dox:`Align` object and the :dox:`Blosum80` score matrix.
 
    Solution
      .. container:: foldable
@@ -107,7 +107,7 @@ We then count the number of characters (and gap pseudo-characters which have an 
 
 Finally, we compute the consensus and print it to the standard output.
 At each position, the consensus is called as the character with the highest count.
-Note that ``getMaxIndex`` breaks ties by the ordinal value of the caracters, i.e. ``A`` would be preferred over ``C``, ``C`` over ``G`` and so on.
+Note that ``getMaxIndex`` breaks ties by the ordinal value of the characters, i.e. ``A`` would be preferred over ``C``, ``C`` over ``G`` and so on.
 
 .. includefrags:: demos/tutorial/multiple_sequence_alignment/consensus.cpp
    :fragment: consensus-calling

--- a/manual/source/Tutorial/DataStructures/Store/FragmentStore.rst
+++ b/manual/source/Tutorial/DataStructures/Store/FragmentStore.rst
@@ -319,7 +319,7 @@ A annotation file can be read from an open :dox:`GffFileIn` or  :dox:`UcscFileIn
 Similarly, it can be written to an open :dox:`GffFileOut` with :dox:`FragmentStore#writeRecords`.
 
 The :dox:`GffFileIn` is also able to detect and read GTF files in addition to GFF files.
-As the kownGene.txt and knownIsoforms.txt files are two seperate files used by the UCSC Genome Browser, they must be read by two consecutive calls of :dox:`FragmentStore#readRecords` (first knownGene.txt then knownIsoforms.txt).
+As the knownGene.txt and knownIsoforms.txt files are two separate files used by the UCSC Genome Browser, they must be read by two consecutive calls of :dox:`FragmentStore#readRecords` (first knownGene.txt then knownIsoforms.txt).
 An annotation can be loaded without loading the corresponding contigs.
 In that case empty contigs are created in the contigStore with names given in the annonation.
 A subsequent call of :dox:`FragmentStore#loadContigs` would load the sequences of these contigs, if they have the same identifier in the contig file.

--- a/manual/source/Tutorial/DataStructures/Store/GenomeAnnotations.rst
+++ b/manual/source/Tutorial/DataStructures/Store/GenomeAnnotations.rst
@@ -94,7 +94,7 @@ The following example shows how to read an GTF file:
     :fragment: LOAD
 
 The GFF-reader is also able to detect and read GTF files.
-The UCSC Genome Browser uses two seperate files, the ``kownGene.txt`` and ``knownIsoforms.txt``.
+The UCSC Genome Browser uses two separate files, the ``knownGene.txt`` and ``knownIsoforms.txt``.
 They must be read by using two different :dox:`UcscFileIn` objects (one for ``knownGene.txt`` and one for ``knownIsoforms.txt``).
 Finally you call :dox:`FragmentStore#readRecords` with both :dox:`UcscFileIn` objects.
 
@@ -102,7 +102,7 @@ Finally you call :dox:`FragmentStore#readRecords` with both :dox:`UcscFileIn` ob
 
     An annotation can be loaded without loading the corresponding contigs.
 
-    In that case empty contigs are created in the contigStore with names given in the annonation.
+    In that case empty contigs are created in the contigStore with names given in the annotation.
     A subsequent call of :dox:`FragmentStore#loadContigs` would load the sequences of these contigs, if they have the same identifier in the contig file.
 
 Traversing the Annotation Tree
@@ -111,7 +111,7 @@ Traversing the Annotation Tree
 This section will illustrate how to use iterators to traverse the annotation tree.
 
 The annotation tree can be traversed and accessed with the :dox:`AnnotationTreeIterator AnnotationTree Iterator`.
-Again we use the metafunction `dox:ContainerConcept#Iterator Iterator` to determine the appropriate iterator type for our container.
+Again we use the metafunction :dox:`ContainerConcept#Iterator` to determine the appropriate iterator type for our container.
 A new AnnotationTree iterator can be obtained by calling :dox:`ContainerConcept#begin` with a reference to the :dox:`FragmentStore` and the ``AnnotationTree`` tag:
 
 .. includefrags:: demos/tutorial/genome_annotations/base.cpp
@@ -209,7 +209,7 @@ Assume we have loaded the file ``example.gtf`` with the following content to the
 
 .. includefrags:: demos/tutorial/genome_annotations/example.gtf
 
-We now want to iterate to the first exon and output a few information:
+We now want to iterate to the first exon and output a few pieces of information:
 
 .. includefrags:: demos/tutorial/genome_annotations/base.cpp
     :fragment: ACCESS
@@ -287,7 +287,7 @@ Assignment 4
        Transfer
 
      Objective
-       Write a small statistic tool to analyse a given set of annotations.
+       Write a small statistical tool to analyse a given set of annotations.
 
        #. Load the annotations given in the GTF file :download:`assignment_annotations.gtf <assignment_annotations.gtf>`.
        #. Output the average number of mRNAs for genes.


### PR DESCRIPTION
The only semantic change is the order of the gap open and gap extension penalty parameters in MultipleSequenceAlignment.rst, which I checked against code examples from other tutorials (it was suspicious that extension would cost more than opening).  The rest are minor typo fixes.