### PR TITLE
[FIX] newest sphinxcontrib.bibtex does not work

### DIFF
--- a/manual/source/bibtex.json
+++ b/manual/source/bibtex.json
@@ -1,0 +1,55 @@
+{
+    "cited": {
+        "Tutorial/Algorithms/Alignment/MultipleSequenceAlignment": [
+            "Rausch2008",
+            "Thompson1994"
+        ],
+        "Tutorial/Algorithms/Alignment/PairwiseSequenceAlignment": [
+            "gotoh1982improved",
+            "Urgese2014"
+        ],
+        "Tutorial/Algorithms/ConsensusAlignment": [
+            "Rausch2009"
+        ],
+        "Tutorial/Algorithms/PatternMatching/OnlinePatternMatching": [
+            "Horspool1980",
+            "Aho1975",
+            "Myers1999",
+            "Ukkonen1985",
+            "BaezaYates1999"
+        ],
+        "Tutorial/Algorithms/Realignment": [
+            "Anson1997"
+        ],
+        "Tutorial/Algorithms/SeedExtension": [
+            "Altschul1990",
+            "Pearson1990",
+            "Brudno2003",
+            "Brudno2003b",
+            "Gusfield1997"
+        ],
+        "Tutorial/DataStructures/Alignment/ScoringSchemes": [
+            "cartwright2006logarithmic",
+            "Urgese2014"
+        ],
+        "Tutorial/DataStructures/Indices/StringIndices": [
+            "Manber1993",
+            "Abouelhoda2004",
+            "Giegerich2003",
+            "Weese2008",
+            "Ferragina2001"
+        ],
+        "Tutorial/DataStructures/Seeds": [
+            "Altschul1990",
+            "Pearson1990",
+            "Brudno2003"
+        ],
+        "Tutorial/HowTo/Recipes/AccessIndexFibres": [
+            "Abouelhoda2004",
+            "Giegerich2003"
+        ],
+        "Tutorial/HowTo/UseCases/SimpleRnaSeq": [
+            "Mortazavi2008"
+        ]
+    }
+}

--- a/manual/source/conf.py
+++ b/manual/source/conf.py
@@ -47,6 +47,9 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
+# bibliography file for sphinxcontrib.bibtex
+bibtex_bibfiles = ['seqan.bib']
+
 # The master toctree document.
 master_doc = 'index'
 


### PR DESCRIPTION
sphinxcontrib.bibtex was updated from 1.0.0 to 2.0.0
Usage changed a little bit:
* bib file must be configured
* it creates a json file, if this file does not exist, a warning (=error) is emitted, and sphinx must be rerun. It is recommded to put it into the repository if sphinx should only be run once.

https://sphinxcontrib-bibtex.readthedocs.io/en/latest/usage.html