### PR TITLE
Fixes for cpp20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,90 +1,83 @@
-sudo: false
+version: ~> 1.0
+os: linux
+dist: xenial
 language: cpp
-cache:
-  directories:
-    - $HOME/ccache
-before_install: mkdir -p ${HOME}/.local/bin/
-matrix:
+
+cache: ccache
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+      - george-edison55-precise-backports
+      - llvm-toolchain-precise-3.9
+      - llvm-toolchain-trusty-7
+    packages:
+      - libboost-dev
+      - libbz2-dev
+      - libxml2-utils
+      - zlib1g-dev
+      - cmake
+      - g++-4.9
+      - g++-5
+      - g++-7
+      - clang-3.9
+      - clang-7
+
+jobs:
   include:
-    - os: linux
-      compiler: gcc-4.9
-      addons:
-        apt:
-          sources: ['ubuntu-toolchain-r-test', 'george-edison55-precise-backports']
-          packages: ['g++-4.9', 'zlib1g-dev', 'libbz2-dev', 'libboost-dev', 'python3', 'virtualenv', 'libxml2-utils']
-      install: export CXX="g++-4.9" CC="gcc-4.9"
+    - name: "GCC 4.9"
+      env:
+        - CXX=g++-4.9
+        - CC=gcc-4.9
+    - name: "GCC 5"
+      env:
+        - CXX=g++-5
+        - CC=gcc-5
+    - name: "GCC 7"
+      env:
+        - CXX=g++-7
+        - CC=gcc-7
+    - name: "Clang 3.9"
+      env:
+        - CXX=clang++-3.9
+        - CC=clang-3.9
+    - name: "Clang 7"
+      env:
+        - CXX=clang++-7
+        - CC=clang-7
 
-    - os: linux
-      compiler: gcc-5
-      addons:
-        apt:
-          sources: ['ubuntu-toolchain-r-test', 'george-edison55-precise-backports']
-          packages: ['g++-5', 'zlib1g-dev', 'libbz2-dev', 'libboost-dev', 'python3', 'virtualenv', 'libxml2-utils']
-      install: export CXX="g++-5" CC="gcc-5"
+    # - name: "Clang 3.8"
+    #   env:
+    #     - CXX=clang++-3.8
+    #     - CC=clang-3.8
+    # - name: "OSX Clang 3.6" # currently too slow on osx
+    #   os: osx
+    #   before_install:
+    #     - brew update
+    #     - brew tap homebrew/versions
+    #     - brew install llvm36
+    #   env:
+    #     - CXX=clang++-3.6
+    #     - CC=clang-3.6
+    # - name: "OSX Clang 3.7"
+    #   os: osx
+    #   before_install:
+    #     - brew update
+    #     - brew tap homebrew/versions
+    #     - brew install llvm37
+    #   env:
+    #     - CXX=clang++-3.7
+    #     - CC=clang-3.7
 
-    - os: linux
-      compiler: gcc-7
-      addons:
-        apt:
-          sources: ['ubuntu-toolchain-r-test', 'george-edison55-precise-backports']
-          packages: ['g++-7', 'zlib1g-dev', 'libbz2-dev', 'libboost-dev', 'python3', 'virtualenv', 'libxml2-utils']
-      install: export CXX="g++-7" CC="gcc-7"
+install:
+  - pyenv global 3.7.1
+  - pip3 install setuptools wheel
+  - pip3 install -r manual/requirements.txt
+  - ccache -M 10G
 
-    # - os: linux
-    #   compiler: clang-3.8
-    #   addons:
-    #     apt:
-    #       sources: ['ubuntu-toolchain-r-test', 'george-edison55-precise-backports' , 'llvm-toolchain-precise-3.8']
-    #       packages: ['clang-3.8', 'g++-4.9', 'zlib1g-dev', 'libbz2-dev', 'libboost-dev', 'python3', 'virtualenv'] # g++ required for newer libstdc++
-    #   install: export CXX="clang++-3.8" CC="clang-3.8"
-
-    # clang-3.9 currently not white listed.
-    - os: linux
-      compiler: clang-3.9
-      addons:
-        apt:
-          sources: ['ubuntu-toolchain-r-test', 'george-edison55-precise-backports' , 'llvm-toolchain-precise-3.9']
-          packages: ['clang-3.9', 'g++-7', 'zlib1g-dev', 'libbz2-dev', 'libboost-dev', 'python3', 'virtualenv', 'libxml2-utils'] # g++ required for newer libstdc++
-      install: export CXX="clang++-3.9" CC="clang-3.9"
-
-    - os: linux
-      compiler: clang-7
-      addons:
-        apt:
-          sources: ['ubuntu-toolchain-r-test', 'george-edison55-precise-backports', 'llvm-toolchain-trusty-7']
-          packages: ['clang-7', 'g++-7', 'zlib1g-dev', 'libbz2-dev', 'libboost-dev', 'python3', 'virtualenv', 'libxml2-utils'] # g++ required for newer libstdc++
-      install: export CXX="clang++-7" CC="clang-7"
-
-# currently too slow on osx
-    #- os: osx
-      #compiler: clang-3.6
-      #before_install:
-        #- sudo brew update
-        #- sudo brew tap homebrew/versions
-        #- sudo brew install llvm36
-      #install: ['export CXX="clang++-3.6" CC="clang-3.6"' ]
-
-    #- os: osx
-      #compiler: clang-3.7
-      #before_install:
-        #- sudo brew update
-        #- sudo brew tap homebrew/versions
-        #- sudo brew install llvm37
-      #install: ['export CXX="clang++-3.7" CC="clang-3.7"' ]
-
-before_script:
-  - export PATH=$HOME/.local/bin:/usr/lib/ccache:$PATH
-  - mkdir -p venv
-  - virtualenv -p python3 venv
-  - source venv/bin/activate
-  - pip install -r manual/requirements.txt
-  - pip install cmake
-  - rm -rf ${HOME}/.ccache
-  - mkdir -p ${HOME}/ccache/${TRAVIS_BRANCH}/${TRAVIS_OS_NAME}/${CXX}
-  - ln -s  ${HOME}/ccache/${TRAVIS_BRANCH}/${TRAVIS_OS_NAME}/${CXX} ${HOME}/.ccache
-  - ln -s /usr/bin/ccache ${HOME}/.local/bin/${CXX}
-  - ln -s /usr/bin/ccache ${HOME}/.local/bin/${CC}
 script:
-  - ccache -s
-  - ./util/travis/linux-cibuild.sh
+  - bash ./util/travis/linux-cibuild.sh
+
+after_script:
   - ccache -s

--- a/include/seqan/index/index_pizzachili.h
+++ b/include/seqan/index/index_pizzachili.h
@@ -302,7 +302,6 @@ namespace impl {
 } // namespace impl
 
 template <typename TText, typename TSpec>
-[[deprecated("The PizzaChiliIndex is outdated and is not maintained anymore.")]]
 inline bool
 indexCreate(Index<TText, PizzaChili<TSpec> >& me, PizzaChiliCompressed const) {
     typedef

--- a/include/seqan/sequence/sequence_interface.h
+++ b/include/seqan/sequence/sequence_interface.h
@@ -369,6 +369,24 @@ begin(T const & me)
     return begin(me, typename DefaultGetIteratorSpec<T>::Type()) ;
 }
 
+#if defined(__cpp_lib_ranges)
+template <typename T>
+    requires (Is<ContainerConcept<T> >::VALUE)
+inline typename Iterator<T, typename DefaultGetIteratorSpec<T>::Type>::Type
+begin(T & me)
+{
+    return begin(me, typename DefaultGetIteratorSpec<T>::Type()) ;
+}
+
+template <typename T>
+    requires (Is<ContainerConcept<T> >::VALUE)
+inline typename Iterator<T const, typename DefaultGetIteratorSpec<T>::Type>::Type
+begin(T const & me)
+{
+    return begin(me, typename DefaultGetIteratorSpec<T>::Type()) ;
+}
+#endif // defined(__cpp_lib_ranges)
+
 //folgende forward Deklaration wurde wegen Phaenomene bei VC++ 2003 hinzugenommen
 //implemented in string_pointer.h
 // template <typename TValue,
@@ -503,6 +521,24 @@ end(T const & me)
 {
     return end(me, typename DefaultGetIteratorSpec<T>::Type()) ;
 }
+
+#if defined(__cpp_lib_ranges)
+template <typename T>
+    requires (Is<ContainerConcept<T> >::VALUE)
+inline typename Iterator<T, typename DefaultGetIteratorSpec<T>::Type>::Type
+end(T & me)
+{
+    return end(me, typename DefaultGetIteratorSpec<T>::Type()) ;
+}
+
+template <typename T>
+    requires (Is<ContainerConcept<T> >::VALUE)
+inline typename Iterator<T const, typename DefaultGetIteratorSpec<T>::Type>::Type
+end(T const & me)
+{
+    return end(me, typename DefaultGetIteratorSpec<T>::Type()) ;
+}
+#endif // defined(__cpp_lib_ranges)
 
 template <typename T, typename TSpec>
 inline typename Iterator<T, Tag<TSpec> const>::Type

--- a/manual/requirements.txt
+++ b/manual/requirements.txt
@@ -1,3 +1,4 @@
+sphinx>=2.0.0
 seqansphinx>=0.4.0
 sphinx_rtd_theme
 sphinxcontrib-bibtex

--- a/util/travis/linux-cibuild.sh
+++ b/util/travis/linux-cibuild.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # get some infos from git to embed it in the build name
 export SOURCE_DIRECTORY=`pwd`
@@ -26,7 +26,7 @@ fi
 # Switch version check default to OFF to prevent checks during app tests
 CXXFLAGS="${CXXFLAGS} -DSEQAN_VERSION_CHECK_OPT_IN=YES"
 
-ctest -V -S util/travis/linux-cibuild.cmake
+ctest -V --output-on-failure -S util/travis/linux-cibuild.cmake
 
 # we indicate build failures if ctest experienced any errors
 if [ -f ${SOURCE_DIRECTORY}/failed ]; then


### PR DESCRIPTION
(1) We need some specialised overloads for `String`, `StringSet` and `Segment`, because the general overload for `begin` will be ambiguous in the context `std::ranges::begin` is evaluated in (https://eel.is/c++draft/range.access.begin#2.5).

(2) Including `index.h` will cause a deprecation warning even though the PizzaChili Index is not used; I removed the deprecation warning, because there is still one in the `impl::` function that is called when the index is actually created.