### PR TITLE
[FIX] Add missing wrapper interfaces for accelerated alignment with trace

### DIFF
--- a/include/seqan/align/global_alignment_banded.h
+++ b/include/seqan/align/global_alignment_banded.h
@@ -655,13 +655,17 @@ String<TScoreValue> globalAlignmentScore(TString const & stringH,
 // Function globalAlignment()              [banded, SIMD version, GapsH, GapsV]
 // ----------------------------------------------------------------------------
 
-template <typename TGapSequenceH, typename TSetSpecH,
-typename TGapSequenceV, typename TSetSpecV,
-typename TScoreValue, typename TScoreSpec,
-bool TOP, bool LEFT, bool RIGHT, bool BOTTOM, typename TACSpec, typename TAlgoTag>
-inline auto
-globalAlignment(StringSet<TGapSequenceH, TSetSpecH> & gapSeqSetH,
-                StringSet<TGapSequenceV, TSetSpecV> & gapSeqSetV,
+template <typename TSeqH,
+          typename TSeqV,
+          typename TScoreValue, typename TScoreSpec,
+          bool TOP, bool LEFT, bool RIGHT, bool BOTTOM, typename TACSpec,
+          typename TAlgoTag>
+SEQAN_FUNC_ENABLE_IF(And<And<Is<ContainerConcept<TSeqH>>, Is<ContainerConcept<typename Value<TSeqH>::Type>>>,
+                         And<Is<ContainerConcept<TSeqV>>, Is<ContainerConcept<typename Value<TSeqV>::Type>>>
+                        >,
+                     String<TScoreValue>)
+globalAlignment(TSeqH & gapSeqSetH,
+                TSeqV & gapSeqSetV,
                 Score<TScoreValue, TScoreSpec> const & scoringScheme,
                 AlignConfig<TOP, LEFT, RIGHT, BOTTOM, TACSpec> const & /*alignConfig*/,
                 int const lowerDiag,
@@ -674,6 +678,71 @@ globalAlignment(StringSet<TGapSequenceH, TSetSpecH> & gapSeqSetH,
     typedef typename SubstituteAlgoTag_<TAlgoTag>::Type                 TGapModel;
 
     return _alignWrapper(gapSeqSetH, gapSeqSetV, scoringScheme, TAlignConfig2(lowerDiag, upperDiag), TGapModel());
+}
+
+// Interface without AlignConfig<>.
+template <typename TSeqH,
+          typename TSeqV,
+          typename TScoreValue, typename TScoreSpec,
+          typename TAlgoTag>
+SEQAN_FUNC_ENABLE_IF(And<And<Is<ContainerConcept<TSeqH>>, Is<ContainerConcept<typename Value<TSeqH>::Type>>>,
+                         And<Is<ContainerConcept<TSeqV>>, Is<ContainerConcept<typename Value<TSeqV>::Type>>>
+                        >,
+                     String<TScoreValue>)
+globalAlignment(TSeqH & gapSeqSetH,
+                TSeqV & gapSeqSetV,
+                Score<TScoreValue, TScoreSpec> const & scoringScheme,
+                int const lowerDiag,
+                int const upperDiag,
+                TAlgoTag const & algoTag)
+{
+    AlignConfig<> alignConfig;
+    return globalAlignment(gapSeqSetH, gapSeqSetV, scoringScheme, alignConfig, lowerDiag, upperDiag, algoTag);
+}
+
+// Interface without algorithm tag.
+template <typename TSeqH,
+          typename TSeqV,
+          typename TScoreValue, typename TScoreSpec,
+          bool TOP, bool LEFT, bool RIGHT, bool BOTTOM, typename TACSpec>
+SEQAN_FUNC_ENABLE_IF(And<And<Is<ContainerConcept<TSeqH>>, Is<ContainerConcept<typename Value<TSeqH>::Type>>>,
+                         And<Is<ContainerConcept<TSeqV>>, Is<ContainerConcept<typename Value<TSeqV>::Type>>>
+                        >,
+                     String<TScoreValue>)
+globalAlignment(TSeqH & gapSeqSetH,
+                TSeqV & gapSeqSetV,
+                Score<TScoreValue, TScoreSpec> const & scoringScheme,
+                AlignConfig<TOP, LEFT, RIGHT, BOTTOM, TACSpec> const & alignConfig,
+                int const lowerDiag,
+                int const upperDiag)
+{
+    if (scoreGapOpen(scoringScheme) == scoreGapExtend(scoringScheme))
+    {
+        return globalAlignment(gapSeqSetH, gapSeqSetV, scoringScheme, alignConfig, lowerDiag, upperDiag,
+                               NeedlemanWunsch());
+    }
+    else
+    {
+        return globalAlignment(gapSeqSetH, gapSeqSetV, scoringScheme, alignConfig, lowerDiag, upperDiag, Gotoh());
+    }
+}
+
+// Interface without AlignConfig<> and algorithm tag.
+template <typename TSeqH,
+          typename TSeqV,
+          typename TScoreValue, typename TScoreSpec>
+SEQAN_FUNC_ENABLE_IF(And<And<Is<ContainerConcept<TSeqH>>, Is<ContainerConcept<typename Value<TSeqH>::Type>>>,
+                         And<Is<ContainerConcept<TSeqV>>, Is<ContainerConcept<typename Value<TSeqV>::Type>>>
+                        >,
+                     String<TScoreValue>)
+globalAlignment(TSeqH & gapSeqSetH,
+                TSeqV & gapSeqSetV,
+                Score<TScoreValue, TScoreSpec> const & scoringScheme,
+                int const lowerDiag,
+                int const upperDiag)
+{
+    AlignConfig<> alignConfig;
+    return globalAlignment(gapSeqSetH, gapSeqSetV, scoringScheme, alignConfig, lowerDiag, upperDiag);
 }
 
 // ----------------------------------------------------------------------------

--- a/include/seqan/align/global_alignment_unbanded.h
+++ b/include/seqan/align/global_alignment_unbanded.h
@@ -742,14 +742,17 @@ String<TScoreValue> globalAlignmentScore(TString1 const & stringH,
 // Function globalAlignment()            [unbanded, SIMD version, GapsH, GapsV]
 // ----------------------------------------------------------------------------
 
-template <typename TSequenceH, typename TGapsSpecH, typename TSetSpecH,
-          typename TSequenceV, typename TGapsSpecV, typename TSetSpecV,
+template <typename TSeqH,
+          typename TSeqV,
           typename TScoreValue, typename TScoreSpec,
           bool TOP, bool LEFT, bool RIGHT, bool BOTTOM, typename TACSpec,
           typename TAlgoTag>
-inline auto
-globalAlignment(StringSet<Gaps<TSequenceH, TGapsSpecH>, TSetSpecH> & gapSeqSetH,
-                StringSet<Gaps<TSequenceV, TGapsSpecV>, TSetSpecV> & gapSeqSetV,
+SEQAN_FUNC_ENABLE_IF(And<And<Is<ContainerConcept<TSeqH>>, Is<ContainerConcept<typename Value<TSeqH>::Type>>>,
+                         And<Is<ContainerConcept<TSeqV>>, Is<ContainerConcept<typename Value<TSeqV>::Type>>>
+                        >,
+                      String<TScoreValue>)
+globalAlignment(TSeqH & gapSeqSetH,
+                TSeqV & gapSeqSetV,
                 Score<TScoreValue, TScoreSpec> const & scoringScheme,
                 AlignConfig<TOP, LEFT, RIGHT, BOTTOM, TACSpec> const & /*alignConfig*/,
                 TAlgoTag const & /*algoTag*/)
@@ -763,14 +766,18 @@ globalAlignment(StringSet<Gaps<TSequenceH, TGapsSpecH>, TSetSpecH> & gapSeqSetH,
 }
 
 // Interface without algorithm tag.
-template <typename TSequenceH, typename TGapsSpecH, typename TSetSpecH,
-          typename TSequenceV, typename TGapsSpecV, typename TSetSpecV,
+template <typename TSeqH,
+          typename TSeqV,
           typename TScoreValue, typename TScoreSpec,
           bool TOP, bool LEFT, bool RIGHT, bool BOTTOM, typename TACSpec>
-String<TScoreValue> globalAlignment(StringSet<Gaps<TSequenceH, TGapsSpecH>, TSetSpecH> & gapSeqSetH,
-                                    StringSet<Gaps<TSequenceV, TGapsSpecV>, TSetSpecV> & gapSeqSetV,
-                                    Score<TScoreValue, TScoreSpec> const & scoringScheme,
-                                    AlignConfig<TOP, LEFT, RIGHT, BOTTOM, TACSpec> const & alignConfig)
+SEQAN_FUNC_ENABLE_IF(And<And<Is<ContainerConcept<TSeqH>>, Is<ContainerConcept<typename Value<TSeqH>::Type>>>,
+                         And<Is<ContainerConcept<TSeqV>>, Is<ContainerConcept<typename Value<TSeqV>::Type>>>
+                        >,
+                     String<TScoreValue>)
+globalAlignment(TSeqH & gapSeqSetH,
+                TSeqV & gapSeqSetV,
+                Score<TScoreValue, TScoreSpec> const & scoringScheme,
+                AlignConfig<TOP, LEFT, RIGHT, BOTTOM, TACSpec> const & alignConfig)
 {
     if (scoreGapOpen(scoringScheme) == scoreGapExtend(scoringScheme))
         return globalAlignment(gapSeqSetH, gapSeqSetV, scoringScheme, alignConfig, NeedlemanWunsch());
@@ -779,12 +786,16 @@ String<TScoreValue> globalAlignment(StringSet<Gaps<TSequenceH, TGapsSpecH>, TSet
 }
 
 // Interface without AlignConfig<> and algorithm tag.
-template <typename TSequenceH, typename TGapsSpecH, typename TSetSpecH,
-          typename TSequenceV, typename TGapsSpecV, typename TSetSpecV,
+template <typename TSeqH,
+          typename TSeqV,
           typename TScoreValue, typename TScoreSpec>
-String<TScoreValue> globalAlignment(StringSet<Gaps<TSequenceH, TGapsSpecH>, TSetSpecH> & gapSeqSetH,
-                                    StringSet<Gaps<TSequenceV, TGapsSpecV>, TSetSpecV> & gapSeqSetV,
-                                    Score<TScoreValue, TScoreSpec> const & scoringScheme)
+SEQAN_FUNC_ENABLE_IF(And<And<Is<ContainerConcept<TSeqH>>, Is<ContainerConcept<typename Value<TSeqH>::Type>>>,
+                         And<Is<ContainerConcept<TSeqV>>, Is<ContainerConcept<typename Value<TSeqV>::Type>>>
+                        >,
+                     String<TScoreValue>)
+globalAlignment(TSeqH & gapSeqSetH,
+                TSeqV & gapSeqSetV,
+                Score<TScoreValue, TScoreSpec> const & scoringScheme)
 {
     AlignConfig<> alignConfig;
     return globalAlignment(gapSeqSetH, gapSeqSetV, scoringScheme, alignConfig);

--- a/include/seqan/align/local_alignment_banded.h
+++ b/include/seqan/align/local_alignment_banded.h
@@ -232,13 +232,15 @@ TScoreValue localAlignment(String<Fragment<TSize, TFragmentSpec>, TStringSpec> &
 // Function localAlignment()               [banded, SIMD version, GapsH, GapsV]
 // ----------------------------------------------------------------------------
 
-template <typename TGapSequenceH, typename TSetSpecH,
-          typename TGapSequenceV, typename TSetSpecV,
+template <typename TSequenceH,
+          typename TSequenceV,
           typename TScoreValue, typename TScoreSpec,
           typename TAlgoTag>
-inline auto
-localAlignment(StringSet<TGapSequenceH, TSetSpecH> & gapSeqSetH,
-               StringSet<TGapSequenceV, TSetSpecV> & gapSeqSetV,
+SEQAN_FUNC_ENABLE_IF(And<And<Is<ContainerConcept<TSequenceH>>, Is<ContainerConcept<typename Value<TSequenceH>::Type>>>,
+                         And<Is<ContainerConcept<TSequenceV>>, Is<ContainerConcept<typename Value<TSequenceV>::Type>>>
+                        >, String<TScoreValue>)
+localAlignment(TSequenceH & gapSeqSetH,
+               TSequenceV & gapSeqSetV,
                Score<TScoreValue, TScoreSpec> const & scoringScheme,
                int const lowerDiag,
                int const upperDiag,
@@ -248,6 +250,24 @@ localAlignment(StringSet<TGapSequenceH, TSetSpecH> & gapSeqSetH,
     typedef typename SubstituteAlgoTag_<TAlgoTag>::Type                     TGapModel;
 
     return _alignWrapper(gapSeqSetH, gapSeqSetV, scoringScheme, TAlignConfig2(lowerDiag, upperDiag), TGapModel());
+}
+
+template <typename TSequenceH,
+          typename TSequenceV,
+          typename TScoreValue, typename TScoreSpec>
+SEQAN_FUNC_ENABLE_IF(And<And<Is<ContainerConcept<TSequenceH>>, Is<ContainerConcept<typename Value<TSequenceH>::Type>>>,
+                         And<Is<ContainerConcept<TSequenceV>>, Is<ContainerConcept<typename Value<TSequenceV>::Type>>>
+                        >, String<TScoreValue>)
+localAlignment(TSequenceH & gapSeqSetH,
+               TSequenceV & gapSeqSetV,
+               Score<TScoreValue, TScoreSpec> const & scoringScheme,
+               int const lowerDiag,
+               int const upperDiag)
+{
+    if (_usesAffineGaps(scoringScheme, source(gapSeqSetH[0]), source(gapSeqSetV[0])))
+         return localAlignment(gapSeqSetH, gapSeqSetV, scoringScheme, lowerDiag, upperDiag, AffineGaps());
+    else
+         return localAlignment(gapSeqSetH, gapSeqSetV, scoringScheme, lowerDiag, upperDiag, LinearGaps());
 }
 
 // ----------------------------------------------------------------------------

--- a/include/seqan/align/local_alignment_unbanded.h
+++ b/include/seqan/align/local_alignment_unbanded.h
@@ -320,13 +320,15 @@ TScoreValue localAlignment(String<Fragment<TSize, TFragmentSpec>, TStringSpec> &
 // Function localAlignment()             [unbanded, SIMD version, GapsH, GapsV]
 // ----------------------------------------------------------------------------
 
-template <typename TGapSequenceH, typename TSetSpecH,
-          typename TGapSequenceV, typename TSetSpecV,
+template <typename TSequenceH,
+          typename TSequenceV,
           typename TScoreValue, typename TScoreSpec,
           typename TAlgoTag>
-inline auto
-localAlignment(StringSet<TGapSequenceH, TSetSpecH> & gapSeqSetH,
-               StringSet<TGapSequenceV, TSetSpecV> & gapSeqSetV,
+SEQAN_FUNC_ENABLE_IF(And<And<Is<ContainerConcept<TSequenceH>>, Is<ContainerConcept<typename Value<TSequenceH>::Type>>>,
+                         And<Is<ContainerConcept<TSequenceV>>, Is<ContainerConcept<typename Value<TSequenceV>::Type>>>
+                        >, String<TScoreValue>)
+localAlignment(TSequenceH & gapSeqSetH,
+               TSequenceV & gapSeqSetV,
                Score<TScoreValue, TScoreSpec> const & scoringScheme,
                TAlgoTag const & /*algoTag*/)
 {
@@ -334,6 +336,22 @@ localAlignment(StringSet<TGapSequenceH, TSetSpecH> & gapSeqSetH,
     typedef typename SubstituteAlgoTag_<TAlgoTag>::Type                      TGapModel;
 
     return _alignWrapper(gapSeqSetH, gapSeqSetV, scoringScheme, TAlignConfig2(), TGapModel());
+}
+
+template <typename TSequenceH,
+          typename TSequenceV,
+          typename TScoreValue, typename TScoreSpec>
+SEQAN_FUNC_ENABLE_IF(And<And<Is<ContainerConcept<TSequenceH>>, Is<ContainerConcept<typename Value<TSequenceH>::Type>>>,
+                         And<Is<ContainerConcept<TSequenceV>>, Is<ContainerConcept<typename Value<TSequenceV>::Type>>>
+                        >, String<TScoreValue>)
+localAlignment(TSequenceH & gapSeqSetH,
+               TSequenceV & gapSeqSetV,
+               Score<TScoreValue, TScoreSpec> const & scoringScheme)
+{
+   if (_usesAffineGaps(scoringScheme, source(gapSeqSetH[0]), source(gapSeqSetV[0])))
+        return localAlignment(gapSeqSetH, gapSeqSetV, scoringScheme, AffineGaps());
+   else
+        return localAlignment(gapSeqSetH, gapSeqSetV, scoringScheme, LinearGaps());
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Currently there are no wrapper interfaces for the accelerated alignment with trace. This fixes it now.