### PR TITLE
[FIX] Fixes option condition so that yara works in KNIME again.

### DIFF
--- a/apps/yara/CMakeLists.txt
+++ b/apps/yara/CMakeLists.txt
@@ -46,7 +46,7 @@ endif (NOT BZIP2_FOUND)
 # App-Level Configuration
 # ----------------------------------------------------------------------------
 
-set (SEQAN_APP_VERSION "1.0.2")
+set (SEQAN_APP_VERSION "1.0.3")
 
 option (YARA_LARGE_CONTIGS "Set to OFF to disable support for more than 32k contigs or contigs longer than 4Gbp." ON)
 if (YARA_LARGE_CONTIGS AND NOT SEQAN_TRAVIS_BUILD)

--- a/apps/yara/mapper.cpp
+++ b/apps/yara/mapper.cpp
@@ -179,7 +179,6 @@ void setupArgumentParser(ArgumentParser & parser, Options const & options)
                                                           ArgParseOption::INTEGER));
     setMinValue(parser, "strata-rate", "0");
     setMaxValue(parser, "strata-rate", "10");
-    setDefaultValue(parser, "strata-rate", 100.0 * options.strataRate);
 
     addOption(parser, ArgParseOption("sc", "strata-count", "Consider suboptimal alignments within this absolute number \
                                       of errors from the optimal alignment. Increase this threshold to increase \
@@ -187,7 +186,6 @@ void setupArgumentParser(ArgumentParser & parser, Options const & options)
                                                           ArgParseOption::INTEGER));
     setMinValue(parser, "strata-count", "0");
     setMaxValue(parser, "strata-count", "127");
-    setDefaultValue(parser, "strata-count", 0);
 
     addOption(parser, ArgParseOption("y", "sensitivity", "Sensitivity with respect to edit distance. \
                                                           Full sensitivity guarantees to find all considered alignments \


### PR DESCRIPTION
With the latest version of yara, the  mapper cannot be executed within KNIME anymore.
The reason is a subtle difference in the usage of default values between the argument parser and the GKN. 
The GKN sets the default values stored in the CTD as input parameters for the tool execution. But the argument parser differentiates whether an option was set or defaulted. So while it works for the command line in KNIME the check whether both options strata-count and strata-rate were set causes an abort, even though they were intialized with their default values.

Despite this issue, I think there is a general flaw in the usage of the default values here.
Both strata-rate and strata-count are initialized with default values, 0 in particular. But for the strata-count the default value is never read, because it only tests if an option was set from the user. Second, the semantic of using the default values or setting the default values explicitly by the user differs. The first works the second causes an abort. 
So I simply remove the default values from both options and everthing should work as expected.