### PR TITLE
[FIX] T-Coffee file ending for MUM segments

### DIFF
--- a/apps/seqan_tcoffee/seqan_tcoffee.cpp
+++ b/apps/seqan_tcoffee/seqan_tcoffee.cpp
@@ -205,7 +205,7 @@ _initMsaParams(ArgumentParser& parser, TScore& scMat)
         getOptionValue(tmpVal, parser, "libraries", optNo);
         if(endsWith(tmpVal,".blast"))
             appendValue(msaOpt.blastfiles, tmpVal);
-        else if(endsWith(tmpVal,".mummer"))
+        else if(endsWith(tmpVal,".mums"))
                 appendValue(msaOpt.mummerfiles, tmpVal);
             else if(endsWith(tmpVal,".lib"))
                     appendValue(msaOpt.libfiles, tmpVal);


### PR DESCRIPTION
This PR fixes an error, where the argument parser of T-Coffee requires the file ending `.mums`, while in the implementation the ending `.mummer` was considered. 
Solution: The implementation checks for files ending with `.mums`.