### PR TITLE
[FIX] Fixes #2417: Difference between SIMD and serial local alignment

### DIFF
--- a/include/seqan/align/dp_formula.h
+++ b/include/seqan/align/dp_formula.h
@@ -104,6 +104,25 @@ typedef Tag<RecursionDirectionZero_> RecursionDirectionZero;
 template <typename TCellTuple>
 using ExtractedScoreValueType_ = std::decay_t<decltype(_scoreOfCell(std::get<0>(std::declval<TCellTuple>())))>;
 
+// A transformation trait to select the correct _maxScore overload for checking against 0 in local alignment.
+template <typename TTraceConfig>
+struct TraceConfigForLocalAlignment_
+{
+private:
+    // If not CompleteTrace then use same type.
+    template <typename TType>
+    static auto selectType(TType) -> TType;
+
+    // In last check of local alignment always invoke SingleTrace _maxScore overload.
+    template <typename TGapsPlacement>
+    static auto selectType(TracebackOn<TracebackConfig_<CompleteTrace, TGapsPlacement>>)
+        -> TracebackOn<TracebackConfig_<SingleTrace, TGapsPlacement>>;
+
+public:
+    // The modified type
+    using Type = decltype(selectType(TTraceConfig{}));
+};
+
 // ============================================================================
 // Functions
 // ============================================================================
@@ -248,12 +267,13 @@ _computeScore(DPCell_<TScoreValue, TGapCosts> & current,
 
     if (IsLocalAlignment_<TAlgorithm>::VALUE)
     {
+        using TMaxScorePolicy = typename TraceConfigForLocalAlignment_<TTracebackConfig>::Type;
         return _maxScore(_scoreOfCell(current),
                          TraceBitMap_<TScoreValue>::NONE,
                          _scoreOfCell(current),
                          TraceBitMap_<TScoreValue>::NONE,
                          TraceBitMap_<TScoreValue>::DIAGONAL,
-                         TTracebackConfig{});
+                         TMaxScorePolicy{});
     }
     else
     {

--- a/include/seqan/align/dp_formula_affine.h
+++ b/include/seqan/align/dp_formula_affine.h
@@ -112,12 +112,13 @@ _computeScore(DPCell_<TScoreValue, AffineGaps> & current,
                     TTracebackConfig{});
     if (IsLocalAlignment_<TAlgorithm>::VALUE)
     {
+        using TMaxScorePolicy = typename TraceConfigForLocalAlignment_<TTracebackConfig>::Type;
         tmp = _maxScore(_scoreOfCell(current),
                         TraceBitMap_<TScoreValue>::NONE,
                         _scoreOfCell(current),
                         TraceBitMap_<TScoreValue>::NONE,
                         tmp,
-                        TTracebackConfig{});
+                        TMaxScorePolicy{});
     }
     // Cache score for previous vertical.
     _scoreOfCell(previousVertical) = _scoreOfCell(current);
@@ -172,12 +173,13 @@ _computeScore(DPCell_<TScoreValue, AffineGaps> & current,
                    TTracebackConfig());
     if (IsLocalAlignment_<TAlgorithm>::VALUE)
     {
+        using TMaxScorePolicy = typename TraceConfigForLocalAlignment_<TTracebackConfig>::Type;
         tv = _maxScore(_scoreOfCell(current),
                        TraceBitMap_<TScoreValue>::NONE,
                        _scoreOfCell(current),
                        TraceBitMap_<TScoreValue>::NONE,
                        tv,
-                       TTracebackConfig{});
+                       TMaxScorePolicy{});
     }
     _scoreOfCell(previousVertical) = _scoreOfCell(current);
     return tv;
@@ -224,12 +226,13 @@ _computeScore(DPCell_<TScoreValue, AffineGaps> & current,
                    TTracebackConfig());
     if (IsLocalAlignment_<TAlgorithm>::VALUE)
     {
+        using TMaxScorePolicy = typename TraceConfigForLocalAlignment_<TTracebackConfig>::Type;
         tv = _maxScore(_scoreOfCell(current),
                        TraceBitMap_<TScoreValue>::NONE,
                        _scoreOfCell(current),
                        TraceBitMap_<TScoreValue>::NONE,
                        tv,
-                       TTracebackConfig{});
+                       TMaxScorePolicy{});
     }
     return tv;
 }
@@ -269,12 +272,13 @@ _computeScore(DPCell_<TScoreValue, AffineGaps> & current,
 
     if (IsLocalAlignment_<TAlgorithm>::VALUE)
     {
+        using TMaxScorePolicy = typename TraceConfigForLocalAlignment_<TTracebackConfig>::Type;
         traceDir = _maxScore(_scoreOfCell(current),
                              TraceBitMap_<TScoreValue>::NONE,
                              _scoreOfCell(current),
                              TraceBitMap_<TScoreValue>::NONE,
                              traceDir,
-                             TTracebackConfig{});
+                             TMaxScorePolicy{});
     }
     _scoreOfCell(previousVertical) = _scoreOfCell(current);
     return traceDir;
@@ -313,12 +317,13 @@ _computeScore(DPCell_<TScoreValue, AffineGaps> & current,
 
     if (IsLocalAlignment_<TAlgorithm>::VALUE)
     {
+        using TMaxScorePolicy = typename TraceConfigForLocalAlignment_<TTracebackConfig>::Type;
         traceDir = _maxScore(_scoreOfCell(current),
                              TraceBitMap_<TScoreValue>::NONE,
                              _scoreOfCell(current),
                              TraceBitMap_<TScoreValue>::NONE,
                              traceDir,
-                             TTracebackConfig{});
+                             TMaxScorePolicy{});
     }
     _scoreOfCell(previousVertical) = _scoreOfCell(current);
     return traceDir;

--- a/include/seqan/align/dp_formula_dynamic.h
+++ b/include/seqan/align/dp_formula_dynamic.h
@@ -454,12 +454,13 @@ _computeScore(DPCell_<TScoreValue, DynamicGaps> & activeCell,
 
     if (IsLocalAlignment_<TAlgorithm>::VALUE)
     {
+        using TMaxScorePolicy = typename TraceConfigForLocalAlignment_<TTracebackConfig>::Type;
         tvMax = _maxScore(_scoreOfCell(activeCell),
                           TraceBitMap_<TScoreValue>::NONE,
                           _scoreOfCell(activeCell),
                           TraceBitMap_<TScoreValue>::NONE,
                           tvMax,
-                          TTracebackConfig{});
+                          TMaxScorePolicy{});
     }
     previousVertical = activeCell;
     return tvMax;
@@ -500,12 +501,13 @@ _computeScore(DPCell_<TScoreValue, DynamicGaps> & activeCell,
 
     if (IsLocalAlignment_<TAlgorithm>::VALUE)
     {
+        using TMaxScorePolicy = typename TraceConfigForLocalAlignment_<TTracebackConfig>::Type;
         tv = _maxScore(_scoreOfCell(activeCell),
                        TraceBitMap_<TScoreValue>::NONE,
                        _scoreOfCell(activeCell),
                        TraceBitMap_<TScoreValue>::NONE,
                        tv,
-                       TTracebackConfig{});
+                       TMaxScorePolicy{});
     }
     previousVertical = activeCell;
     return tv;
@@ -540,12 +542,13 @@ _computeScore(DPCell_<TScoreValue, DynamicGaps> & activeCell,
                                  TTracebackConfig(), RecursionDirectionDiagonal());
     if (IsLocalAlignment_<TAlgorithm>::VALUE)
     {
+        using TMaxScorePolicy = typename TraceConfigForLocalAlignment_<TTracebackConfig>::Type;
         tv = _maxScore(_scoreOfCell(activeCell),
                        TraceBitMap_<TScoreValue>::NONE,
                        _scoreOfCell(activeCell),
                        TraceBitMap_<TScoreValue>::NONE,
                        tv,
-                       TTracebackConfig{});
+                       TMaxScorePolicy{});
     }
     return tv;
 }
@@ -601,12 +604,13 @@ _computeScore(DPCell_<TScoreValue, DynamicGaps> & activeCell,
     previousVertical = activeCell;
     if (IsLocalAlignment_<TAlgorithm>::VALUE)
     {
+        using TMaxScorePolicy = typename TraceConfigForLocalAlignment_<TTracebackConfig>::Type;
         tv = _maxScore(_scoreOfCell(activeCell),
                        TraceBitMap_<TScoreValue>::NONE,
                        _scoreOfCell(activeCell),
                        TraceBitMap_<TScoreValue>::NONE,
                        tv,
-                       TTracebackConfig{});
+                       TMaxScorePolicy{});
     }
     return tv;
 }
@@ -635,12 +639,13 @@ _computeScore(DPCell_<TScoreValue, DynamicGaps> & activeCell,
     previousVertical = activeCell;
     if (IsLocalAlignment_<TAlgorithm>::VALUE)
     {
+        using TMaxScorePolicy = typename TraceConfigForLocalAlignment_<TTracebackConfig>::Type;
         tv = _maxScore(_scoreOfCell(activeCell),
                        TraceBitMap_<TScoreValue>::NONE,
                        _scoreOfCell(activeCell),
                        TraceBitMap_<TScoreValue>::NONE,
                        tv,
-                       TTracebackConfig{});
+                       TMaxScorePolicy{});
     }
     return tv;
 }

--- a/include/seqan/align/dp_formula_linear.h
+++ b/include/seqan/align/dp_formula_linear.h
@@ -93,12 +93,13 @@ _computeScore(DPCell_<TScoreValue, LinearGaps> & current,
                    TTracebackConfig());
     if (IsLocalAlignment_<TAlgorithm>::VALUE)
     {
+        using TMaxScorePolicy = typename TraceConfigForLocalAlignment_<TTracebackConfig>::Type;
         tv = _maxScore(_scoreOfCell(current),
                        TraceBitMap_<TScoreValue>::NONE,
                        _scoreOfCell(current),
                        TraceBitMap_<TScoreValue>::NONE,
                        tv,
-                       TTracebackConfig{});
+                       TMaxScorePolicy{});
     }
     previousVertical = current;
     return tv;
@@ -134,12 +135,13 @@ _computeScore(DPCell_<TScoreValue, LinearGaps> & current,
                         TTracebackConfig());
     if (IsLocalAlignment_<TAlgorithm>::VALUE)
     {
+        using TMaxScorePolicy = typename TraceConfigForLocalAlignment_<TTracebackConfig>::Type;
         tv = _maxScore(_scoreOfCell(current),
                        TraceBitMap_<TScoreValue>::NONE,
                        _scoreOfCell(current),
                        TraceBitMap_<TScoreValue>::NONE,
                        tv,
-                       TTracebackConfig{});
+                       TMaxScorePolicy{});
     }
     previousVertical = current;
     return tv;
@@ -172,12 +174,13 @@ _computeScore(DPCell_<TScoreValue, LinearGaps> & current,
                          TTracebackConfig());
     if (IsLocalAlignment_<TAlgorithm>::VALUE)
     {
+        using TMaxScorePolicy = typename TraceConfigForLocalAlignment_<TTracebackConfig>::Type;
         tv = _maxScore(_scoreOfCell(current),
                        TraceBitMap_<TScoreValue>::NONE,
                        _scoreOfCell(current),
                        TraceBitMap_<TScoreValue>::NONE,
                        tv,
-                       TTracebackConfig{});
+                       TMaxScorePolicy{});
     }
     return tv;
 }
@@ -207,12 +210,13 @@ _computeScore(DPCell_<TScoreValue, LinearGaps> & activeCell,
     auto tv = TraceBitMap_<TScoreValue>::HORIZONTAL | TraceBitMap_<TScoreValue>::MAX_FROM_HORIZONTAL_MATRIX;
     if (IsLocalAlignment_<TAlgorithm>::VALUE)
     {
+        using TMaxScorePolicy = typename TraceConfigForLocalAlignment_<TTracebackConfig>::Type;
         tv = _maxScore(_scoreOfCell(activeCell),
                        TraceBitMap_<TScoreValue>::NONE,
                        _scoreOfCell(activeCell),
                        TraceBitMap_<TScoreValue>::NONE,
                        tv,
-                       TTracebackConfig{});
+                       TMaxScorePolicy{});
     }
     // Cache next vertical.
     previousVertical = activeCell;
@@ -240,12 +244,13 @@ _computeScore(DPCell_<TScoreValue, LinearGaps> & current,
     auto tv = TraceBitMap_<TScoreValue>::VERTICAL | TraceBitMap_<TScoreValue>::MAX_FROM_VERTICAL_MATRIX;
     if (IsLocalAlignment_<TAlgorithm>::VALUE)
     {
+        using TMaxScorePolicy = typename TraceConfigForLocalAlignment_<TTracebackConfig>::Type;
         tv = _maxScore(_scoreOfCell(current),
                        TraceBitMap_<TScoreValue>::NONE,
                        _scoreOfCell(current),
                        TraceBitMap_<TScoreValue>::NONE,
                        tv,
-                       TTracebackConfig{});
+                       TMaxScorePolicy{});
     }
     // Cache previous vertical.
     previousVertical = current;

--- a/tests/align/CMakeLists.txt
+++ b/tests/align/CMakeLists.txt
@@ -91,11 +91,15 @@ if (ALIGN_SIMD_TEST)
                     test_align_simd_local.h
                     test_mock.h)
 
+    add_executable (test_align_bugs
+                    test_align_bugs.cpp)
+
     # Add dependencies found by find_package (SeqAn).
     target_link_libraries (test_align_simd_global_equal_length ${SEQAN_LIBRARIES})
     target_link_libraries (test_align_simd_global_variable_length ${SEQAN_LIBRARIES})
     target_link_libraries (test_align_simd_local_equal_length ${SEQAN_LIBRARIES})
     target_link_libraries (test_align_simd_local_variable_length ${SEQAN_LIBRARIES})
+    target_link_libraries (test_align_bugs ${SEQAN_LIBRARIES})
     # note(marehr): there is a bug when using <=clang3.8 with gcc4.9's stdlib,
     # where the default -ftemplate-depth=256 of clang is insufficient.
     # test_align_simd_avx2 needs a depth of at least 266.

--- a/tests/align/test_align_bugs.cpp
+++ b/tests/align/test_align_bugs.cpp
@@ -1,0 +1,111 @@
+// ==========================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ==========================================================================
+// Copyright (c) 2006-2018, Knut Reinert, FU Berlin
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ==========================================================================
+// Author: Rene Rahn <rene.rahn@fu-berlin.de>
+// ==========================================================================
+
+#include <seqan/basic.h>
+#include <seqan/stream.h>
+
+#include <seqan/align.h>
+
+// Call the internal interface since we cannot publicly control the Traceback configuration.
+template <typename TGapSequence1, typename TGapSequence2, typename TScoringScheme>
+auto compute_affine_alignment(TGapSequence1 & gapSequence1,
+                              TGapSequence2 & gapSequence2,
+                              TScoringScheme const & scoringScheme)
+{
+    using TSize = typename seqan::Size<TGapSequence1>::Type;
+    using TPosition = typename seqan::Position<TGapSequence1>::Type;
+    using TTraceSegment = seqan::TraceSegment_<TPosition, TSize>;
+
+    // Test explicitly the complete trace functionality.
+    using TTracebackPolicy = seqan::TracebackOn<seqan::TracebackConfig_<seqan::CompleteTrace, seqan::GapsLeft>>;
+    using TAlignConfig = seqan::AlignConfig2<seqan::LocalAlignment_<>,
+                                             seqan::DPBandConfig<seqan::BandOff>,
+                                             seqan::FreeEndGaps_<seqan::True, seqan::True, seqan::True, seqan::True>,
+                                             TTracebackPolicy>;
+
+    seqan::String<TTraceSegment> trace;
+    seqan::DPScoutState_<seqan::Default> dpScoutState;
+    TAlignConfig config;
+    auto score = seqan::_setUpAndRunAlignment(trace,
+                                              dpScoutState,
+                                              seqan::source(gapSequence1),
+                                              seqan::source(gapSequence2),
+                                              scoringScheme,
+                                              config,
+                                              seqan::AffineGaps());
+    seqan::_adaptTraceSegmentsTo(gapSequence1, gapSequence2, trace);
+    return score;
+}
+
+SEQAN_DEFINE_TEST(test_local_alignment_with_complete_trace_produces_wrong_alignment)
+{
+    seqan::String<seqan::AminoAcid> s1 = "QDPKEPCISIYCLYLPVAGLGNLRGCCLPWM**";
+    seqan::String<seqan::AminoAcid> s2 = "*SS*IVSRTPARTSPPGPGPIGGPH*TIQSVVATVGVYKGQGRNQRELMTRAYWEFLVQGK*LQFPIPST"
+                                         "TGVQRVSRTCRPRRAHADPVSVARVRPRTSKGITDLLLLNLVWLNATCPSKKLNADRDGRVTI*QARVSF"
+                                         "VIGINQTNRSTN*ERPCTTTHRIKKELSICQSSLCPGRVRFPVLSQIKPQAPLLVVPFRQFL*VSALQPY"
+                                         "FPRNPKTLVSRKLPEGSSM*RPPIASWHRL*SELGRYLIVFEPLTFALD*RKHSWQMLSQSFVLRRSKNF"
+                                         "TSNGTVRIAPVCPS*SLPRAPKTNKIEPRSYSIIPCTIIQAREPALNTLIFSK*TFRPPPTLSQEHRRRT"
+                                         "GGKARTSSTRLATDRPPAPKIQLRAF*PQQLKYILLELELPRLLAPDLPSNGYSLKLLKCTHSNYRASNE"
+                                         "SCIVIFRHYLPASGMGNLRACCLPWMW*PFLRLPLRNRTLIPRHP*EPR*ANTVPTKVDRADT*MIRRRC"
+                                         "*TVRSAKLSRVTKANAPEDAAGFWSDKCT";
+
+    seqan::Align<seqan::String<seqan::AminoAcid> > correctAlignment;
+    seqan::resize(seqan::rows(correctAlignment), 2);
+    seqan::assignSource(seqan::row(correctAlignment, 0), s1);
+    seqan::assignSource(seqan::row(correctAlignment, 1), s2);
+
+    seqan::Blosum62 scoringScheme(-1, -11);
+
+    // Compute the known correct alignment.
+    auto correctScore = seqan::localAlignment(correctAlignment, scoringScheme);
+
+    seqan::Align<seqan::String<seqan::AminoAcid> > testAlignment;
+    seqan::resize(seqan::rows(testAlignment), 2);
+    seqan::assignSource(seqan::row(testAlignment, 0), s1);
+    seqan::assignSource(seqan::row(testAlignment, 1), s2);
+
+    // Compute the known incorrect alignment.
+    auto testScore = compute_affine_alignment(seqan::row(testAlignment, 0),
+                                              seqan::row(testAlignment, 1),
+                                              scoringScheme);
+
+    SEQAN_ASSERT_EQ(correctScore, testScore);
+    SEQAN_ASSERT_EQ(correctAlignment, testAlignment);
+}
+
+SEQAN_BEGIN_TESTSUITE(test_align_simd_bugs)
+{
+    SEQAN_CALL_TEST(test_local_alignment_with_complete_trace_produces_wrong_alignment);
+}
+SEQAN_END_TESTSUITE

--- a/tests/align/test_alignment_dp_formula.h
+++ b/tests/align/test_alignment_dp_formula.h
@@ -2357,7 +2357,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_linear_diagonal_direction)
     traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
                                scoringScheme, RecursionDirectionDiagonal(), TDPProfileCompleteTrace());
 
-    SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(TraceBitMap_<>::DIAGONAL));
+    SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(TraceBitMap_<>::NONE));
     SEQAN_ASSERT_EQ(activeCell._score, 0);
     SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
     SEQAN_ASSERT_EQ(prevHorizontal._score, 10);
@@ -2610,7 +2610,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_linear_lower_band_direction)
         traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(TraceBitMap_<>::DIAGONAL));
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(TraceBitMap_<>::NONE));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 2);
@@ -2750,7 +2750,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_affine_diagonal_direction)
         traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
                                                scoringScheme, RecursionDirectionDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(TraceBitMap_<>::DIAGONAL));
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(TraceBitMap_<>::NONE));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
         SEQAN_ASSERT_EQ(activeCell._horizontalScore, inf);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
@@ -2978,7 +2978,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_affine_upper_band_direction)
         traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
                                    scoringScheme, RecursionDirectionUpperDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::HORIZONTAL));
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(TraceBitMap_<>::NONE));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
         SEQAN_ASSERT_EQ(activeCell._horizontalScore, -3);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 1);
@@ -3055,7 +3055,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_affine_lower_band_direction)
         traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
                                    scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::VERTICAL));
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(TraceBitMap_<>::NONE));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
         SEQAN_ASSERT_EQ(activeCell._horizontalScore, inf);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
@@ -3134,7 +3134,7 @@ SEQAN_DEFINE_TEST(test_dp_formula_trace_local_affine_all_direction)
         traceValue = _computeScore(activeCell, prevDiagonal, prevHorizontal, prevVertical, 'C', 'A',
                                                scoringScheme, RecursionDirectionLowerDiagonal(), TDPProfileCompleteTrace());
 
-        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(TraceBitMap_<>::DIAGONAL | TraceBitMap_<>::VERTICAL));
+        SEQAN_ASSERT_EQ(static_cast<int>(traceValue), static_cast<int>(TraceBitMap_<>::NONE));
         SEQAN_ASSERT_EQ(activeCell._score, 0);
         SEQAN_ASSERT_EQ(prevDiagonal._score, 2);
         SEQAN_ASSERT_EQ(prevHorizontal._score, 1);


### PR DESCRIPTION
In local alignment the comparison against 0 was fixed when
computing all traces. The rational behind this is that
whenever the score at a cell is not greater than 0 the trace
must be set to NONE to indicate the begin of the
alignment. Otherwise, a scoring matrix that evaluates to
score 0 for two residues might falsely add the substitution
to the alignment.

fixes #2417 