### PR TITLE
Silence bogus gcc10 warning

### DIFF
--- a/include/seqan/pipe/pipe_sampler.h
+++ b/include/seqan/pipe/pipe_sampler.h
@@ -170,6 +170,8 @@ namespace seqan
             return *outRef;
         }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
         Pipe& operator++()
         {
             unsigned skipped = 0;
@@ -212,6 +214,7 @@ namespace seqan
             swap();
             return *this;
         }
+#pragma GCC diagnostic pop
     };
 
 


### PR DESCRIPTION
```
$ make
[  0%] Built target seqan_library
Scanning dependencies of target test_pipe
[  0%] Building CXX object tests/pipe/CMakeFiles/test_pipe.dir/test_pipe.cpp.o
In file included from seqan/include/seqan/pipe.h:65,
                 from seqan/tests/pipe/test_pipe.cpp:41:
In member function ‘seqan::Pipe<TInput, seqan::Sampler<m, TPack> >& seqan::Pipe<TInput, seqan::Sampler<m, TPack> >::operator++() [with TInput = seqan::Pipe<seqan::String<seqan::SimpleType<unsigned char, seqan::Dna_>, seqan::Alloc<> >, seqan::Source<> >; unsigned int m = 3; TPack = seqan::Tag<seqan::Pack_>]’,
    inlined from ‘void comparePipeStream(TPipe&, const TStrings&) [with TPipe = seqan::Pipe<seqan::Pipe<seqan::String<seqan::SimpleType<unsigned char, seqan::Dna_>, seqan::Alloc<> >, seqan::Source<> >, seqan::Sampler<3> >; TStrings = seqan::StringSet<seqan::String<char, seqan::Alloc<> > >]’ at seqan/tests/pipe/test_pipe.cpp:330:9:
seqan/include/seqan/pipe/pipe_sampler.h:191:57: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  191 |                                 outRef->i2.i[skipped++] = 0;
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~^~~
In file included from seqan/include/seqan/basic/basic_aggregate.h:59,
                 from seqan/include/seqan/basic.h:98,
                 from seqan/include/seqan/stream.h:61,
                 from seqan/tests/pipe/test_pipe.cpp:40:
seqan/include/seqan/basic/tuple_base.h: In function ‘void comparePipeStream(TPipe&, const TStrings&) [with TPipe = seqan::Pipe<seqan::Pipe<seqan::String<seqan::SimpleType<unsigned char, seqan::Dna_>, seqan::Alloc<> >, seqan::Source<> >, seqan::Sampler<3> >; TStrings = seqan::StringSet<seqan::String<char, seqan::Alloc<> > >]’:
seqan/include/seqan/basic/tuple_base.h:141:46: note: at offset 3 to object ‘seqan::Tuple<seqan::SimpleType<unsigned char, seqan::Dna_>, 3, seqan::Tag<seqan::Pack_> >::i’ with size 3 declared here
  141 |     typename StoredTupleValue_<TValue>::Type i[SIZE];
      |                                              ^
[100%] Linking CXX executable ../../bin/test_pipe
[100%] Built target test_pipe
```

From what I can tell, `0 ≤ skipped < 3` holds, and we actually never access OOB.

Notes:
  * Changing the TValue the tuple holds from `unsigned char` to `unsigned` also silences the warning - these warnings are only generated when accessing an array of some char type.
  * Explicitly inserting something like `&& skipped < SIZE` in the `while` condition also silences the warning. The compiler then sees that we never do OOB access. However, this might impact performance and has room for error due to the nested `while`s.