### PR TITLE
[FIX] warnings on gcc9

### DIFF
--- a/apps/rep_sep/rgraph_base.h
+++ b/apps/rep_sep/rgraph_base.h
@@ -41,11 +41,8 @@ struct GraphCargo {
     TColumns spanned_columns;
 
     GraphCargo() {}
-    GraphCargo(GraphCargo const& other) 
-    {
-        alignedRead = other.alignedRead;
-        spanned_columns = other.spanned_columns;
-    }
+    GraphCargo(GraphCargo const&) = default;
+    GraphCargo & operator=(GraphCargo const&) = default;
 };
 
 //////////////////////////////////////////////////////////////////////////////

--- a/include/seqan/align/align_base.h
+++ b/include/seqan/align/align_base.h
@@ -101,11 +101,9 @@ public:
         setStrings(*this, stringset);
     }
 
-    Align & operator=(Align const & other)
-    {
-        data_rows = other.data_rows;
-        return *this;
-    }
+    Align(Align const &) = default;
+
+    Align & operator=(Align const & other) = default;
 };
 
 // ============================================================================

--- a/include/seqan/align/gaps_iterator_anchor.h
+++ b/include/seqan/align/gaps_iterator_anchor.h
@@ -109,18 +109,9 @@ public:
     {
     }
 
-    Iter const & operator = (Iter const & other_)
-    {
-        data_container = other_.data_container;
-        seqLength = other_.seqLength;
-        current = other_.current;
-        prevAnchor = other_.prevAnchor;
-        nextAnchor = other_.nextAnchor;
-        anchorIdx = other_.anchorIdx;
-        viewBegin = other_.viewBegin;
-        viewEnd = other_.viewEnd;
-        return *this;
-    }
+    Iter(Iter const &) = default;
+
+    Iter & operator = (Iter const &) = default;
 };
 
 // ============================================================================

--- a/include/seqan/align/gaps_iterator_array.h
+++ b/include/seqan/align/gaps_iterator_array.h
@@ -88,10 +88,9 @@ public:
     {}
 
     // Copy constructor, required since we specify the one with complemented const below.
-    Iter(Iter const & other) :
-            _container(other._container), _bucketIndex(other._bucketIndex), _bucketOffset(other._bucketOffset),
-            _sourcePosition(other._sourcePosition), _unclippedViewPosition(other._unclippedViewPosition)
-    {}
+    Iter(Iter const & other) = default;
+
+    Iter & operator=(Iter const &) = default;
 
     // Copy construtor for iterator -> const iterator conversion.
     // TODO(holtgrew): Think of something smarter, to restrict source types?

--- a/include/seqan/basic/iterator_counting.h
+++ b/include/seqan/basic/iterator_counting.h
@@ -71,9 +71,9 @@ public:
         data_position(position)
     {}
 
-    Iter(Iter const & other) :
-        data_position(other.data_position)
-    {}
+    Iter(Iter const &) = default;
+
+    Iter & operator=(Iter const &) = default;
 };
 
 // ============================================================================

--- a/include/seqan/basic/iterator_position.h
+++ b/include/seqan/basic/iterator_position.h
@@ -107,6 +107,8 @@ public:
         data_container(other_.data_container)
     {}
 
+    Iter & operator=(Iter const &) = default;
+
     template <typename TContainer2, typename TSpec2>
     Iter(Iter<TContainer2, TSpec2> const & other_) :
         TBase(position(other_)),

--- a/include/seqan/basic/triple_packed.h
+++ b/include/seqan/basic/triple_packed.h
@@ -79,8 +79,9 @@ struct Triple<T1, T2, T3, Pack>
 
     inline Triple() : i1(T1()), i2(T2()), i3(T3()) {}
 
-    inline Triple(Triple const &_p)
-            : i1(_p.i1), i2(_p.i2), i3(_p.i3) {}
+    inline Triple(Triple const &) = default;
+
+    inline Triple & operator=(Triple const &) = default;
 
     inline Triple(T1 const &_i1, T2 const &_i2, T3 const &_i3)
             : i1(_i1), i2(_i2), i3(_i3) {}
@@ -88,6 +89,14 @@ struct Triple<T1, T2, T3, Pack>
     template <typename T1_, typename T2_, typename T3_, typename TSpec__>
     inline Triple(Triple<T1_, T2_, T3_, TSpec__> const & _p)
             : i1(getValueI1(_p)), i2(getValueI2(_p)), i3(getValueI3(_p)) {}
+
+    template <typename T1_, typename T2_, typename T3_, typename TSpec__>
+    inline Triple & operator=(Triple<T1_, T2_, T3_, TSpec__> const & _p)
+    {
+        i1 = getValueI1(_p);
+        i2 = getValueI2(_p);
+        i3 = getValueI3(_p);
+    }
 };
 #pragma pack(pop)
 

--- a/include/seqan/find/find_myers_ukkonen.h
+++ b/include/seqan/find/find_myers_ukkonen.h
@@ -213,7 +213,7 @@ struct MyersSmallState_<TNeedle, AlignTextBanded<TSpec, TFinderCSP, TPatternCSP>
 #endif
     typedef typename Value<TNeedle>::Type TValue;
 
-    TWord bitMasks[ValueSize<TValue>::VALUE];
+    TWord bitMasks[ValueSize<TValue>::VALUE + 1];
     TWord VP0;                    // VP[0] (saves one dereferentiation)
     TWord VN0;                    // VN[0]
     unsigned short errors;      // the current number of errors

--- a/include/seqan/index/index_esa_base.h
+++ b/include/seqan/index/index_esa_base.h
@@ -218,10 +218,10 @@ namespace seqan
             range(otherRange),
             parentRight(otherParentRight) {}
 
-       
-        VertexEsa(VertexEsa const &other):
-            range(other.range),
-            parentRight(other.parentRight) {}
+
+        VertexEsa(VertexEsa const &other) = default;
+
+        VertexEsa & operator=(VertexEsa const &) = default;
     };
 
     template <typename TSize>
@@ -416,25 +416,9 @@ namespace seqan
 
         Index() {}
 
-        Index(Index &other):
-            text(other.text),
-            sa(other.sa),
-            isa(other.isa),
-            lcp(other.lcp),
-            lcpe(other.lcpe),
-            childtab(other.childtab),
-            bwt(other.bwt),
-            cargo(other.cargo) {}
+        Index(Index const &other) = default;
 
-        Index(Index const &other):
-            text(other.text),
-            sa(other.sa),
-            isa(other.isa),
-            lcp(other.lcp),
-            lcpe(other.lcpe),
-            childtab(other.childtab),
-            bwt(other.bwt),
-            cargo(other.cargo) {}
+        Index & operator=(Index const &) = default;
 
         template <typename TText_>
         Index(TText_ &_text):

--- a/include/seqan/index/index_fm_stree.h
+++ b/include/seqan/index/index_fm_stree.h
@@ -66,6 +66,8 @@ struct HistoryStackFM_
         lastChar(_lastChar)
     {}
 
+    HistoryStackFM_(HistoryStackFM_ const &) = default;
+
     HistoryStackFM_ const &
     operator=(HistoryStackFM_ const & _origin)
     {

--- a/include/seqan/index/index_qgram.h
+++ b/include/seqan/index/index_qgram.h
@@ -275,15 +275,9 @@ public:
     cargo(other.cargo),
     stepSize(1) {}
 
-    Index(Index const &other):
-    text(other.text),
-    sa(other.sa),
-    dir(other.dir),
-    counts(other.counts),
-    countsDir(other.countsDir),
-    shape(other.shape),
-    cargo(other.cargo),
-    stepSize(1) {}
+    Index(Index const &other) = default;
+
+    Index & operator=(Index const &) = default;
 
     template <typename TText__>
     Index(TText__ &_text):

--- a/include/seqan/index/index_qgram_openaddressing.h
+++ b/include/seqan/index/index_qgram_openaddressing.h
@@ -140,17 +140,9 @@ namespace seqan
             stepSize(1),
             alpha(defaultAlpha) {}
 
-        Index(Index const &other):
-            text(other.text),
-            sa(other.sa),
-            dir(other.dir),
-            counts(other.counts),
-            countsDir(other.countsDir),
-            shape(other.shape),
-            cargo(other.cargo),
-            bucketMap(other.bucketMap),
-            stepSize(1),
-            alpha(defaultAlpha) {}
+        Index(Index const &other) = default;
+
+        Index & operator=(Index const &) = default;
 
         template <typename TText_>
         Index(TText_ &_text):

--- a/include/seqan/index/index_sa_stree.h
+++ b/include/seqan/index/index_sa_stree.h
@@ -80,15 +80,11 @@ public:
 
     Index() {}
 
-    Index(Index & other) :
-        text(other.text),
-        sa(other.sa)
-    {}
+    Index(Index & other) = default;
 
-    Index(Index const & other) :
-        text(other.text),
-        sa(other.sa)
-    {}
+    Index(Index const & other) = default;
+
+    Index & operator=(Index const &) = default;
 
     template <typename TText_>
     Index(TText_ & _text) :
@@ -136,6 +132,8 @@ struct VertexSA : public VertexEsa<TSize>
         repLen(other.repLen),
         lastChar(other.lastChar)
     {}
+
+    VertexSA & operator=(VertexSA const &) = default;
 };
 
 template <typename TSize, typename TAlphabet>

--- a/include/seqan/index/shape_gapped.h
+++ b/include/seqan/index/shape_gapped.h
@@ -278,11 +278,7 @@ namespace seqan
             }
         }
 
-        Shape(Shape const &other):
-            span(other.span),
-            weight(other.weight),
-            diffs(other.diffs),
-            hValue(other.hValue) {}
+        Shape(Shape const &) = default;
 
         template <typename TSpec>
         Shape(Shape<TValue, TSpec> const &other)
@@ -303,6 +299,8 @@ namespace seqan
         }
 
 //____________________________________________________________________________
+
+        inline Shape & operator=(Shape const &) = default;
 
         template <unsigned q>
         inline Shape &

--- a/include/seqan/index/shape_onegapped.h
+++ b/include/seqan/index/shape_onegapped.h
@@ -104,14 +104,9 @@ namespace seqan
             factor2 = _intPow((THValue)ValueSize<TValue>::VALUE, blockLen2);
         }
 
-        Shape(Shape const &other):
-            blockLen1(other.blockLen1),
-            gapLen(other.gapLen),
-            blockLen2(other.blockLen2),
-            hValue(other.hValue),
-            leftChar(other.leftChar),
-            factor1(other.factor1),
-            factor2(other.factor2) {}
+        Shape(Shape const &other) = default;
+
+        Shape & operator=(Shape const &) = default;
 
         template <typename TSpec>
         Shape(Shape<TValue, TSpec> const &other) :

--- a/include/seqan/misc/interval_tree.h
+++ b/include/seqan/misc/interval_tree.h
@@ -285,12 +285,9 @@ public:
     {
     }
 
-    IntervalTreeNode(IntervalTreeNode const & other) :
-        center(other.center),
-        list1(other.list1),
-        list2(other.list2)
-    {
-    }
+    IntervalTreeNode(IntervalTreeNode const & other) = default;
+
+    IntervalTreeNode & operator=(IntervalTreeNode const &) = default;
 
 };
 

--- a/include/seqan/modifier/cyclic_shape.h
+++ b/include/seqan/modifier/cyclic_shape.h
@@ -200,9 +200,9 @@ public:
         appendValue(diffs, 1);
     }
 
-    CyclicShape(CyclicShape const & other) :
-        diffs(other.diffs), loffset(other.loffset), span(other.span)
-    {}
+    CyclicShape(CyclicShape const & other)  = default;
+
+    CyclicShape & operator=(CyclicShape const &) = default;
 };
 
 // --------------------------------------------------------------------------
@@ -285,8 +285,9 @@ public:
     CyclicShape()
     {}
 
-    CyclicShape(CyclicShape const &)
-    {}
+    CyclicShape(CyclicShape const &) = default;
+
+    CyclicShape & operator=(CyclicShape const &) = default;
 };
 
 // --------------------------------------------------------------------------

--- a/include/seqan/sequence/iter_concat_virtual.h
+++ b/include/seqan/sequence/iter_concat_virtual.h
@@ -107,8 +107,8 @@ public:
     typedef typename Difference<TString>::Type  difference_type;
     // ----------------------------------------------------------------------
 
-    TStringSet *    host;
-    unsigned        objNo;
+    TStringSet *    host{nullptr};
+    unsigned        objNo{0};
     obj_iterator    _begin, _cur, _end;
 
     Iter() {}

--- a/include/seqan/sequence/segment_infix.h
+++ b/include/seqan/sequence/segment_infix.h
@@ -139,6 +139,11 @@ public:
     {
     }
 
+    Segment(Segment const & source)
+    {
+        assign(*this, source);
+    }
+
     inline Segment &
     operator = (Segment const & source)
     {

--- a/include/seqan/sequence/segment_prefix.h
+++ b/include/seqan/sequence/segment_prefix.h
@@ -113,6 +113,11 @@ public:
         data_end_position(endPosition(_other))
     {}
 
+    Segment(Segment const & source)
+    {
+        assign(*this, source);
+    }
+
     inline Segment &
     operator = (Segment const & source)
     {

--- a/include/seqan/sequence/segment_suffix.h
+++ b/include/seqan/sequence/segment_suffix.h
@@ -125,6 +125,11 @@ public:
     {
     }
 
+    Segment(Segment const & source)
+    {
+        assign(*this, source);
+    }
+
     inline Segment &
     operator = (Segment const & source)
     {

--- a/include/seqan/sequence/string_packed.h
+++ b/include/seqan/sequence/string_packed.h
@@ -153,6 +153,11 @@ public:
         reserve(*this, capacity(source), Exact());
         assign(*this, source);
     }
+    String(String const & source)
+    {
+        reserve(*this, capacity(source), Exact());
+        assign(*this, source);
+    }
 
     template <typename TSource>
     String & operator =(TSource const & source)

--- a/include/seqan/store/store_annotation.h
+++ b/include/seqan/store/store_annotation.h
@@ -268,13 +268,8 @@ public:
         store(&_store),
         _id(TAnnotation::INVALID_ID) {}
 
-    inline Iter const &
-    operator = (Iter const &_origin)
-    {
-        store = &container(_origin);
-        _id = _origin._id;
-        return *this;
-    }
+    Iter(Iter const &) = default;
+    inline Iter & operator=(Iter const &_origin) = default;
 };
 
 //////////////////////////////////////////////////////////////////////////////

--- a/tests/modifier/helpers.h
+++ b/tests/modifier/helpers.h
@@ -44,8 +44,8 @@ struct CaesarChiffre : public std::unary_function<TArgChar, TResultChar>
     TArgChar _delta;
 
     CaesarChiffre() : _delta(0) {}
-    CaesarChiffre(CaesarChiffre &other) : _delta(other._delta) {}
-    CaesarChiffre(CaesarChiffre const &other) : _delta(other._delta) {}
+    CaesarChiffre(CaesarChiffre const &other) = default;
+    CaesarChiffre & operator=(CaesarChiffre const &) = default;
 
     CaesarChiffre(TArgChar delta) {
         if (delta < 0)

--- a/tests/sequence/test_sequence.h
+++ b/tests/sequence/test_sequence.h
@@ -71,6 +71,8 @@ struct CountingChar
         numConstruct += 1;
     }
 
+    CountingChar & operator=(CountingChar const &) = default;
+
     ~CountingChar()
     {
         numDeconstruct += 1;


### PR DESCRIPTION
GCC9 introduces new rules when implicitly defaulted copy constructor and copy assignment are valid.

If there is a user-provided copy constructor, the copy assignment has to be provided too, and vice versa.
Additionally, a user-provided destructor requires both copy constructor and assignment to be defined.

Violating this rule results in a `deprecated-copy` warning (e.g. when using `SeqFileIn`):
```
seqan/include/seqan/stream/guess_format.h:159:14: warning: implicitly-declared [COPYCTOR] is deprecated [-Wdeprecated-copy]
  159 |     TLowcase lowcaseFileName(fileName);

seqan/include/seqan/sequence/segment_prefix.h:117:5: note: because 'seqan::Segment<const char*, seqan::PrefixSegment>' has user-provided [COPYASSIGNMENT]
  117 |     operator = (Segment const & source)
```
Where COPYCTOR and COPYASSIGNMENT are the abbreviations of the usually issued full signatures. 

So in this case, we need to add `Segment(Segment const &) = default;`.