### PR TITLE
Move the include files to outside the seqan namespace.

### DIFF
--- a/include/seqan/find/find_base.h
+++ b/include/seqan/find/find_base.h
@@ -244,19 +244,12 @@ struct Needle<Segment<THost, TSpec> const>
  * The following example shows how to restart a search from the beginning of a
  * text.
  *
- * @code{.cpp}
- * CharString hstck = "I spy with my little eye something that is yellow";
- * Finder<CharString> finder(hstck);
+ * @include demos/dox/find/finder_online.cpp
  *
- * Pattern<CharString, Horspool> p1("y");
- * findAll(finder, p1);
+ * The output is as follows:
  *
- * goBegin(finder);    // move Finder to the beginning of the text
- * clear(finder);      // reset Finder
- *
- * Pattern<CharString, Horspool> p2("t");
- * findAll(finder, p2);
- * @endcode
+ * @include demos/dox/find/finder_online.cpp.stdout
+ * 
  * Demo: Demo.Index Finder StringSet
  *
  * Demo: Demo.Index Finder

--- a/include/seqan/misc/terminal.h
+++ b/include/seqan/misc/terminal.h
@@ -41,6 +41,14 @@
 
 #include <seqan/platform.h>
 
+#if defined(STDLIB_VS)
+#include <io.h>
+#include <Windows.h>
+#else
+#include <unistd.h>
+#include <sys/ioctl.h>
+#endif  // defined(STDLIB_VS)
+
 namespace seqan {
 
 // ============================================================================
@@ -78,8 +86,6 @@ namespace seqan {
 
 #if defined(STDLIB_VS)
 
-#include <io.h>
-
 inline bool isTerminal()
 {
     return false;  // Windows does not understand ANSI codes.
@@ -88,8 +94,6 @@ inline bool isTerminal()
 #endif  // #if defined(STDLIB_VS)
 
 #if !defined(STDLIB_VS)
-
-#include <unistd.h>
 
 inline bool isTerminal()
 {
@@ -171,8 +175,6 @@ inline bool isAnsiColorTerminal()
 
 #if defined(STDLIB_VS)
 
-#include <Windows.h>
-
 // NOTE: cols actually is the buffer size :(
 inline bool getTerminalSize(unsigned & cols, unsigned & rows)
 {
@@ -190,9 +192,6 @@ inline bool getTerminalSize(unsigned & cols, unsigned & rows)
 #endif  // #if defined(STDLIB_VS)
 
 #if !defined(STDLIB_VS)
-
-#include <sys/ioctl.h>
-#include <unistd.h>
 
 inline bool getTerminalSize(unsigned & cols, unsigned & rows)
 {


### PR DESCRIPTION
This fixes an issue with the terminal sizing in argument parsers when porting apps from seqan2 to seqan3. 