### PR TITLE
[FIX-#2331] correct infinity value in dp alignment

### DIFF
--- a/include/seqan/align/dp_cell.h
+++ b/include/seqan/align/dp_cell.h
@@ -142,7 +142,7 @@ struct DPCellDefaultInfinity<DPCell_<TScoreValue, TGapCostFunction> >
 
 template <typename TScoreValue, typename TGapCostFunction>
     const TScoreValue DPCellDefaultInfinity<DPCell_<TScoreValue, TGapCostFunction> >::VALUE =
-        createVector<TScoreValue>(std::numeric_limits<typename Value<TScoreValue>::Type>::min()) / createVector<TScoreValue>(2);
+        createVector<TScoreValue>(std::numeric_limits<typename Value<TScoreValue>::Type>::lowest()) / createVector<TScoreValue>(2);
 
 template <typename TScoreValue, typename TGapCostFunction>
 struct DPCellDefaultInfinity<DPCell_<TScoreValue, TGapCostFunction> const> :

--- a/include/seqan/align/dp_cell.h
+++ b/include/seqan/align/dp_cell.h
@@ -126,11 +126,11 @@ struct Reference<DPCell_<TScoreValue, TGapCostFunction> const>
 template <typename T>
 struct DPCellDefaultInfinity
 {
-    static const int VALUE;
+    static const typename Value<T>::Type VALUE;
 };
 
 template <typename T>
-const int DPCellDefaultInfinity<T>::VALUE = std::numeric_limits<int>::min();
+const typename Value<T>::Type DPCellDefaultInfinity<T>::VALUE = std::numeric_limits<typename Value<T>::Type>::lowest();
 
 // We use the min value of the score type and shift it one bits to the left.  This way we can use "infinity" without
 // checking for it during the computation.
@@ -142,7 +142,8 @@ struct DPCellDefaultInfinity<DPCell_<TScoreValue, TGapCostFunction> >
 
 template <typename TScoreValue, typename TGapCostFunction>
     const TScoreValue DPCellDefaultInfinity<DPCell_<TScoreValue, TGapCostFunction> >::VALUE =
-        createVector<TScoreValue>(std::numeric_limits<typename Value<TScoreValue>::Type>::lowest()) / createVector<TScoreValue>(2);
+        createVector<TScoreValue>(std::numeric_limits<typename Value<TScoreValue>::Type>::lowest()) /
+        createVector<TScoreValue>(static_cast<typename Value<TScoreValue>::Type>(2));
 
 template <typename TScoreValue, typename TGapCostFunction>
 struct DPCellDefaultInfinity<DPCell_<TScoreValue, TGapCostFunction> const> :

--- a/tests/align/test_align.cpp
+++ b/tests/align/test_align.cpp
@@ -476,8 +476,11 @@ SEQAN_BEGIN_TESTSUITE(test_align)
     SEQAN_CALL_TEST(test_alignment_algorithms_fragments_gaps_semi_global_affine);
     SEQAN_CALL_TEST(test_alignment_algorithms_score_semi_global_affine);
 
-    // Global Alignment with Differnt Container Types
+    // Global Alignment with Different Container Types
     SEQAN_CALL_TEST(test_alignment_algorithms_global_different_container);
+
+    // Fix for Floating Point Scores
+    SEQAN_CALL_TEST(test_alignment_algorithms_fix_floating_point_scores);
 
     // Local Alignment.
     SEQAN_CALL_TEST(test_alignment_algorithms_align_local_linear);

--- a/tests/align/test_alignment_algorithms_global.h
+++ b/tests/align/test_alignment_algorithms_global.h
@@ -2725,4 +2725,34 @@ SEQAN_DEFINE_TEST(test_alignment_algorithms_global_different_container)
     }
 }
 
+SEQAN_DEFINE_TEST(test_alignment_algorithms_fix_floating_point_scores)
+{
+    using namespace seqan;
+
+    Dna5String strH = "AAATGACGGATTG";
+    DnaString strV = "AGTCGGATCTACTG";
+
+    Align<Dna5String, ArrayGaps> align;
+    resize(rows(align), 2);
+    assignSource(row(align, 0), strH);
+    assignSource(row(align, 1), strV);
+
+    std::stringstream stream1, stream2, stream3;
+
+    int score_int = globalAlignment(align, Score<int, Simple>(4, -2, -2, -4), AffineGaps());
+    stream1 << align;
+    std::string const expected = stream1.str();
+    SEQAN_ASSERT_EQ(score_int, 16);
+
+    double score_dbl = globalAlignment(align, Score<double, Simple>(4., -2., -2., -4.), AffineGaps());
+    stream2 << align;
+    SEQAN_ASSERT_EQ(stream2.str(), expected);
+    SEQAN_ASSERT_IN_DELTA(score_dbl, 16.0, 1e-3);
+
+    float score_flt = globalAlignment(align, Score<float, Simple>(4.f, -2.f, -2.f, -4.f), AffineGaps());
+    stream3 << align;
+    SEQAN_ASSERT_EQ(stream3.str(), expected);
+    SEQAN_ASSERT_IN_DELTA(score_flt, 16.f, 1e-3f);
+}
+
 #endif  // #ifndef SANDBOX_RMAERKER_TESTS_ALIGN2_TEST_ALIGNMENT_ALGORITHMS_GLOBAL_H_

--- a/tests/align/test_alignment_dp_cell.h
+++ b/tests/align/test_alignment_dp_cell.h
@@ -77,15 +77,19 @@ void testDPCellDefaultInfinity(TGapCosts const &)
 {
     using namespace seqan;
 
-    typedef DPCell_<int, TGapCosts> TDPCell;
-    typedef DPCell_<int, TGapCosts> const TDPConstCell;
+    int    result_int       = DPCellDefaultInfinity<DPCell_<int, TGapCosts>>::VALUE;
+    int    result_int_const = DPCellDefaultInfinity<DPCell_<int, TGapCosts> const>::VALUE;
+    float  result_flt       = DPCellDefaultInfinity<DPCell_<float, TGapCosts>>::VALUE;
+    float  result_flt_const = DPCellDefaultInfinity<DPCell_<float, TGapCosts> const>::VALUE;
+    double result_dbl       = DPCellDefaultInfinity<DPCell_<double, TGapCosts>>::VALUE;
+    double result_dbl_const = DPCellDefaultInfinity<DPCell_<double, TGapCosts> const>::VALUE;
 
-    int result1 = DPCellDefaultInfinity<TDPCell>::VALUE;
-    int result2 = DPCellDefaultInfinity<TDPConstCell>::VALUE;
-
-    int test = std::numeric_limits<int>::min() / 2;
-    SEQAN_ASSERT_EQ(result1, test);
-    SEQAN_ASSERT_EQ(result2, test);
+    SEQAN_ASSERT_EQ      (result_int,       std::numeric_limits<int>::lowest() / 2);
+    SEQAN_ASSERT_EQ      (result_int_const, std::numeric_limits<int>::lowest() / 2);
+    SEQAN_ASSERT_IN_DELTA(result_flt,       std::numeric_limits<float>::lowest() / 2.0f, 1e-3);
+    SEQAN_ASSERT_IN_DELTA(result_flt_const, std::numeric_limits<float>::lowest() / 2.0f, 1e-3);
+    SEQAN_ASSERT_IN_DELTA(result_dbl,       std::numeric_limits<double>::lowest() / 2.0, 1e-3);
+    SEQAN_ASSERT_IN_DELTA(result_dbl_const, std::numeric_limits<double>::lowest() / 2.0, 1e-3);
 }
 
 template <typename TGaps>


### PR DESCRIPTION
Fix for #2331: The problem was a wrong alignment result and a wrong score, whenever TScoreValue is a float type in dp alignment computation. 

The issue was caused by the border initialization, which was aimed to be -inf/2 and implemented as std::numeric_limits::min / 2. This works fine for integer types, but for floating point types `std::numeric_limits::min` gives the closest positive value to 0. When adding gap extension cost to ≈0 in the first column and row, this leads in general to a better score in the max-function than the intended gap open cost, so all matrix values become wrong. 

I changed the implementation to `std::numeric_limits::lowest`, which does not change anything for integer types, but for floating point types it represents the smallest possible value as intended. 