### PR TITLE
[FIX] UB reverse on packed strings

### DIFF
--- a/include/seqan/modifier/modifier_reverse.h
+++ b/include/seqan/modifier/modifier_reverse.h
@@ -591,6 +591,22 @@ reverse(StringSet<TSequence, TSpec> & stringSet, Tag<TParallelTag>)
         reverse(stringSet[seqNo], Serial());
 }
 
+// Reversing a Packed ConcatDirect StringSet in parallel is undefined behaviour
+template < typename TAlphabet, typename TAlloc, typename TSpec, typename TParallelTag>
+inline SEQAN_FUNC_ENABLE_IF(IsSameType<Tag<TParallelTag>, Parallel>, void)
+reverse(StringSet<String<TAlphabet, Packed<TAlloc> >, Owner<ConcatDirect<TSpec> > > & stringSet, Tag<TParallelTag>)
+{
+    reverse(stringSet, Serial());
+}
+
+// Reversing a Packed ConcatDirect StringSet in parallel is undefined behaviour
+template < typename TAlphabet, typename TAlloc, typename TSpec, typename TParallelTag>
+inline SEQAN_FUNC_ENABLE_IF(IsSameType<Tag<TParallelTag>, Parallel>, void)
+reverse(StringSet<String<TAlphabet, Packed<TAlloc> >, Owner<ConcatDirect<TSpec> > > const & stringSet, Tag<TParallelTag>)
+{
+    reverse(stringSet, Serial());
+}
+
 template < typename TText >
 inline SEQAN_FUNC_DISABLE_IF(Is<StlContainerConcept<TText> >)
 reverse(TText & text)

--- a/include/seqan/modifier/modifier_shortcuts.h
+++ b/include/seqan/modifier/modifier_shortcuts.h
@@ -308,6 +308,22 @@ inline void reverseComplement(StringSet<TSequence, TSpec> const & stringSet, Tag
         reverseComplement(stringSet[seqNo], Serial());
 }
 
+// Reversing a Packed ConcatDirect StringSet in parallel is undefined behaviour
+template < typename TAlphabet, typename TAlloc, typename TSpec, typename TParallelTag>
+inline SEQAN_FUNC_ENABLE_IF(IsSameType<Tag<TParallelTag>, Parallel>, void)
+reverseComplement(StringSet<String<TAlphabet, Packed<TAlloc> >, Owner<ConcatDirect<TSpec> > > & stringSet, Tag<TParallelTag>)
+{
+    reverseComplement(stringSet, Serial());
+}
+
+// Reversing a Packed ConcatDirect StringSet in parallel is undefined behaviour
+template < typename TAlphabet, typename TAlloc, typename TSpec, typename TParallelTag>
+inline SEQAN_FUNC_ENABLE_IF(IsSameType<Tag<TParallelTag>, Parallel>, void)
+reverseComplement(StringSet<String<TAlphabet, Packed<TAlloc> >, Owner<ConcatDirect<TSpec> > > const & stringSet, Tag<TParallelTag>)
+{
+    reverseComplement(stringSet, Serial());
+}
+
 template <typename TText>
 inline void reverseComplement(TText & text)
 {

--- a/tests/modifier/test_modifier.cpp
+++ b/tests/modifier/test_modifier.cpp
@@ -68,6 +68,8 @@ SEQAN_BEGIN_TESTSUITE(test_modifier)
     SEQAN_CALL_TEST(test_modifer_shortcuts_to_lower_in_place_string_set);
     SEQAN_CALL_TEST(test_modifer_shortcuts_to_upper_in_place_string);
     SEQAN_CALL_TEST(test_modifer_shortcuts_to_upper_in_place_string_set);
+    SEQAN_CALL_TEST(test_modifer_shortcuts_reverse_packed_concat_direct_stringset);
+    SEQAN_CALL_TEST(test_modifer_shortcuts_reverse_complement_packed_concat_direct_stringset);
 
     // Test modifier functors.
     SEQAN_CALL_TEST(test_modifier_functors_functor_upcase);

--- a/tests/modifier/test_modifier_shortcuts.h
+++ b/tests/modifier/test_modifier_shortcuts.h
@@ -317,4 +317,70 @@ SEQAN_DEFINE_TEST(test_modifer_shortcuts_to_upper_in_place_string_set)
     SEQAN_ASSERT_EQ(EXPECTED_STRING2, strSet[1]);
 }
 
+// https://github.com/seqan/seqan/pull/2433
+SEQAN_DEFINE_TEST(test_modifer_shortcuts_reverse_packed_concat_direct_stringset)
+{
+    // It might require a few repetitions to encounter the error.
+    size_t const test_repetitions{4};
+
+    for (size_t repetition = 0; repetition < test_repetitions; ++repetition)
+    {
+        size_t const string_repetitions{4};
+        seqan::DnaString str1("ACGTAGCTCGTACGATCGATCGTAGCATCGATCG");
+        seqan::DnaString str2("ACTACGATGCTAGCTGACTGAC");
+        seqan::DnaString const EXPECTED_STRING1 = "GCTAGCTACGATGCTAGCTAGCATGCTCGATGCA";
+        seqan::DnaString const EXPECTED_STRING2 = "CAGTCAGTCGATCGTAGCATCA";
+
+        // Test non-const version.
+        seqan::StringSet<seqan::String<seqan::Dna, seqan::Packed<> >, seqan::Owner<seqan::ConcatDirect<> > > strSet;
+        for (size_t i = 0; i < string_repetitions; ++i)
+        {
+            appendValue(strSet, str1);
+            appendValue(strSet, str2);
+        }
+
+        seqan::reverse(strSet);
+        SEQAN_ASSERT_EQ(string_repetitions * 2u, length(strSet));
+
+        for (size_t i = 0; i < string_repetitions; ++i)
+        {
+            SEQAN_ASSERT_EQ(EXPECTED_STRING1, strSet[i]);
+            SEQAN_ASSERT_EQ(EXPECTED_STRING2, strSet[++i]);
+        }
+    }
+}
+
+// https://github.com/seqan/seqan/pull/2433
+SEQAN_DEFINE_TEST(test_modifer_shortcuts_reverse_complement_packed_concat_direct_stringset)
+{
+    // It might require a few repetitions to encounter the error.
+    size_t const test_repetitions{4};
+
+    for (size_t repetition = 0; repetition < test_repetitions; ++repetition)
+    {
+        size_t const string_repetitions{4};
+        seqan::DnaString str1("ACGTAGCTCGTACGATCGATCGTAGCATCGATCG");
+        seqan::DnaString str2("ACTACGATGCTAGCTGACTGAC");
+        seqan::DnaString const EXPECTED_STRING1 = "CGATCGATGCTACGATCGATCGTACGAGCTACGT";
+        seqan::DnaString const EXPECTED_STRING2 = "GTCAGTCAGCTAGCATCGTAGT";
+
+        // Test non-const version.
+        seqan::StringSet<seqan::String<seqan::Dna, seqan::Packed<> >, seqan::Owner<seqan::ConcatDirect<> > > strSet;
+        for (size_t i = 0; i < string_repetitions; ++i)
+        {
+            appendValue(strSet, str1);
+            appendValue(strSet, str2);
+        }
+
+        seqan::reverseComplement(strSet, seqan::Parallel());
+        SEQAN_ASSERT_EQ(string_repetitions * 2u, length(strSet));
+
+        for (size_t i = 0; i < string_repetitions; ++i)
+        {
+            SEQAN_ASSERT_EQ(EXPECTED_STRING1, strSet[i]);
+            SEQAN_ASSERT_EQ(EXPECTED_STRING2, strSet[++i]);
+        }
+    }
+}
+
 #endif  // SEQAN_TESTS_MODIFIER_TEST_MODIFIER_SHORTCUTS_H_


### PR DESCRIPTION
If a ConcatDirect StringSet with packed strings is reversed (and OpenMP supported), reversing the strings is currently undefined behavior.
This is critical, because reversing the strings will use the parallel implementation by default.
These types of string sets are often used for string indices with a low memory footprint.