### PR TITLE
[FIX] Bidirectional FM Index: goDownString pushing too many states on…

### DIFF
--- a/include/seqan/index/index_bidirectional_stree.h
+++ b/include/seqan/index/index_bidirectional_stree.h
@@ -218,6 +218,7 @@ inline bool goDown(Iter<Index<TText, BidirectionalIndex<TIndexSpec> >, VSTree<To
 {
     if (goDown(_iter(it, Fwd())))
     {
+        _historyPush(_iter(it, Rev()));
         _update(it, Fwd());
         return true;
     }
@@ -229,6 +230,7 @@ inline bool goDown(Iter<Index<TText, BidirectionalIndex<TIndexSpec> >, VSTree<To
 {
     if (goDown(_iter(it, Rev())))
     {
+        _historyPush(_iter(it, Fwd()));
         _update(it, Rev());
         return true;
     }
@@ -251,8 +253,11 @@ _goDownObject(
     False,
     TDirection)
 {
+    typedef typename IfC<IsSameType<TDirection, Tag<BidirectionalFwd_> >::VALUE, Rev, Fwd>::Type TOppositeDirection;
+
     if (_goDownChar(_iter(it, TDirection()), obj))
     {
+        _historyPush(_iter(it, TOppositeDirection()));
         _update(it, TDirection());
         return true;
     }

--- a/include/seqan/index/index_bifm_stree.h
+++ b/include/seqan/index/index_bifm_stree.h
@@ -48,8 +48,6 @@ inline void _update(Iter<Index<TText, BidirectionalIndex<FMIndex<TOccSpec, TInde
 {
     typedef typename IfC<IsSameType<TDirection, Tag<BidirectionalFwd_> >::VALUE, Rev, Fwd>::Type TOppositeDirection;
 
-    _historyPush(_iter(it, TOppositeDirection()));
-
     auto & dirIter = _iter(it, TDirection());
     auto & oppDirIter = _iter(it, TOppositeDirection());
 
@@ -82,6 +80,7 @@ _goDownString(Iter<Index<TText, BidirectionalIndex<FMIndex<TOccSpec, TIndexSpec>
     typedef typename Size<TIndex>::Type                         TSize2;
     typedef Pair<TSize2>                                        TRange;
     typedef typename Iterator<TString const, Standard>::Type    TStringIter;
+    typedef typename IfC<IsSameType<TDirection, Tag<BidirectionalFwd_> >::VALUE, Rev, Fwd>::Type TOppositeDirection;
 
     TStringIter stringIt = begin(string, Standard());
     TStringIter stringEnd = end(string, Standard());
@@ -90,6 +89,7 @@ _goDownString(Iter<Index<TText, BidirectionalIndex<FMIndex<TOccSpec, TIndexSpec>
         return true;
 
     _historyPush(_iter(it, TDirection()));
+    _historyPush(_iter(it, TOppositeDirection()));
 
     for (lcp = 0; stringIt != stringEnd; ++stringIt, ++lcp)
     {

--- a/include/seqan/index/index_esa_stree.h
+++ b/include/seqan/index/index_esa_stree.h
@@ -1999,7 +1999,7 @@ SEQAN_CONCEPT_IMPL((Index<TText, IndexEsa<TSpec> > const), (StringTreeConcept));
 /*!
  * @fn TopDownHistoryIterator#goUp
  * @headerfile <seqan/index.h>
- * @brief Iterates up one edge to the parent in a tree/trie. After using goDown(iterator, string [, lcp]) on a suffix or
+ * @brief Iterates up one or multiple edges to the parent in a tree/trie. E.g., after using goDown(iterator, string [, lcp]) on a suffix or
  * prefix trie (e.g. IndexSa or FMIndex) and thus going down multiple edges at once, goUp(iterator) will go up as many
  * edges as the corresponding call of goDown(iterator, string[, lcp]) has moved down.
  *

--- a/include/seqan/index/index_esa_stree.h
+++ b/include/seqan/index/index_esa_stree.h
@@ -1999,7 +1999,9 @@ SEQAN_CONCEPT_IMPL((Index<TText, IndexEsa<TSpec> > const), (StringTreeConcept));
 /*!
  * @fn TopDownHistoryIterator#goUp
  * @headerfile <seqan/index.h>
- * @brief Iterates up one edge to the parent in a tree/trie.
+ * @brief Iterates up one edge to the parent in a tree/trie. After using goDown(iterator, string [, lcp]) on a suffix or
+ * prefix trie (e.g. IndexSa or FMIndex) and thus going down multiple edges at once, goUp(iterator) will go up as many
+ * edges as the corresponding call of goDown(iterator, string[, lcp]) has moved down.
  *
  * @signature bool goUp(iterator);
  *

--- a/tests/index/test_index_stree_iterators.cpp
+++ b/tests/index/test_index_stree_iterators.cpp
@@ -58,6 +58,7 @@ SEQAN_BEGIN_TESTSUITE(test_index)
 	SEQAN_CALL_TEST(testIssue509);
 	SEQAN_CALL_TEST(testIssue509b);
 	SEQAN_CALL_TEST(goDownOnEmptyString);
+	SEQAN_CALL_TEST(bidirectionalGoDownStringHistory);
 	SEQAN_CALL_TEST(testSTreeIterators_Wotd);
 	SEQAN_CALL_TEST(testSTreeIterators_WotdOriginal);
 	SEQAN_CALL_TEST(testSTreeIterators_Esa);

--- a/tests/index/test_stree_iterators.h
+++ b/tests/index/test_stree_iterators.h
@@ -121,6 +121,31 @@ SEQAN_DEFINE_TEST(goDownOnEmptyString)
     SEQAN_ASSERT_EQ(representative(it), DnaString("TC"));
 }
 
+SEQAN_DEFINE_TEST(bidirectionalGoDownStringHistory)
+{
+    typedef Index<DnaString, BidirectionalIndex<FMIndex<> > > TIndex;
+    typedef Iter<TIndex, VSTree<TopDown<ParentLinks<> > > > TIter;
+
+    DnaString text("GCTAAAA");
+    TIndex index(text);
+    TIter it(index);
+
+    SEQAN_ASSERT_EQ(goDown(it, "AAAT"), true);
+    SEQAN_ASSERT_EQ(representative(it, Fwd()), "TAAA");
+    SEQAN_ASSERT_EQ(representative(it, Rev()), "AAAT");
+    SEQAN_ASSERT_EQ(goDown(it, "CG"), true);
+    SEQAN_ASSERT_EQ(representative(it, Fwd()), "GCTAAA");
+    SEQAN_ASSERT_EQ(representative(it, Rev()), "AAATCG");
+    SEQAN_ASSERT_EQ(goUp(it), true);
+    SEQAN_ASSERT_EQ(representative(it, Fwd()), "TAAA");
+    SEQAN_ASSERT_EQ(representative(it, Rev()), "AAAT");
+    SEQAN_ASSERT_EQ(goUp(it), true);
+    SEQAN_ASSERT_EQ(representative(it, Fwd()), "");
+    SEQAN_ASSERT_EQ(representative(it, Rev()), "");
+    SEQAN_ASSERT_EQ(length(_iter(it, Fwd()).history), 0u);
+    SEQAN_ASSERT_EQ(length(_iter(it, Rev()).history), 0u);
+}
+
 SEQAN_DEFINE_TEST(testBuild)
 {
         typedef String<char> TText;


### PR DESCRIPTION
…to ParentLinks iterator

fixes #2300