### PR TITLE
[FIX] Added *.fas file extension to FASTA files

### DIFF
--- a/include/seqan/seq_io/fasta_fastq.h
+++ b/include/seqan/seq_io/fasta_fastq.h
@@ -104,17 +104,18 @@ struct MagicHeader<Raw, T> :
 template <typename T>
 struct FileExtensions<Fasta, T>
 {
-    static char const * VALUE[6];
+    static char const * VALUE[7];
 };
 template <typename T>
-char const * FileExtensions<Fasta, T>::VALUE[6] =
+char const * FileExtensions<Fasta, T>::VALUE[7] =
 {
     ".fa",      // default output extension
     ".fasta",
     ".faa",     // FASTA Amino Acid file
     ".ffn",     // FASTA nucleotide coding regions file
     ".fna",     // FASTA Nucleic Acid file
-    ".frn"
+    ".frn",
+    ".fas"
 };
 
 


### PR DESCRIPTION
Passing FASTA files with `*.fas` extensions to the argument parser fails currently.