### PR TITLE
[FIX-#2360] Initialization of iterators over empty graphs

### DIFF
--- a/include/seqan/graph_types/graph_iterator_edge.h
+++ b/include/seqan/graph_types/graph_iterator_edge.h
@@ -86,9 +86,13 @@ public:
 
     Iter(TGraph const& _graph) :
         data_vertex_it(_graph),
-        data_edge_it(_graph, getIdLowerBound(_getVertexIdManager(_graph)))  ,
         data_first_slot()
     {
+        if (numVertices(_graph) != 0)
+            data_edge_it = TOutEdgeIterator_(_graph, getIdLowerBound(_getVertexIdManager(_graph)));
+        else
+            data_edge_it = TOutEdgeIterator_();
+
         while((atEnd(data_edge_it)) && (!atEnd(data_vertex_it)))
         {
                 goNext(data_vertex_it);

--- a/include/seqan/graph_types/graph_iterator_outedge.h
+++ b/include/seqan/graph_types/graph_iterator_outedge.h
@@ -92,8 +92,10 @@ public:
     Iter(TGraph_ const& _graph, TVertexDescriptor_ const v) :
         data_host(&_graph),
         data_source(v),
-        data_edge(getValue(_graph.data_vertex,v))
+        data_edge()
     {
+        if (!empty(_graph.data_vertex))
+            data_edge = getValue(_graph.data_vertex, v);
     }
 
     Iter(Iter const& _iter) :
@@ -155,8 +157,10 @@ public:
     Iter(TGraph const& _graph, TVertexDescriptor const v) :
         data_host(&_graph),
         data_source(v),
-        data_edge(getValue(_graph.data_vertex,v))
+        data_edge()
     {
+        if (!empty(_graph.data_vertex))
+            data_edge = getValue(_graph.data_vertex, v);
     }
 
     Iter(Iter const& _iter) :
@@ -218,8 +222,10 @@ public:
     Iter(TGraph const& _graph, TVertexDescriptor const v) :
         data_host(&_graph),
         data_source(v),
-        data_edge(getValue(_graph.data_vertex,v))
+        data_edge()
     {
+        if (!empty(_graph.data_vertex))
+            data_edge = getValue(_graph.data_vertex, v);
     }
 
     Iter(Iter const& _iter) :
@@ -289,9 +295,9 @@ public:
         TVertexDescriptor_ nilVal = getNil<TVertexDescriptor_>();
         TSize_ table_length = ValueSize<TAlphabet>::VALUE;
         TSize_ pos = 0;
-        while (    (pos < table_length) &&
-                (_graph.data_vertex[v].data_edge[pos].data_target == nilVal))
+        if (!empty(_graph.data_vertex))
         {
+            while (pos < table_length && _graph.data_vertex[v].data_edge[pos].data_target == nilVal)
                 ++pos;
         }
         data_pos = pos;
@@ -365,8 +371,10 @@ public:
     Iter(TGraph_ const& _graph, TVertexDescriptor_ const v) :
         data_host(&_graph),
         data_source(v),
-        data_edge(getValue(_graph.data_model.data_vertex,v))
+        data_edge()
     {
+        if (!empty(_graph.data_model.data_vertex))
+            data_edge = getValue(_graph.data_model.data_vertex, v);
     }
 
     Iter(Iter const& _iter) :

--- a/include/seqan/graph_types/graph_iterator_outedge.h
+++ b/include/seqan/graph_types/graph_iterator_outedge.h
@@ -94,8 +94,8 @@ public:
         data_source(v),
         data_edge()
     {
-        if (!empty(_graph.data_vertex))
-            data_edge = getValue(_graph.data_vertex, v);
+        SEQAN_ASSERT_LT_MSG(v, length(_graph.data_vertex), "Trying to access a vertex that does not exist.");
+        data_edge = getValue(_graph.data_vertex, v);
     }
 
     Iter(Iter const& _iter) :
@@ -105,7 +105,8 @@ public:
     {
     }
 
-    ~Iter() {
+    ~Iter()
+    {
     }
 
     Iter const&    operator = (Iter const & _other) {
@@ -159,8 +160,8 @@ public:
         data_source(v),
         data_edge()
     {
-        if (!empty(_graph.data_vertex))
-            data_edge = getValue(_graph.data_vertex, v);
+        SEQAN_ASSERT_LT_MSG(v, length(_graph.data_vertex), "Trying to access a vertex that does not exist.");
+        data_edge = getValue(_graph.data_vertex, v);
     }
 
     Iter(Iter const& _iter) :
@@ -170,7 +171,8 @@ public:
     {
     }
 
-    ~Iter() {
+    ~Iter()
+    {
     }
 
     Iter const&    operator = (Iter const & _other) {
@@ -224,8 +226,8 @@ public:
         data_source(v),
         data_edge()
     {
-        if (!empty(_graph.data_vertex))
-            data_edge = getValue(_graph.data_vertex, v);
+        SEQAN_ASSERT_LT_MSG(v, length(_graph.data_vertex), "Trying to access a vertex that does not exist.");
+        data_edge = getValue(_graph.data_vertex, v);
     }
 
     Iter(Iter const& _iter) :
@@ -235,7 +237,8 @@ public:
     {
     }
 
-    ~Iter() {
+    ~Iter()
+    {
     }
 
     Iter const&    operator = (Iter const & _other) {
@@ -295,11 +298,11 @@ public:
         TVertexDescriptor_ nilVal = getNil<TVertexDescriptor_>();
         TSize_ table_length = ValueSize<TAlphabet>::VALUE;
         TSize_ pos = 0;
-        if (!empty(_graph.data_vertex))
-        {
-            while (pos < table_length && _graph.data_vertex[v].data_edge[pos].data_target == nilVal)
-                ++pos;
-        }
+
+        SEQAN_ASSERT_LT_MSG(v, length(_graph.data_vertex), "Trying to access a vertex that does not exist.");
+        while (pos < table_length && _graph.data_vertex[v].data_edge[pos].data_target == nilVal)
+            ++pos;
+
         data_pos = pos;
         data_begin = pos;
         data_end = table_length;
@@ -373,8 +376,8 @@ public:
         data_source(v),
         data_edge()
     {
-        if (!empty(_graph.data_model.data_vertex))
-            data_edge = getValue(_graph.data_model.data_vertex, v);
+        SEQAN_ASSERT_LT_MSG(v, length(_graph.data_model.data_vertex), "Trying to access a vertex that does not exist.");
+        data_edge = getValue(_graph.data_model.data_vertex, v);
     }
 
     Iter(Iter const& _iter) :

--- a/tests/graph_types/test_graph_types_iterators.cpp
+++ b/tests/graph_types/test_graph_types_iterators.cpp
@@ -96,6 +96,10 @@ void Test_VertexIterator()
     goBegin(it2);
     SEQAN_ASSERT(it2 != it);
     SEQAN_ASSERT(&hostGraph(it) == &g);
+
+    TGraph emptyGraph;
+    TVertexIterator emptyVertexIter(emptyGraph);
+    SEQAN_ASSERT(atEnd(emptyVertexIter) == true);
 }
 
 void Test_TreeInternalVertexIterator()
@@ -131,6 +135,10 @@ void Test_TreeInternalVertexIterator()
     itV--;
     SEQAN_ASSERT(getValue(itV) == 0);
     SEQAN_ASSERT(atBegin(itV) == true);
+
+    TTree emptyTree;
+    TVertexIterator emptyVertexIter(emptyTree);
+    SEQAN_ASSERT(atEnd(emptyVertexIter) == true);
 }
 
 template <typename TGraphType>
@@ -277,6 +285,10 @@ void Test_EdgeIterator()
     goBegin(it2);
     SEQAN_ASSERT(it2 != it);
     SEQAN_ASSERT(&hostGraph(it) == &g);
+
+    TGraph emptyGraph;
+    TEdgeIterator emptyEdgeIter(emptyGraph);
+    SEQAN_ASSERT(atEnd(emptyEdgeIter) == true);
 }
 
 template <typename TGraphType>


### PR DESCRIPTION
Solves a problem (#2360) with Graph Iterators, when initialized with an empty graph. 

The constructor checks, whether the vertex string is not empty before accessing the first vertex. Furthermore, the iterator of an empty graph must be always in the condition _atEnd_. 

fixes #2360 