### PR TITLE
[FIX] Aligned allocation for newer macos platforms.

### DIFF
--- a/include/seqan/basic/allocator_interface.h
+++ b/include/seqan/basic/allocator_interface.h
@@ -233,7 +233,7 @@ allocate(T const &,
 #ifdef PLATFORM_WINDOWS_VS
     data = (TValue *) _aligned_malloc(count * sizeof(TValue), __alignof(TValue));
 #else
-    #if _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600
+    #if _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || __APPLE__
         const size_t align = (__alignof__(TValue) < sizeof(void*)) ? sizeof(void*): __alignof__(TValue);
         if (posix_memalign(&(void* &)data, align, count * sizeof(TValue)))
             data = NULL;
@@ -253,7 +253,7 @@ allocate(T &,
 #ifdef PLATFORM_WINDOWS_VS
     data = (TValue *) _aligned_malloc(count * sizeof(TValue), __alignof(TValue));
 #else
-    #if _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600
+    #if _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || __APPLE__
         const size_t align = (__alignof__(TValue) < sizeof(void*)) ? sizeof(void*) : __alignof__(TValue);
         if (posix_memalign(&(void* &)data, align, count * sizeof(TValue)))
         data = NULL;


### PR DESCRIPTION
All recent macos versions should support posix_memalign but somehow the currently used macros are not sufficient anymore.