### PR TITLE
[FIX-#2346] correct BED12 file parsing, compatible with UCSC

### DIFF
--- a/include/seqan/bed_io/read_bed.h
+++ b/include/seqan/bed_io/read_bed.h
@@ -224,7 +224,7 @@ _readBedRecordNoData(BedRecord<Bed12> & record,
         record.itemRgb.blue = lexicalCast<int32_t>(buffer);
         skipOne(iter);
     }
-    else if (value(iter) == '\t' && record.itemRgb.red == 0)
+    else if (value(iter) == '\t' && record.itemRgb.red == 0) // allow a single '0' value for 0,0,0
     {
         skipOne(iter);
         record.itemRgb.green = 0;
@@ -253,7 +253,7 @@ _readBedRecordNoData(BedRecord<Bed12> & record,
     clear(buffer);
     readUntil(buffer, iter, OrFunctor<IsTab, OrFunctor<EqualsChar<','>, AssertNoNewline> >());
     appendValue(record.blockSizes, lexicalCast<int>(buffer));
-    if (value(iter) == ',')
+    if (value(iter) == ',') // allow trailing comma at the end of the list
         skipOne(iter);
 
     skipOne(iter);
@@ -269,13 +269,14 @@ _readBedRecordNoData(BedRecord<Bed12> & record,
     clear(buffer);
     readUntil(buffer, iter, OrFunctor<IsTab, OrFunctor<EqualsChar<','>, IsNewline> >());
     appendValue(record.blockBegins, lexicalCast<int>(buffer));
-    if (!atEnd(iter) && value(iter) == ',')
+    if (!atEnd(iter) && value(iter) == ',') // allow trailing comma at the end of the list
         skipOne(iter);
 
     if (!atEnd(iter) && value(iter) == '\t')
         skipOne(iter);
 
-    // DO NOT skip line here, because the rest of the line is written into record.data!
+    // DO NOT skip line here, because the rest of the line (empty or not) is written
+    // into record.data in the readRecord function below.
 }
 
 // The front-end function automatically calls the correct overload of

--- a/tests/bed_io/test_bed_io.cpp
+++ b/tests/bed_io/test_bed_io.cpp
@@ -219,6 +219,26 @@ SEQAN_DEFINE_TEST(test_bed_read_bed12_record)
     SEQAN_ASSERT_EQ(record.data, "data again!");
 }
 
+SEQAN_DEFINE_TEST(test_bed_read_bed12_ucsc_compatibility)
+{
+    // Prepare in-memory data.
+    String<char> test = "I\t123\t456\tNAME\t3\t-\t33\t66\t255,0,0\t3\t10,11,12\t1,2,3\n" // no text after 12th column
+                        "II\t999\t1000\tNAME2\t2e5\t.\t44\t55\t0\t3\t3,4,5\t4,5,6\tdata again!\n" // RGB = 0
+                        "III\t1001\t2000\tNAME3\t2e4\t.\t22\t23\t0,0,0\t3\t12,13,14,\t7,8,9,"; // additional comma
+
+    // Iterator to use
+    DirectionIterator<String<char>, Input>::Type iter = directionIterator(test, Input());
+
+    // The record to load into.
+    seqan::BedRecord<seqan::Bed12> record;
+    CharString buffer;
+
+    // Perform tests.
+    readRecord(record, buffer, iter, seqan::Bed());
+    readRecord(record, buffer, iter, seqan::Bed());
+    readRecord(record, buffer, iter, seqan::Bed());
+}
+
 SEQAN_DEFINE_TEST(test_bed_write_bed3_record)
 {
     seqan::BedRecord<seqan::Bed3> record1;
@@ -480,6 +500,7 @@ SEQAN_BEGIN_TESTSUITE(test_bed_io)
     SEQAN_CALL_TEST(test_bed_read_bed5_record);
     SEQAN_CALL_TEST(test_bed_read_bed6_record);
     SEQAN_CALL_TEST(test_bed_read_bed12_record);
+    SEQAN_CALL_TEST(test_bed_read_bed12_ucsc_compatibility);
 
     // Writing of BED records.
     SEQAN_CALL_TEST(test_bed_write_bed3_record);

--- a/tests/bed_io/test_bed_io.cpp
+++ b/tests/bed_io/test_bed_io.cpp
@@ -224,7 +224,7 @@ SEQAN_DEFINE_TEST(test_bed_read_bed12_ucsc_compatibility)
     // Prepare in-memory data.
     String<char> test = "I\t123\t456\tNAME\t3\t-\t33\t66\t255,0,0\t3\t10,11,12\t1,2,3\n" // no text after 12th column
                         "II\t999\t1000\tNAME2\t2e5\t.\t44\t55\t0\t3\t3,4,5\t4,5,6\tdata again!\n" // RGB = 0
-                        "III\t1001\t2000\tNAME3\t2e4\t.\t22\t23\t0,0,0\t3\t12,13,14,\t7,8,9,"; // additional comma
+                        "III\t1001\t2000\tNAME3\t2e4\t.\t22\t23\t0,0,0\t3\t12,13,14,\t7,8,9,\n"; // additional comma
 
     // Iterator to use
     DirectionIterator<String<char>, Input>::Type iter = directionIterator(test, Input());
@@ -235,7 +235,11 @@ SEQAN_DEFINE_TEST(test_bed_read_bed12_ucsc_compatibility)
 
     // Perform tests.
     readRecord(record, buffer, iter, seqan::Bed());
+
     readRecord(record, buffer, iter, seqan::Bed());
+    SEQAN_ASSERT(record.itemRgb == BedRgb(0,0,0));
+    SEQAN_ASSERT_EQ(record.data, "data again!");
+
     readRecord(record, buffer, iter, seqan::Bed());
 }
 


### PR DESCRIPTION
This PR adds compatibility for BED12 files:
- allow additional comma at the end of _blockSizes_ and _blockStart_
- allow RGB field to contain a single `0`, which is interpreted as 0,0,0
- fix newline problems: Two lines were skipped, if there was no additional text after the 12th column.