### PR TITLE
[FIX] wrong results when searching with horspool

### DIFF
--- a/include/seqan/find/find_horspool.h
+++ b/include/seqan/find/find_horspool.h
@@ -437,6 +437,9 @@ template <typename TFinder, typename TNeedle2>
 bool
 find(TFinder & finder, Pattern<TNeedle2, Horspool> & me)
 {
+    if (length(haystack(finder)) < length(needle(me)))
+        return false;
+
     bool find_first = empty(finder);
     if (find_first)
     {


### PR DESCRIPTION
This seems to fix https://github.com/seqan/product_backlog/issues/261#issuecomment-746779628

In the test, we search (internally) for `GTGGT` in `GTG`. On windows, this sometimes returns `true`.