### PR TITLE
[FIX] Fixes bad memory access when updating the positions for the loc…

### DIFF
--- a/include/seqan/align/dp_algorithm_impl.h
+++ b/include/seqan/align/dp_algorithm_impl.h
@@ -364,7 +364,7 @@ _computeTrack(TDPScout & scout,
     TSeqHValue tmpSeqH = _precomputeScoreMatrixOffset(seqHValue, scoringScheme);
 
     // Initilaize SIMD version with multiple end points.
-    _preInitScoutVertical(scout);
+    _preInitScoutVertical(scout, coordinate(dpTraceMatrixNavigator, +DPMatrixDimension_::VERTICAL));
 
     // Compute the first cell.
     _computeCell(scout,
@@ -500,7 +500,7 @@ _computeAlignmentImpl(TDPScout & scout,
     typedef typename Iterator<TSequenceV const, Rooted>::Type TConstSeqVIterator;
 
     // Initilaize SIMD version with multiple end points.
-    _preInitScoutHorizontal(scout);
+    _preInitScoutHorizontal(scout, 0);
 
     // ============================================================================
     // PREPROCESSING
@@ -652,6 +652,7 @@ _computeAlignmentImpl(TDPScout & scout,
         // Set the iterator to the begin of the track.
         _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), FirstCell());
         _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), FirstCell());
+        _preInitScoutHorizontal(scout, coordinate(dpTraceMatrixNavigator, +DPMatrixDimension_::HORIZONTAL));
         // Only one cell
         _computeCell(scout, dpTraceMatrixNavigator, value(dpScoreMatrixNavigator),
                      cacheDiag, previousCellHorizontal(dpScoreMatrixNavigator), cacheVert,
@@ -668,6 +669,7 @@ _computeAlignmentImpl(TDPScout & scout,
         // Set the iterator to the begin of the track.
         _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom>(), FirstCell());
         _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnBottom>(), FirstCell());
+        _preInitScoutHorizontal(scout, coordinate(dpTraceMatrixNavigator, +DPMatrixDimension_::HORIZONTAL));
         // Only one cell
         _computeCell(scout, dpTraceMatrixNavigator, value(dpScoreMatrixNavigator),
                      cacheDiag, previousCellHorizontal(dpScoreMatrixNavigator), cacheVert,
@@ -682,6 +684,7 @@ _computeAlignmentImpl(TDPScout & scout,
 
     if (upperDiagonal(band) < 0)
     {
+        _preInitScoutHorizontal(scout, 0);
         ++seqVBegin;
         if (lowerDiagonal(band) > -seqVlength)
             _computeTrack(scout, dpScoreMatrixNavigator, dpTraceMatrixNavigator,
@@ -701,6 +704,7 @@ _computeAlignmentImpl(TDPScout & scout,
         // Set the iterator to the begin of the track.
         _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), FirstCell());
         _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInitialColumn, PartialColumnTop>(), FirstCell());
+        _preInitScoutHorizontal(scout, coordinate(dpTraceMatrixNavigator, +DPMatrixDimension_::HORIZONTAL));
         //TODO(rrahn): We possibly need to set the cache values here?
         // Should we not just compute the cell?
         _computeCell(scout, dpTraceMatrixNavigator, value(dpScoreMatrixNavigator),
@@ -715,6 +719,7 @@ _computeAlignmentImpl(TDPScout & scout,
     }
     else  // Upper diagonal >= 0 and lower Diagonal < 0
     {
+        _preInitScoutHorizontal(scout, 0);
         if (lowerDiagonal(band) <= -seqVlength)      // The band is bounded by the top and bottom of the matrix.
         {
             _computeTrack(scout, dpScoreMatrixNavigator, dpTraceMatrixNavigator,
@@ -745,6 +750,7 @@ _computeAlignmentImpl(TDPScout & scout,
     // Compute the first part of the band, where the band is bounded by the top but not by the bottom of the matrix.
     for (; seqHIter != seqHIterEndColumnTop; ++seqHIter)
     {
+        _incHorizontalPos(scout);
         ++seqVEnd;
         _computeTrack(scout, dpScoreMatrixNavigator, dpTraceMatrixNavigator,
                       sequenceEntryForScore(scoringScheme, seqH, position(seqHIter)),
@@ -768,6 +774,7 @@ _computeAlignmentImpl(TDPScout & scout,
             _scoutBestScore(scout, value(dpScoreMatrixNavigator), dpTraceMatrixNavigator, False(), True());
         for (; seqHIter != seqHIterEndColumnMiddle; ++seqHIter)
         {
+            _incHorizontalPos(scout);
             _computeTrack(scout, dpScoreMatrixNavigator, dpTraceMatrixNavigator,
                           sequenceEntryForScore(scoringScheme, seqH, position(seqHIter)),
                           sequenceEntryForScore(scoringScheme, seqV, 0),
@@ -784,6 +791,7 @@ _computeAlignmentImpl(TDPScout & scout,
     {
         for (; seqHIter != seqHIterEndColumnMiddle; ++seqHIter)
         {
+            _incHorizontalPos(scout);
             ++seqVBegin;
             ++seqVEnd;
             _computeTrack(scout, dpScoreMatrixNavigator, dpTraceMatrixNavigator,
@@ -808,6 +816,7 @@ _computeAlignmentImpl(TDPScout & scout,
     // Compute the third part of the band, where the band, is bounded by the bottom but not by the top of the matrix.
     for (; seqHIter != seqHIterEndColumnBottom; ++seqHIter)
     {
+        _incHorizontalPos(scout);
         ++seqVBegin;
         _computeTrack(scout, dpScoreMatrixNavigator, dpTraceMatrixNavigator,
                       sequenceEntryForScore(scoringScheme, seqH, position(seqHIter)),
@@ -824,6 +833,7 @@ _computeAlignmentImpl(TDPScout & scout,
     // POSTPROCESSING
     // ============================================================================
 
+    _incHorizontalPos(scout);
     // Check where the last track of the column is located.
     if (seqHIter - begin(seqH, Rooted()) < seqHlength - 1)  // Case 1: The band ends before the final column is reached.
     {
@@ -993,6 +1003,9 @@ _computeHammingDistance(TDPScout & scout,
     TConstSeqVIterator itV = begin(seqV, Rooted()) + _max(0, _min(seqVlength - 1, -lowerDiagonal(band)));
     TConstSeqVIterator itVEnd = begin(seqV, Rooted()) + _min(seqVlength - 1, lowerDiagonal(band) + seqHlength);
 
+    _preInitScoutHorizontal(scout, coordinate(dpTraceMatrixNavigator, +DPMatrixDimension_::HORIZONTAL));
+    _preInitScoutVertical(scout, coordinate(dpTraceMatrixNavigator, +DPMatrixDimension_::VERTICAL));
+
     TDPCell dummy;
     assignValue(dpTraceMatrixNavigator,
                 _computeScore(value(dpScoreMatrixNavigator), dummy, dummy, dummy,
@@ -1044,6 +1057,8 @@ _computeHammingDistance(TDPScout & scout,
     {
         _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, FullColumn>(), FirstCell());
         _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, FullColumn>(), FirstCell());
+        _incHorizontalPos(scout);
+        _incVerticalPos(scout);
         assignValue(dpTraceMatrixNavigator,
                     _computeScore(value(dpScoreMatrixNavigator), prevDiagonal, dummy, dummy,
                                   sequenceEntryForScore(scoringScheme, seqH, position(itH)),
@@ -1062,7 +1077,8 @@ _computeHammingDistance(TDPScout & scout,
 
     _goNextCell(dpScoreMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, FullColumn>(), FirstCell());
     _goNextCell(dpTraceMatrixNavigator, MetaColumnDescriptor<DPInnerColumn, FullColumn>(), FirstCell());
-
+    _incHorizontalPos(scout);
+    _incVerticalPos(scout);
     assignValue(dpTraceMatrixNavigator,
                 _computeScore(value(dpScoreMatrixNavigator), prevDiagonal, dummy, dummy,
                               sequenceEntryForScore(scoringScheme, seqH, position(itH)),

--- a/include/seqan/align/dp_scout.h
+++ b/include/seqan/align/dp_scout.h
@@ -250,9 +250,9 @@ terminateScout(DPScout_<TDPCell, Terminator_<TSpec> > & scout)
 // Function _preInitScoutHorizontal()
 // ----------------------------------------------------------------------------
 
-template <typename TDPCell, typename TSpec>
+template <typename TDPCell, typename TSpec, typename TPosition>
 inline void
-_preInitScoutHorizontal(DPScout_<TDPCell, TSpec> const & /*scout*/)
+_preInitScoutHorizontal(DPScout_<TDPCell, TSpec> const & /*scout*/, TPosition const /*offset*/)
 {
     // no-op.
 }
@@ -273,9 +273,9 @@ _reachedHorizontalEndPoint(DPScout_<TDPCell, TSpec> const & /*scout*/,
 // Function _preInitScoutVertical()
 // ----------------------------------------------------------------------------
 
-template <typename TDPCell, typename TSpec>
+template <typename TDPCell, typename TSpec, typename TPosition>
 inline void
-_preInitScoutVertical(DPScout_<TDPCell, TSpec> const & /*scout*/)
+_preInitScoutVertical(DPScout_<TDPCell, TSpec> const & /*scout*/, TPosition const /*offset*/)
 {
     // no-op.
 }

--- a/include/seqan/align_parallel/dp_parallel_scout.h
+++ b/include/seqan/align_parallel/dp_parallel_scout.h
@@ -218,9 +218,10 @@ _scoutBestScore(DPScout_<TDPCell, DPTiled<TBuffer, TThreadContext, void> > & dpS
 // Function _preInitScoutHorizontal()
 // ----------------------------------------------------------------------------
 
-template <typename TDPCell, typename TBuffer, typename TThreadContext, typename TSpec>
+template <typename TDPCell, typename TBuffer, typename TThreadContext, typename TSpec, typename TPosition>
 inline void
-_preInitScoutHorizontal(DPScout_<TDPCell, DPTiled<TBuffer, TThreadContext, TSpec> > & scout)
+_preInitScoutHorizontal(DPScout_<TDPCell, DPTiled<TBuffer, TThreadContext, TSpec> > & scout,
+                        TPosition const /*offset*/)
 {
     scout.horizontalPos = 0;
 }
@@ -229,9 +230,10 @@ _preInitScoutHorizontal(DPScout_<TDPCell, DPTiled<TBuffer, TThreadContext, TSpec
 // Function _preInitScoutVertical()
 // ----------------------------------------------------------------------------
 
-template <typename TDPCell, typename TBuffer, typename TThreadContext, typename TSpec>
+template <typename TDPCell, typename TBuffer, typename TThreadContext, typename TSpec, typename TPosition>
 inline void
-_preInitScoutVertical(DPScout_<TDPCell, DPTiled<TBuffer, TThreadContext, TSpec> > & scout)
+_preInitScoutVertical(DPScout_<TDPCell, DPTiled<TBuffer, TThreadContext, TSpec> > & scout,
+                      TPosition const /*offset*/)
 {
     scout.verticalPos = 0;
 }

--- a/include/seqan/align_parallel/dp_parallel_scout_simd.h
+++ b/include/seqan/align_parallel/dp_parallel_scout_simd.h
@@ -214,15 +214,13 @@ _setSimdLane(DPScout_<TDPCell, DPTiled<TBuffer, TThreadContext, SimdAlignmentSco
 // Function _preInitScoutHorizontal()
 // ----------------------------------------------------------------------------
 
-template <typename TDPCell, typename TBuffer, typename TThreadContext, typename TTraits>
+template <typename TDPCell, typename TBuffer, typename TThreadContext, typename TSpec, typename TPosition>
 inline void
-_preInitScoutHorizontal(DPScout_<TDPCell, DPTiled<TBuffer, TThreadContext, SimdAlignmentScout<SimdAlignVariableLength<TTraits> > > > & scout)
+_preInitScoutHorizontal(DPScout_<TDPCell, DPTiled<TBuffer, TThreadContext, SimdAlignmentScout<TSpec> > > & scout,
+                        TPosition const offset)
 {
-    using TScoutBase = typename DPScout_<TDPCell,
-                                         DPTiled<TBuffer,
-                                                 TThreadContext,
-                                                 SimdAlignmentScout<SimdAlignVariableLength<TTraits>>>>::TBase;
-    _preInitScoutHorizontal(static_cast<TScoutBase&>(scout));
+    using TScoutBase = typename DPScout_<TDPCell, DPTiled<TBuffer, TThreadContext, SimdAlignmentScout<TSpec>>>::TBase;
+    _preInitScoutHorizontal(static_cast<TScoutBase&>(scout), offset);
     scout.horizontalPos = 0;
 }
 
@@ -230,18 +228,13 @@ _preInitScoutHorizontal(DPScout_<TDPCell, DPTiled<TBuffer, TThreadContext, SimdA
 // Function _preInitScoutVertical()
 // ----------------------------------------------------------------------------
 
-template <typename TDPCell, typename TBuffer, typename TThreadContext, typename TTraits>
+template <typename TDPCell, typename TBuffer, typename TThreadContext, typename TSpec, typename TPosition>
 inline void
-_preInitScoutVertical(DPScout_<TDPCell,
-                               DPTiled<TBuffer,
-                                       TThreadContext,
-                                       SimdAlignmentScout<SimdAlignVariableLength<TTraits>>>> & scout)
+_preInitScoutVertical(DPScout_<TDPCell, DPTiled<TBuffer, TThreadContext, SimdAlignmentScout<TSpec>>> & scout,
+                      TPosition const offset)
 {
-    using TScoutBase = typename DPScout_<TDPCell,
-                                         DPTiled<TBuffer,
-                                                 TThreadContext,
-                                                 SimdAlignmentScout<SimdAlignVariableLength<TTraits>>>>::TBase;
-    _preInitScoutVertical(static_cast<TScoutBase&>(scout));
+    using TScoutBase = typename DPScout_<TDPCell, DPTiled<TBuffer, TThreadContext, SimdAlignmentScout<TSpec>>>::TBase;
+    _preInitScoutVertical(static_cast<TScoutBase&>(scout), offset);
     scout.verticalPos = 0;
 }
 
@@ -323,17 +316,11 @@ _nextVerticalEndPos(DPScout_<TDPCell,
 // Function _incHorizontalPos()
 // ----------------------------------------------------------------------------
 
-template <typename TDPCell, typename TBuffer, typename TThreadContext, typename TTraits>
+template <typename TDPCell, typename TBuffer, typename TThreadContext, typename TSpec>
 inline void
-_incHorizontalPos(DPScout_<TDPCell,
-                           DPTiled<TBuffer,
-                                   TThreadContext,
-                                   SimdAlignmentScout<SimdAlignVariableLength<TTraits> > > > & scout)
+_incHorizontalPos(DPScout_<TDPCell, DPTiled<TBuffer, TThreadContext, SimdAlignmentScout<TSpec> > > & scout)
 {
-    using TScoutBase = typename DPScout_<TDPCell,
-                                         DPTiled<TBuffer,
-                                                 TThreadContext,
-                                                 SimdAlignmentScout<SimdAlignVariableLength<TTraits> > > >::TBase;
+    using TScoutBase = typename DPScout_<TDPCell, DPTiled<TBuffer, TThreadContext, SimdAlignmentScout<TSpec> > >::TBase;
     _incHorizontalPos(static_cast<TScoutBase&>(scout));
     ++scout.horizontalPos;
 }
@@ -342,17 +329,11 @@ _incHorizontalPos(DPScout_<TDPCell,
 // Function _incVerticalPos()
 // ----------------------------------------------------------------------------
 
-template <typename TDPCell, typename TBuffer, typename TThreadContext, typename TTraits>
+template <typename TDPCell, typename TBuffer, typename TThreadContext, typename TSpec>
 inline void
-_incVerticalPos(DPScout_<TDPCell,
-                         DPTiled<TBuffer,
-                                 TThreadContext,
-                                 SimdAlignmentScout<SimdAlignVariableLength<TTraits> > > > & scout)
+_incVerticalPos(DPScout_<TDPCell, DPTiled<TBuffer, TThreadContext, SimdAlignmentScout<TSpec> > > & scout)
 {
-    using TScoutBase = typename DPScout_<TDPCell,
-                                         DPTiled<TBuffer,
-                                                 TThreadContext,
-                                                 SimdAlignmentScout<SimdAlignVariableLength<TTraits> > > >::TBase;
+    using TScoutBase = typename DPScout_<TDPCell, DPTiled<TBuffer, TThreadContext, SimdAlignmentScout<TSpec> > >::TBase;
     _incVerticalPos(static_cast<TScoutBase&>(scout));
     ++scout.verticalPos;
 }


### PR DESCRIPTION
fixes #2429 

### Description:

When computing the traceback in the local alignment we asked for the current row or column position through the given traceback navigator. The issue here was that for every cell a memory access to a scalar type was done and then converted into a simd register. For the global alignment this didn't hurt because it is only done once for the entire alignment. This PR fixes this by maintaining the current column/row position as simd register within the simd scout.
