### PR TITLE
[FIX] Avoid std::bad_alloc by adding an assertion.

### DIFF
--- a/include/seqan/bam_io/read_bam.h
+++ b/include/seqan/bam_io/read_bam.h
@@ -168,6 +168,11 @@ _readBamRecordWithoutSize(TBuffer & rawRecord, TForwardIter & iter)
     if (recordLen == 0x014D4142)
         SEQAN_THROW(ParseError("Unexpected BAM header encountered."));
 
+    // The recordLen after readRawPod() was -1 for a corrupted BAM file (EOF marker absent)
+    // which made the following write(rawRecord, iter, (size_t)recordLen) function call 
+    // throw a std::bad_alloc exception.
+    SEQAN_ASSERT(recordLen >= 0, "Cannot read BAM record of length < 0. Possibly corrupted BAM file!");
+
     clear(rawRecord);
     write(rawRecord, iter, (size_t)recordLen);
     return recordLen;


### PR DESCRIPTION
When I was accidentally running SViper on a corrupted BAM file, the program terminated by throwing a std::bad_alloc exception in release and debug mode. I added a debug assertion to direct others to the possibility of a corrupted file (so that they don't need to spend hours debugging like me..)