### PR TITLE
Small fixes for Lambda

### DIFF
--- a/include/seqan/align/evaluate_alignment.h
+++ b/include/seqan/align/evaluate_alignment.h
@@ -277,8 +277,8 @@ TScoreVal computeAlignmentStats(AlignmentStats & stats,
         if (!isGap(it0) && !isGap(it1))
         {
             // Compute the alignment score and register in stats.
-            TAlphabet c0 = *it0;
-            TAlphabet c1 = static_cast<TAlphabet>(*it1);
+            TAlphabet c0 = convert<TAlphabet>(*it0);
+            TAlphabet c1 = convert<TAlphabet>(*it1);
             TScoreVal scoreVal = score(scoringScheme, c0, c1);
             stats.alignmentScore += scoreVal;
             // Register other statistics.

--- a/include/seqan/blast/blast_io_context.h
+++ b/include/seqan/blast/blast_io_context.h
@@ -277,8 +277,6 @@ struct BlastIOContext
     TString _stringBuffer;
     StringSet<TString, Owner<ConcatDirect<>>> _setBuffer1;
     StringSet<TString, Owner<ConcatDirect<>>> _setBuffer2;
-    BlastMatch<> bufMatch;
-    BlastRecord<> bufRecord;
 };
 
 }


### PR DESCRIPTION
Two fixes:
  * the first uses explicit convert instead of static_cast. Relevant because SeqAn2 concepts only require that convert is available and not that a gapped alphabet is actually cast-able to it's non-gapped version. When combining with SeqAn3 gapped alphabets, this breaks.
* Two unused buffers prevented comparability in certain situations.