### PR TITLE
[INFRA] make CI more robust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,4 +196,4 @@ jobs:
       - name: Run tests
         run: |
           cd seqan-build
-          ctest . -j2 --output-on-failure --timeout 120
+          ctest . -j2 --output-on-failure --timeout 120 || ctest . -j2 --output-on-failure --timeout 120 --rerun-failed

--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -106,4 +106,4 @@ jobs:
         run: |
           $env:Path += ";${{ github.workspace }}\seqan-contrib\seqan-contrib-$env:SEQAN_CONRIB_VERSION-x64\vs${{ matrix.msvc_ver }}\lib\"
           cd seqan-build
-          ctest . -j2 -C "${{ matrix.build_type }}" --output-on-failure --timeout 120
+          ctest . -j2 -C "${{ matrix.build_type }}" --output-on-failure --timeout 120 -or ctest . -j2 -C "${{ matrix.build_type }}" --output-on-failure --timeout 120 --rerun-failed


### PR DESCRIPTION
Commit 1: Rerun failed tests. This probably circumvents the spurious fails until we find a permanent solution
Commit 2: Add a timeout to the version check. The tests do not fail if the server is down, but the version check does not time out if the server is down.