### PR TITLE
[FIX] FMIndex/approximate using short search schemes

### DIFF
--- a/include/seqan/index/find2_index_approx.h
+++ b/include/seqan/index/find2_index_approx.h
@@ -322,7 +322,7 @@ inline void _optimalSearchSchemeDeletion(TDelegate & delegate,
     if (minErrorsLeftInBlock == 0)
     {
         uint8_t const blockIndex2 = std::min(blockIndex + 1, static_cast<uint8_t>(s.u.size()) - 1);
-        bool const goToRight2 = s.pi[blockIndex2] > s.pi[blockIndex2 - 1];
+        bool const goToRight2 = (blockIndex2 == 0) ? true : (s.pi[blockIndex2] > s.pi[blockIndex2 - 1]);
 
         if (goToRight2)
         {
@@ -395,7 +395,7 @@ inline void _optimalSearchSchemeChildren(TDelegate & delegate,
                 else
                 {
                     uint8_t blockIndex2 = std::min(blockIndex + 1, static_cast<uint8_t>(s.u.size()) - 1);
-                    bool goToRight2 = s.pi[blockIndex2] > s.pi[blockIndex2 - 1];
+                    bool const goToRight2 = (blockIndex2 == 0) ? true : (s.pi[blockIndex2] > s.pi[blockIndex2 - 1]);
                     if (goToRight2)
                     {
                         _optimalSearchScheme(delegate, iter, needle, needleLeftPos2, needleRightPos2, errors + delta, s,


### PR DESCRIPTION
In the case a search scheme with only one part is being used
(s.pi.size() == 1) an invalid read is being produced.

Every part has to be read in forwards or backwards direction. This
depends on the previous parts. Normally the shown code is only being
executed with the second or above part, this might be different in the
case when only one part exists. In general it doesn't matter if the
first part is being read in forward or backwards direction.

The suggested code change is derived from the equivalent seqan3 code
base with a similar adjustment
https://github.com/seqan/seqan3/blob/58429c14117444dba6448713b0ad9c3160af0ed3/include/seqan3/search/detail/search_scheme_algorithm.hpp#L429