### PR TITLE
Rework seqan config.cmake

### DIFF
--- a/util/cmake/seqan-config-version.cmake
+++ b/util/cmake/seqan-config-version.cmake
@@ -1,0 +1,41 @@
+# include (CMakePackageConfigHelpers)
+# write_basic_package_version_file( ${CMAKE_CURRENT_LIST_DIR}/seqan-config-version-test.cmake VERSION 2.4.1 COMPATIBILITY ExactVersion )
+
+# This is a basic version file for the Config-mode of find_package().
+# It is used by write_basic_package_version_file() as input file for configure_file()
+# to create a version-file which can be installed along a config.cmake file.
+#
+# The created file sets PACKAGE_VERSION_EXACT if the current version string and
+# the requested version string are exactly the same and it sets
+# PACKAGE_VERSION_COMPATIBLE if the current version is >= requested version,
+# but only if the requested major version is the same as the current one.
+# The variable CVF_VERSION must be set before calling configure_file().
+
+find_file(SEQAN_VERSION_FILE seqan/version.h HINTS ${CMAKE_CURRENT_LIST_DIR}/../../include)
+
+file(STRINGS "${SEQAN_VERSION_FILE}" SEQAN_VERSION_FILE_H REGEX "#define SEQAN_VERSION_(MAJOR|MINOR|PATCH)")
+string(REGEX REPLACE "#define SEQAN_VERSION_(MAJOR|MINOR|PATCH) " "" SEQAN_VERSION_STRING "${SEQAN_VERSION_FILE_H}")
+string(REGEX REPLACE ";" "." SEQAN_VERSION_STRING "${SEQAN_VERSION_STRING}")
+
+set(PACKAGE_VERSION "${SEQAN_VERSION_STRING}")
+
+if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)
+  set(PACKAGE_VERSION_COMPATIBLE FALSE)
+else()
+
+  if("${PACKAGE_VERSION}" MATCHES "^([0-9]+)\\.")
+    set(CVF_VERSION_MAJOR "${CMAKE_MATCH_1}")
+  else()
+    set(CVF_VERSION_MAJOR "${PACKAGE_VERSION}")
+  endif()
+
+  if(PACKAGE_FIND_VERSION_MAJOR STREQUAL CVF_VERSION_MAJOR)
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+  else()
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+  endif()
+
+  if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
+      set(PACKAGE_VERSION_EXACT TRUE)
+  endif()
+endif()

--- a/util/cmake/seqan-config.cmake
+++ b/util/cmake/seqan-config.cmake
@@ -269,29 +269,27 @@ if (SEQAN_USE_SEQAN_BUILD_SYSTEM)
   endforeach (_SEQAN_BASEDIR ${CMAKE_INCLUDE_PATH})
 
   if (_SEQAN_INCLUDE_DIRS)
-    set(SEQAN_FOUND        TRUE)
     set(SEQAN_INCLUDE_DIRS_MAIN ${SEQAN_INCLUDE_DIRS_MAIN} ${_SEQAN_INCLUDE_DIRS})
-  else (_SEQAN_INCLUDE_DIRS)
-    set(SEQAN_FOUND        FALSE)
+    set(SEQAN_INCLUDE_PATH ${SEQAN_INCLUDE_DIRS_MAIN})
   endif (_SEQAN_INCLUDE_DIRS)
 else (SEQAN_USE_SEQAN_BUILD_SYSTEM)
   # When NOT using the SeqAn build system then we only look for one directory
   # with subdirectory seqan and thus only one library.
-  find_path(_SEQAN_BASEDIR "seqan"
+  find_path(_SEQAN_BASEDIR "seqan/version.h"
             PATHS ${SEQAN_INCLUDE_PATH} ENV SEQAN_INCLUDE_PATH
             NO_DEFAULT_PATH)
 
   if (NOT _SEQAN_BASEDIR)
-    find_path(_SEQAN_BASEDIR "seqan")
+    find_path(_SEQAN_BASEDIR "seqan/version.h")
   endif()
 
   mark_as_advanced(_SEQAN_BASEDIR)
 
   if (_SEQAN_BASEDIR)
-    set(SEQAN_FOUND        TRUE)
     set(SEQAN_INCLUDE_DIRS_MAIN ${SEQAN_INCLUDE_DIRS_MAIN} ${_SEQAN_BASEDIR})
+    set(SEQAN_INCLUDE_PATH ${SEQAN_INCLUDE_DIRS_MAIN})
   else ()
-    set(SEQAN_FOUND        FALSE)
+    unset(SEQAN_INCLUDE_PATH)
   endif ()
 endif (SEQAN_USE_SEQAN_BUILD_SYSTEM)
 
@@ -480,9 +478,8 @@ endif (NOT DEFINED SEQAN_VERSION_STRING)
 # Print Variables
 # ----------------------------------------------------------------------------
 
-if (NOT SeqAn_FIND_QUIETLY)
-    message (STATUS "Found Seqan: ${SEQAN_INCLUDE_DIRS_MAIN} (found version \"${SEQAN_VERSION_STRING}\")")
-endif ()
+include (FindPackageHandleStandardArgs)
+find_package_handle_standard_args (SeqAn FOUND_VAR SEQAN_FOUND REQUIRED_VARS SEQAN_INCLUDE_PATH VERSION_VAR SEQAN_VERSION_STRING)
 
 if (SEQAN_FIND_DEBUG)
   message("Result for ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt")


### PR DESCRIPTION
This PR allows `find_package(SeqAn 2.4)`.

TODO: if we package seqan, include `seqan-config-version.cmake`