### PR TITLE
[INFRA] increase CI timeout to 180 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 120
+    timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 120
+    timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
macOS runs sometimes use longer than 2 hours (~95% complete at that time).