### PR TITLE
directly building test cases with g++ fails

### DIFF
--- a/include/seqan/basic/debug_test_system.h
+++ b/include/seqan/basic/debug_test_system.h
@@ -2365,7 +2365,7 @@ inline void fail()
 #define SEQAN_END_TESTSUITE \
     return 0;                                   \
     }
-#define SEQAN_CALL_TEST(test_name) do { SEQAN_TEST_ ## test_name(); } while (false)
+#define SEQAN_CALL_TEST(test_name) do { SEQAN_TEST_ ## test_name<true>(); } while (false)
 #define SEQAN_SKIP_TEST do {} while (false)
 
 #endif  // #if !SEQAN_ENABLE_TESTING


### PR DESCRIPTION
The underlying function of a test case is templatized and thus needs an explicit call `test_name<true>` to invoke.

This only happens when `SEQAN_ENABLE_TESTING` is not set.