### PR TITLE
[FIX-#2347] Mini-Fix for using C++-conformant numerical limits

### DIFF
--- a/include/seqan/basic/alphabet_math.h
+++ b/include/seqan/basic/alphabet_math.h
@@ -36,7 +36,9 @@
 // ==========================================================================
 
 #include <climits>
-#include <float.h>
+#include <limits>
+
+using namespace std;
 
 #ifndef SEQAN_BASIC_ALPHABET_MATH_H_
 #define SEQAN_BASIC_ALPHABET_MATH_H_
@@ -77,9 +79,9 @@ struct MaximumValueDouble_ { static const double VALUE; };
 template <typename T>
 const T MaximumValueSigned_<T>::VALUE = ((((T)1 << (BitsPerValue<T>::VALUE - 2)) - 1) << 1) + 1;
 template <typename T>
-const float MaximumValueFloat_<T>::VALUE = FLT_MAX;
+const float MaximumValueFloat_<T>::VALUE = numeric_limits<float>::max();
 template <typename T>
-const double MaximumValueDouble_<T>::VALUE = DBL_MAX;
+const double MaximumValueDouble_<T>::VALUE = numeric_limits<double>::max();
 
 template <>
 struct MaximumValueSigned_<bool>
@@ -135,9 +137,9 @@ const T MinimumValueUnsigned_<T>::VALUE = T(0);
 template <typename T>
 const T MinimumValueSigned_<T>::VALUE = ~(T)MaximumValueSigned_<T>::VALUE;
 template <typename T>
-const float MinimumValueFloat_<T>::VALUE = -FLT_MAX;
+const float MinimumValueFloat_<T>::VALUE = numeric_limits<float>::lowest();
 template <typename T>
-const double MinimumValueDouble_<T>::VALUE = -DBL_MAX;
+const double MinimumValueDouble_<T>::VALUE = numeric_limits<double>::lowest();
 
 template <>
 struct MinimumValueSigned_<bool>

--- a/include/seqan/basic/alphabet_math.h
+++ b/include/seqan/basic/alphabet_math.h
@@ -38,8 +38,6 @@
 #include <climits>
 #include <limits>
 
-using namespace std;
-
 #ifndef SEQAN_BASIC_ALPHABET_MATH_H_
 #define SEQAN_BASIC_ALPHABET_MATH_H_
 
@@ -79,9 +77,9 @@ struct MaximumValueDouble_ { static const double VALUE; };
 template <typename T>
 const T MaximumValueSigned_<T>::VALUE = ((((T)1 << (BitsPerValue<T>::VALUE - 2)) - 1) << 1) + 1;
 template <typename T>
-const float MaximumValueFloat_<T>::VALUE = numeric_limits<float>::max();
+const float MaximumValueFloat_<T>::VALUE = std::numeric_limits<float>::max();
 template <typename T>
-const double MaximumValueDouble_<T>::VALUE = numeric_limits<double>::max();
+const double MaximumValueDouble_<T>::VALUE = std::numeric_limits<double>::max();
 
 template <>
 struct MaximumValueSigned_<bool>
@@ -137,9 +135,9 @@ const T MinimumValueUnsigned_<T>::VALUE = T(0);
 template <typename T>
 const T MinimumValueSigned_<T>::VALUE = ~(T)MaximumValueSigned_<T>::VALUE;
 template <typename T>
-const float MinimumValueFloat_<T>::VALUE = numeric_limits<float>::lowest();
+const float MinimumValueFloat_<T>::VALUE = std::numeric_limits<float>::lowest();
 template <typename T>
-const double MinimumValueDouble_<T>::VALUE = numeric_limits<double>::lowest();
+const double MinimumValueDouble_<T>::VALUE = std::numeric_limits<double>::lowest();
 
 template <>
 struct MinimumValueSigned_<bool>


### PR DESCRIPTION
Hi,

This is a basic fix for issue #2347 - introducing numerical limits instead of relying to <float.h>. Still, do not know why float.h constants were not accepted, though.

Best,
Christian