### PR TITLE
Yara: Add option to specify strata by absolute errors

### DIFF
--- a/apps/yara/CMakeLists.txt
+++ b/apps/yara/CMakeLists.txt
@@ -46,7 +46,7 @@ endif (NOT BZIP2_FOUND)
 # App-Level Configuration
 # ----------------------------------------------------------------------------
 
-set (SEQAN_APP_VERSION "1.0.0")
+set (SEQAN_APP_VERSION "1.0.1")
 
 option (YARA_LARGE_CONTIGS "Set to OFF to disable support for more than 32k contigs or contigs longer than 4Gbp." ON)
 if (YARA_LARGE_CONTIGS AND NOT SEQAN_TRAVIS_BUILD)

--- a/apps/yara/mapper.cpp
+++ b/apps/yara/mapper.cpp
@@ -174,6 +174,14 @@ void setupArgumentParser(ArgumentParser & parser, Options const & options)
     setMaxValue(parser, "strata-rate", "10");
     setDefaultValue(parser, "strata-rate", 100.0 * options.strataRate);
 
+    addOption(parser, ArgParseOption("sc", "strata-count", "Consider suboptimal alignments within this absolute number \
+                                      of errors from the optimal alignment. Increase this threshold to increase \
+                                      the number of alternative alignments at the expense of runtime.",
+                                                          ArgParseOption::INTEGER));
+    setMinValue(parser, "strata-count", "0");
+    setMaxValue(parser, "strata-count", "127");
+    setDefaultValue(parser, "strata-count", 0);
+
     addOption(parser, ArgParseOption("y", "sensitivity", "Sensitivity with respect to edit distance. \
                                                           Full sensitivity guarantees to find all considered alignments \
                                                           but increases runtime, low sensitivity decreases runtime by \
@@ -287,9 +295,18 @@ parseCommandLine(Options & options, ArgumentParser & parser, int argc, char cons
     if (getOptionValue(errorRate, parser, "error-rate"))
         options.errorRate = errorRate / 100.0;
 
+    if (isSet(parser, "strata-rate") && isSet(parser, "strata-count"))
+    {
+        std::cerr << getAppName(parser) << ": 'strata-rate' and 'strata-count' cannot be specified at the same time." << std::endl;
+        return ArgumentParser::PARSE_ERROR;
+    }
+
     unsigned strataRate;
     if (getOptionValue(strataRate, parser, "strata-rate"))
         options.strataRate = strataRate / 100.0;
+
+    if (isSet(parser, "strata-count"))
+            getOptionValue(options.strataCount, parser, "strata-count");
 
     getOptionValue(options.sensitivity, parser, "sensitivity", options.sensitivityList);
 

--- a/apps/yara/mapper.h
+++ b/apps/yara/mapper.h
@@ -68,6 +68,7 @@ struct Options
     float               errorRate;
     float               indelRate;
     float               strataRate;
+    uint64_t            strataCount;
     Sensitivity         sensitivity;
     TList               sensitivityList;
 
@@ -97,6 +98,7 @@ struct Options
         errorRate(0.05f),
         indelRate(0.25f),
         strataRate(0.00f),
+        strataCount(-1u),
         sensitivity(HIGH),
         singleEnd(true),
         libraryLength(),

--- a/apps/yara/misc_options.h
+++ b/apps/yara/misc_options.h
@@ -282,8 +282,8 @@ inline TReadSeqSize getReadIndels(TOptions const & options, TReadSeqSize readSeq
 template <typename TMatch, typename TOptions, typename TReadSeqSize>
 inline TReadSeqSize getReadStrata(TOptions const & options, TReadSeqSize readSeqLength)
 {
-    return std::min((TReadSeqSize)(readSeqLength * options.strataRate),
-                    (TReadSeqSize)MemberLimits<TMatch, Errors>::VALUE);
+    TReadSeqSize readStrata = options.strataCount != -1u ? options.strataCount : readSeqLength * options.strataRate;
+    return std::min(readStrata, (TReadSeqSize)MemberLimits<TMatch, Errors>::VALUE);
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
We have a use case for this where we map against multiple alternative references which are clustered beforehand, allowing a fixed number of errors N during clustering. To guarantee that we do not miss hits against then hidden members of the reference clusters, we need to map best + N errors.

@esiragusa What do you think about merging this?