### PR TITLE
[FIX] Fixes bug in chainSeedsGlobally().

### DIFF
--- a/include/seqan/seeds/seeds_global_chaining.h
+++ b/include/seqan/seeds/seeds_global_chaining.h
@@ -257,14 +257,14 @@ chainSeedsGlobally(
 
             TIntermediateSolution sol(endPositionV(seed_k), qualityOfChainEndingIn[it_k->i3], it_k->i3);
             // std::cout << "  INSERT (" << sol.i1 << ", " << sol.i2 << ", " << sol.i3 << ")" << __LINE__  << std::endl;
-            intermediateSolutions.insert(sol);
+            TIntermediateSolutionsIterator itDel = intermediateSolutions.insert(sol);
 
+            itDel++; // go to first entry in L after currently inserted triple
             // Delete all intermediate solutions where end1 >= end1 of k and have a lower score than k
             // to ensure that the invariant of V(j) >= V(j'), with j' <= j holds.
             // Roughly then, there is no chain ending in a seed below the seed_k, that has a lower score
             // than the chain ending in seed_k. Thus the last value in `intermediateSolutions` will
             // always point to the optimal chain.
-            TIntermediateSolutionsIterator itDel = intermediateSolutions.upper_bound(referenceSolution);
             TIntermediateSolutionsIterator itDelEnd = intermediateSolutions.end();
             while (itDel != itDelEnd)
             {
@@ -274,6 +274,13 @@ chainSeedsGlobally(
                 {
                     // std::cout << "  ERASE (" << ptr->i1 << ", " << ptr->i2 << ", " << ptr->i3 << ")" << std::endl;
                     intermediateSolutions.erase(ptr);
+                }
+                else
+                {
+                    // since intermediateSolutions are sorted ascending by
+                    // ptr->i2 (score) we can break on the first entry
+                    // which is >= qualityOfChainEndingIn[it_k->i3]
+                    break;
                 }
             }
 

--- a/include/seqan/seeds/seeds_global_chaining.h
+++ b/include/seqan/seeds/seeds_global_chaining.h
@@ -243,8 +243,7 @@ chainSeedsGlobally(
                 // both k and j end at the same vertical position, while
                 // the score of the chain ending in k is bigger than the
                 // score of the chain ending in j.
-                if (endPositionV(seed_j) > endPositionV(seed_k) ||
-                    (endPositionV(seed_j) == endPositionV(seed_k) && qualityOfChainEndingIn[it_k->i3] > it_j->i2))
+                if (endPositionV(seed_j) >= endPositionV(seed_k) && qualityOfChainEndingIn[it_k->i3] > it_j->i2)
                 {
                     TIntermediateSolution sol(endPositionV(seed_k), qualityOfChainEndingIn[it_k->i3], it_k->i3);
                     // std::cout << "  INSERT (" << sol.i1 << ", " << sol.i2 << ", " << sol.i3 << ")" << __LINE__  << std::endl;

--- a/include/seqan/seeds/seeds_global_chaining.h
+++ b/include/seqan/seeds/seeds_global_chaining.h
@@ -145,7 +145,6 @@ chainSeedsGlobally(
         SEQAN_ASSERT_LT(beginPositionV(seed), endPositionV(seed)); // [beginV, endV) must be at least of length 1
         appendValue(seeds, seed);
     }
-    // std::copy(seedSet._seeds.begin(), seedSet._seeds.end(), begin(seeds, Standard()));
 
     // -----------------------------------------------------------------------
     // Step 1: Generate the sorted list of interval points.
@@ -196,11 +195,7 @@ chainSeedsGlobally(
         // The seed belonging ot the interval point is seed k.
         TSeed const & seed_k = seeds[it_k->i3];
 
-        // std::cout << "Processing interval point (" << it_k->i1 << ", " << it_k->i2 << ", " << it_k->i3 << ")" /*<< std::endl*/;
-        // std::cout << " of Seed" << it_k->i3 << ":" << beginPositionH(seed_k) << ","
-        //                                              << beginPositionV(seed_k) << ","
-        //                                              << endPositionH(seed_k) << ","
-        //                                              << endPositionV(seed_k) << "," << std::endl;
+        // std::cout << "Processing interval point (" << it_k->i1 << ", " << it_k->i2 << ", " << it_k->i3 << ")" << std::endl;
         if (it_k->i2) {  // Is is begin point.
             // Find the closest seed j (in y-dimension) with an
             // entry in L whose end coordinate is less or equal the begin position of k.
@@ -283,7 +278,6 @@ chainSeedsGlobally(
                     break;
                 }
             }
-
             // Check if the invariant holds, that the scores in L are in a non-decreasing order.
             SEQAN_ASSERT(_checkScoreInvariant(intermediateSolutions));
         }

--- a/include/seqan/seeds/seeds_global_chaining.h
+++ b/include/seqan/seeds/seeds_global_chaining.h
@@ -138,8 +138,14 @@ chainSeedsGlobally(
     // We copy over the seeds from the seed set into an array of seeds.  We can then directly reference seed by their
     // index in this array which is simpler than handling iterators into the std::set<> of the seed set.
     String<TSeed> seeds;
-    resize(seeds, length(seedSet));
-    std::copy(seedSet._seeds.begin(), seedSet._seeds.end(), begin(seeds, Standard()));
+    reserve(seeds, length(seedSet));
+    for (auto const & seed : seedSet._seeds)
+    {
+        SEQAN_ASSERT_LT(beginPositionH(seed), endPositionH(seed)); // [beginH, endH) must be at least of length 1
+        SEQAN_ASSERT_LT(beginPositionV(seed), endPositionV(seed)); // [beginV, endV) must be at least of length 1
+        appendValue(seeds, seed);
+    }
+    // std::copy(seedSet._seeds.begin(), seedSet._seeds.end(), begin(seeds, Standard()));
 
     // -----------------------------------------------------------------------
     // Step 1: Generate the sorted list of interval points.

--- a/tests/seeds/test_seeds_global_chaining.cpp
+++ b/tests/seeds/test_seeds_global_chaining.cpp
@@ -39,98 +39,109 @@
 
 #include <seqan/seeds.h>  // Include module under test.
 
+// -----------------------------------------------------------------------------
+// Test global chaining weighting the seeds by their length only (Simple Seed)
+// -----------------------------------------------------------------------------
 
-// Test global chaining weighting the seeds by their length only.
-SEQAN_DEFINE_TEST(test_seeds_global_chaining_sparse_length)
+using namespace seqan;
+
+typedef SeedSet<Seed<Simple>, Unordered> TSeedSet;
+typedef Value<TSeedSet>::Type TSeed;
+typedef String<TSeed> TSeedChain;
+
+SEQAN_DEFINE_TEST(test_seeds_global_chaining_one_seed)
 {
-    using namespace seqan;
+    TSeedSet seedSet;
+    addSeed(seedSet, TSeed(1, 2, 3), Single());
 
-    typedef SeedSet<Seed<Simple>, Unordered> TSeedSet;
-    typedef Value<TSeedSet>::Type TSeed;
-    typedef String<TSeed> TSeedChain;
+    TSeedChain result;
+    chainSeedsGlobally(result, seedSet, SparseChaining());
 
-    // Test with one seed.
+    SEQAN_ASSERT_EQ(1u, length(result));
+    SEQAN_ASSERT_EQ(TSeed(1, 2, 3), front(result));
+}
+
+SEQAN_DEFINE_TEST(test_seeds_global_chaining_two_seeds)
+{
+    TSeedSet seedSet;
+    addSeed(seedSet, TSeed(1, 2, 3), Single());
+    addSeed(seedSet, TSeed(4, 5, 6), Single());
+
+    TSeedChain result;
+    chainSeedsGlobally(result, seedSet, SparseChaining());
+
+    SEQAN_ASSERT_EQ(2u, length(result));
+    SEQAN_ASSERT_EQ(TSeed(1, 2, 3), result[0]);
+    SEQAN_ASSERT_EQ(TSeed(4, 5, 6), result[1]);
+}
+
+
+// Test with two seeds, only first one is part of the chain.
+SEQAN_DEFINE_TEST(test_seeds_global_chaining_first_seed)
+{
+    TSeedSet seedSet;
+    addSeed(seedSet, TSeed(1, 2, 3), Single());
+    addSeed(seedSet, TSeed(2, 1, 2), Single());
+
+    TSeedChain result;
+    chainSeedsGlobally(result, seedSet, SparseChaining());
+
+    SEQAN_ASSERT_EQ(1u, length(result));
+    SEQAN_ASSERT_EQ(TSeed(1, 2, 3), front(result));
+}
+
+// A bit larger example.
+SEQAN_DEFINE_TEST(test_seeds_global_chaining_four_seeds)
+{
+    TSeedSet seedSet;
+    addSeed(seedSet, TSeed(0, 0, 2), Single());
+    addSeed(seedSet, TSeed(3, 5, 2), Single());
+    addSeed(seedSet, TSeed(4, 2, 3), Single());
+    addSeed(seedSet, TSeed(9, 9, 2), Single());
+
+    TSeedChain result;
+    chainSeedsGlobally(result, seedSet, SparseChaining());
+
+    SEQAN_ASSERT_EQ(3u, length(result));
+    SEQAN_ASSERT_EQ(TSeed(0, 0, 2), result[0]);
+    SEQAN_ASSERT_EQ(TSeed(4, 2, 3), result[1]);
+    SEQAN_ASSERT_EQ(TSeed(9, 9, 2), result[2]);
+}
+
+// Another non-trivial example that caused a problem earlier.  The
+// seeds are all overlapping here.
+SEQAN_DEFINE_TEST(test_seeds_global_chaining_overlapping_seeds)
+{
+    TSeedSet seedSet;
+    addSeed(seedSet, TSeed(0, 93, 281, 342), Single());
+    addSeed(seedSet, TSeed(3, 237, 127, 364), Single());
+    addSeed(seedSet, TSeed(3, 284, 86, 368), Single());
+    addSeed(seedSet, TSeed(5, 146, 239, 374), Single());
+
+    TSeedChain result;
+    chainSeedsGlobally(result, seedSet, SparseChaining());
+
+    SEQAN_ASSERT_EQ(1u, length(result));
+    SEQAN_ASSERT_EQ(TSeed(0, 93, 281, 342), result[0]);
+}
+
+// Issue #2082
+SEQAN_DEFINE_TEST(test_seeds_global_chaining_issue_2082)
+{
     {
         TSeedSet seedSet;
-        addSeed(seedSet, TSeed(1, 2, 3), Single());
+
+        addSeed(seedSet, TSeed(0, 0, 3), Single());
+        addSeed(seedSet, TSeed(2, 3, 2), Single());
 
         TSeedChain result;
         chainSeedsGlobally(result, seedSet, SparseChaining());
 
         SEQAN_ASSERT_EQ(1u, length(result));
-        SEQAN_ASSERT_EQ(TSeed(1, 2, 3), front(result));
+        SEQAN_ASSERT_EQ(TSeed(0, 0, 3), result[0]);
     }
-    // Test with two seeds, both are part of the chain.
+
     {
-        TSeedSet seedSet;
-        addSeed(seedSet, TSeed(1, 2, 3), Single());
-        addSeed(seedSet, TSeed(4, 5, 6), Single());
-
-        TSeedChain result;
-        chainSeedsGlobally(result, seedSet, SparseChaining());
-
-        SEQAN_ASSERT_EQ(2u, length(result));
-        SEQAN_ASSERT_EQ(TSeed(1, 2, 3), result[0]);
-        SEQAN_ASSERT_EQ(TSeed(4, 5, 6), result[1]);
-    }
-    // Test with two seeds, only first one is part of the chain.
-    {
-        TSeedSet seedSet;
-        addSeed(seedSet, TSeed(1, 2, 3), Single());
-        addSeed(seedSet, TSeed(2, 1, 2), Single());
-
-        TSeedChain result;
-        chainSeedsGlobally(result, seedSet, SparseChaining());
-
-        SEQAN_ASSERT_EQ(1u, length(result));
-        SEQAN_ASSERT_EQ(TSeed(1, 2, 3), front(result));
-    }
-    // A bit larger example.
-    {
-        TSeedSet seedSet;
-        addSeed(seedSet, TSeed(0, 0, 2), Single());
-        addSeed(seedSet, TSeed(3, 5, 2), Single());
-        addSeed(seedSet, TSeed(4, 2, 3), Single());
-        addSeed(seedSet, TSeed(9, 9, 2), Single());
-
-        TSeedChain result;
-        chainSeedsGlobally(result, seedSet, SparseChaining());
-
-        SEQAN_ASSERT_EQ(3u, length(result));
-        SEQAN_ASSERT_EQ(TSeed(0, 0, 2), result[0]);
-        SEQAN_ASSERT_EQ(TSeed(4, 2, 3), result[1]);
-        SEQAN_ASSERT_EQ(TSeed(9, 9, 2), result[2]);
-    }
-    // Another non-trivial example that caused a problem earlier.  The
-    // seeds are all overlapping here.
-    {
-        TSeedSet seedSet;
-        addSeed(seedSet, TSeed(0, 93, 281, 342), Single());
-        addSeed(seedSet, TSeed(3, 237, 127, 364), Single());
-        addSeed(seedSet, TSeed(3, 284, 86, 368), Single());
-        addSeed(seedSet, TSeed(5, 146, 239, 374), Single());
-
-        TSeedChain result;
-        chainSeedsGlobally(result, seedSet, SparseChaining());
-
-        SEQAN_ASSERT_EQ(1u, length(result));
-        SEQAN_ASSERT_EQ(TSeed(0, 93, 281, 342), result[0]);
-    }
-
-    { // Issue #2082
-       TSeedSet seedSet;
-
-       addSeed(seedSet, TSeed(0, 0, 3), Single());
-       addSeed(seedSet, TSeed(2, 3, 2), Single());
-
-       TSeedChain result;
-       chainSeedsGlobally(result, seedSet, SparseChaining());
-
-       SEQAN_ASSERT_EQ(1u, length(result));
-       SEQAN_ASSERT_EQ(TSeed(0, 0, 3), result[0]);
-   }
-
-   { // Issue #2082
         TSeedSet seedSet;
 
         addSeed(seedSet, TSeed(0, 0, 100), Single());
@@ -144,9 +155,154 @@ SEQAN_DEFINE_TEST(test_seeds_global_chaining_sparse_length)
     }
 }
 
+// Issue #2318
+SEQAN_DEFINE_TEST(test_seeds_global_chaining_issue_2318)
+{
+    TSeedSet simple;
+    addSeed(simple, TSeed(1,  5, 10, 15), Single());
+    addSeed(simple, TSeed(5,  9, 40, 34), Single());
+    addSeed(simple, TSeed(40, 10, 45, 17), Single());
+
+    TSeedChain result;
+    chainSeedsGlobally(result, simple, SparseChaining());
+
+    SEQAN_ASSERT_EQ(1u, length(result));
+    SEQAN_ASSERT_EQ(TSeed(5,  9, 40, 34), result[0]);
+}
+
+// Another test case, without deleting seeds (from list L) during the chaining algorithm
+SEQAN_DEFINE_TEST(test_seeds_global_chaining_no_deleting_intermediate_solution)
+{
+    TSeedSet simple;
+    addSeed(simple, TSeed(27, 21, 37, 24), Single());
+    addSeed(simple, TSeed(25, 14, 33, 19), Single());
+    addSeed(simple, TSeed(15, 7, 21, 11), Single());
+    addSeed(simple, TSeed(13, 13, 22, 14), Single());
+    addSeed(simple, TSeed(2,  8, 9, 12), Single());
+    addSeed(simple, TSeed(1,  1, 7, 5), Single());
+
+    TSeedChain result;
+    chainSeedsGlobally(result, simple, SparseChaining());
+
+    SEQAN_ASSERT_EQ(3u, length(result));
+    SEQAN_ASSERT_EQ(TSeed(2,  8, 9, 12), result[0]);
+    SEQAN_ASSERT_EQ(TSeed(13, 13, 22, 14), result[1]);
+    SEQAN_ASSERT_EQ(TSeed(27, 21, 37, 24), result[2]);
+}
+
+// Another test case, with deleting seeds (from list L) during the chaining algorithm
+SEQAN_DEFINE_TEST(test_seeds_global_chaining_deleting_intermediate_solution)
+{
+    TSeedSet simple;
+    addSeed(simple, TSeed(2, 16, 10, 21), Single());
+    addSeed(simple, TSeed(7, 12, 19, 19), Single());
+    addSeed(simple, TSeed(12, 8, 28, 17), Single());
+    addSeed(simple, TSeed(22, 3, 39, 12), Single());
+
+    TSeedChain result;
+    chainSeedsGlobally(result, simple, SparseChaining());
+
+    SEQAN_ASSERT_EQ(1u, length(result));
+    SEQAN_ASSERT_EQ(TSeed(22, 3, 39, 12), result[0]);
+}
+
+// Another test case, with bordering rectangles (each seed touches its neighbours)
+SEQAN_DEFINE_TEST(test_seeds_global_chaining_bordering_rectangles)
+{
+    TSeedSet simple;
+    addSeed(simple, TSeed(1, 1, 3, 3), Single());
+    addSeed(simple, TSeed(3, 1, 6, 3), Single());
+    addSeed(simple, TSeed(6, 1, 10, 3), Single());
+    addSeed(simple, TSeed(1, 3, 3, 6), Single());
+    addSeed(simple, TSeed(3, 3, 6, 6), Single());
+    addSeed(simple, TSeed(6, 3, 10, 6), Single());
+    addSeed(simple, TSeed(1, 6, 3, 10), Single());
+    addSeed(simple, TSeed(3, 6, 6, 10), Single());
+    addSeed(simple, TSeed(6, 6, 10, 10), Single());
+
+    TSeedChain result;
+    chainSeedsGlobally(result, simple, SparseChaining());
+
+    SEQAN_ASSERT_EQ(3u, length(result));
+    SEQAN_ASSERT_EQ(TSeed(1, 1, 3, 3), result[0]);
+    SEQAN_ASSERT_EQ(TSeed(3, 3, 6, 6), result[1]);
+    SEQAN_ASSERT_EQ(TSeed(6, 6, 10, 10), result[2]);
+}
+
+// Another test case, with rectangles on the same height (y axis)
+SEQAN_DEFINE_TEST(test_seeds_global_chaining_same_height)
+{
+    {
+        TSeedSet simple;
+        addSeed(simple, TSeed(1, 1, 3, 3), Single());
+
+        addSeed(simple, TSeed(3, 6, 5,  8), Single());
+        addSeed(simple, TSeed(5, 5, 8,  8), Single());
+        addSeed(simple, TSeed(8, 3, 13, 8), Single());
+
+        addSeed(simple, TSeed(13, 8, 15, 10), Single());
+
+        TSeedChain result;
+        chainSeedsGlobally(result, simple, SparseChaining());
+
+        SEQAN_ASSERT_EQ(3u, length(result));
+        SEQAN_ASSERT_EQ(TSeed(1, 1, 3, 3), result[0]);
+        SEQAN_ASSERT_EQ(TSeed(8, 3, 13, 8), result[1]);
+        SEQAN_ASSERT_EQ(TSeed(13, 8, 15, 10), result[2]);
+    }
+    {
+        TSeedSet simple;
+        addSeed(simple, TSeed(1, 1, 3, 3), Single());
+
+        addSeed(simple, TSeed(3,  3, 8,  8), Single());
+        addSeed(simple, TSeed(8,  6, 10, 8), Single());
+        addSeed(simple, TSeed(10, 5, 13, 8), Single());
+
+        addSeed(simple, TSeed(13, 8, 15, 10), Single());
+
+        TSeedChain result;
+        chainSeedsGlobally(result, simple, SparseChaining());
+
+        SEQAN_ASSERT_EQ(3u, length(result));
+        SEQAN_ASSERT_EQ(TSeed(1,  1, 3,  3), result[0]);
+        SEQAN_ASSERT_EQ(TSeed(3,  3, 8,  8), result[1]);
+        SEQAN_ASSERT_EQ(TSeed(13, 8, 15, 10), result[2]);
+    }
+    {
+        TSeedSet simple;
+        addSeed(simple, TSeed(1, 1, 3, 3), Single());
+
+        addSeed(simple, TSeed(3,  5, 6,  8), Single());
+        addSeed(simple, TSeed(6,  3, 11, 8), Single());
+        addSeed(simple, TSeed(11, 6, 13, 8), Single());
+
+        addSeed(simple, TSeed(13, 8, 15, 10), Single());
+
+        TSeedChain result;
+        chainSeedsGlobally(result, simple, SparseChaining());
+
+        SEQAN_ASSERT_EQ(3u, length(result));
+        SEQAN_ASSERT_EQ(TSeed(1,  1, 3,  3), result[0]);
+        SEQAN_ASSERT_EQ(TSeed(6,  3, 11, 8), result[1]);
+        SEQAN_ASSERT_EQ(TSeed(13, 8, 15, 10), result[2]);
+    }
+}
+
 SEQAN_BEGIN_TESTSUITE(test_seeds_global_chaining)
 {
     // Test global chaining of seeds.
-    SEQAN_CALL_TEST(test_seeds_global_chaining_sparse_length);
+    SEQAN_CALL_TEST(test_seeds_global_chaining_one_seed);
+    SEQAN_CALL_TEST(test_seeds_global_chaining_two_seeds);
+    SEQAN_CALL_TEST(test_seeds_global_chaining_first_seed);
+    SEQAN_CALL_TEST(test_seeds_global_chaining_four_seeds);
+    SEQAN_CALL_TEST(test_seeds_global_chaining_overlapping_seeds);
+    SEQAN_CALL_TEST(test_seeds_global_chaining_issue_2082);
+    SEQAN_CALL_TEST(test_seeds_global_chaining_issue_2082);
+    SEQAN_CALL_TEST(test_seeds_global_chaining_issue_2318);
+    SEQAN_CALL_TEST(test_seeds_global_chaining_no_deleting_intermediate_solution);
+    SEQAN_CALL_TEST(test_seeds_global_chaining_deleting_intermediate_solution);
+    SEQAN_CALL_TEST(test_seeds_global_chaining_bordering_rectangles);
+    SEQAN_CALL_TEST(test_seeds_global_chaining_same_height);
 }
+
 SEQAN_END_TESTSUITE


### PR DESCRIPTION
This fixes #2318 

The if-clause was ill-formed and not consistent with the original Gusfield algorithm. The minimal example that caused the assert in the referenced issue was included as a test case.