### PR TITLE
Fix/vcf io cache accessors

### DIFF
--- a/include/seqan/vcf_io/vcf_io_context.h
+++ b/include/seqan/vcf_io/vcf_io_context.h
@@ -154,7 +154,7 @@ template <typename TNameStore, typename TNameStoreCache, typename TStorageSpec>
 inline TNameStore const &
 contigNames(VcfIOContext<TNameStore, TNameStoreCache, TStorageSpec> const & context)
 {
-    return _referenceCast<TNameStore &>(context._contigNames);
+    return _referenceCast<TNameStore const &>(context._contigNames);
 }
 
 /*!
@@ -179,7 +179,7 @@ template <typename TNameStore, typename TNameStoreCache, typename TStorageSpec>
 inline TNameStoreCache const &
 contigNamesCache(VcfIOContext<TNameStore, TNameStoreCache, TStorageSpec> const & context)
 {
-    return _referenceCast<TNameStoreCache &>(context._contigNamesCache);
+    return _referenceCast<TNameStoreCache const &>(context._contigNamesCache);
 }
 
 /*!
@@ -204,7 +204,7 @@ template <typename TNameStore, typename TNameStoreCache, typename TStorageSpec>
 inline TNameStore const &
 sampleNames(VcfIOContext<TNameStore, TNameStoreCache, TStorageSpec> const & context)
 {
-    return _referenceCast<TNameStore &>(context._sampleNames);
+    return _referenceCast<TNameStore const &>(context._sampleNames);
 }
 
 template <typename TNameStore, typename TNameStoreCache, typename TStorageSpec>
@@ -218,7 +218,7 @@ template <typename TNameStore, typename TNameStoreCache, typename TStorageSpec>
 inline TNameStoreCache const &
 sampleNamesCache(VcfIOContext<TNameStore, TNameStoreCache, TStorageSpec> const & context)
 {
-    return _referenceCast<TNameStoreCache &>(context._sampleNamesCache);
+    return _referenceCast<TNameStoreCache const &>(context._sampleNamesCache);
 }
 
 }  // namespace seqan

--- a/tests/vcf_io/test_vcf_io.cpp
+++ b/tests/vcf_io/test_vcf_io.cpp
@@ -43,6 +43,7 @@ SEQAN_BEGIN_TESTSUITE(test_vcf_io)
     SEQAN_CALL_TEST(test_vcf_io_read_vcf_header);
     SEQAN_CALL_TEST(test_vcf_io_read_vcf_record);
     SEQAN_CALL_TEST(test_vcf_io_vcf_file_read_record);
+    SEQAN_CALL_TEST(test_vcf_io_access_const_io_context);
 
     SEQAN_CALL_TEST(test_vcf_io_write_vcf_header);
     SEQAN_CALL_TEST(test_vcf_io_write_vcf_record);

--- a/tests/vcf_io/test_vcf_io.h
+++ b/tests/vcf_io/test_vcf_io.h
@@ -506,6 +506,25 @@ SEQAN_DEFINE_TEST(test_vcf_io_isOpen_fileIn)
     SEQAN_ASSERT(!isOpen(vcfI));
 }
 
+SEQAN_DEFINE_TEST(test_vcf_io_access_const_io_context)
+{
+    // Build path to file.
+    seqan::CharString vcfPath = seqan::getAbsolutePath("/tests/vcf_io/example.vcf");
+
+    seqan::VcfFileIn vcfStream(toCString(vcfPath));
+    seqan::VcfHeader header;
+
+    readHeader(header, vcfStream);
+
+    seqan::VcfIOContext<> const & cContext = seqan::context(vcfStream);
+
+    SEQAN_ASSERT_EQ(length(contigNames(cContext)), 1u);
+    SEQAN_ASSERT(!empty(contigNamesCache(cContext)));
+
+    SEQAN_ASSERT_EQ(length(sampleNames(cContext)), 3u);
+    SEQAN_ASSERT(!empty(sampleNamesCache(cContext)));
+}
+
 SEQAN_DEFINE_TEST(test_vcf_io_isOpen_fileOut)
 {
     // Build path to file.


### PR DESCRIPTION
Small fix that corrects the constness of the VcfIOContext accessors.
This was not tested before and would otherwise lead to a compile error if used with a const IoContext so I do not expect any breaking changes.