### PR TITLE
[FIX] add missing definition of static variables

### DIFF
--- a/include/seqan/bam_io/bam_alignment_record.h
+++ b/include/seqan/bam_io/bam_alignment_record.h
@@ -249,10 +249,10 @@ public:
     CharString tags;  // raw tags in BAM format
     CharString _buffer; // reusable internal buffer (used for I/O)
 
-    static int32_t const INVALID_POS = -1;
-    static int32_t const INVALID_REFID = -1;  // TODO(holtgrew): Rename to ...REF_ID.
-    static int32_t const INVALID_LEN = 0;
-    static uint32_t const INVALID_QID = 4294967295u;  // TODO(holtgrew): Undocumented as of yet.
+    inline static int32_t const INVALID_POS = -1;
+    inline static int32_t const INVALID_REFID = -1;  // TODO(holtgrew): Rename to ...REF_ID.
+    inline static int32_t const INVALID_LEN = 0;
+    inline static uint32_t const INVALID_QID = 4294967295u;  // TODO(holtgrew): Undocumented as of yet.
 
     BamAlignmentRecord() : _qID(std::numeric_limits<unsigned>::max()) { clear(*this); }
 };

--- a/include/seqan/bed_io/bed_record.h
+++ b/include/seqan/bed_io/bed_record.h
@@ -140,8 +140,8 @@ template <>
 class BedRecord<Bed3>
 {
 public:
-    static const int INVALID_REFID = -1;
-    static const int INVALID_POS = -1;
+    inline static const int INVALID_REFID = -1;
+    inline static const int INVALID_POS = -1;
 
     // The chromosome name.
     CharString ref;

--- a/include/seqan/rna_io/rna_record.h
+++ b/include/seqan/rna_io/rna_record.h
@@ -120,7 +120,7 @@ class RnaRecord
 {
 private:
     // Constant for an undefined ID.
-    static std::uint32_t const _undef = std::numeric_limits<std::uint32_t>::max();
+    inline static std::uint32_t const _undef = std::numeric_limits<std::uint32_t>::max();
 
 public:
     // NOTE(marehr): Explicitly define a default constructor, to fix a msvc 2017

--- a/include/seqan/roi_io/roi_record.h
+++ b/include/seqan/roi_io/roi_record.h
@@ -64,7 +64,7 @@ public:
 class RoiRecord
 {
 public:
-    static const int INVALID_POS = -1;
+    inline static const int INVALID_POS = -1;
 
     // Chromosome that this region is on.
     CharString ref;

--- a/include/seqan/vcf_io/vcf_record.h
+++ b/include/seqan/vcf_io/vcf_record.h
@@ -128,9 +128,9 @@ class VcfRecord
 {
 public:
     // Constant for invalid reference id.
-    static const int32_t INVALID_REFID = -1;
+    inline static const int32_t INVALID_REFID = -1;
     // Constant for invalid position.
-    static const int32_t INVALID_POS = -1;
+    inline static const int32_t INVALID_POS = -1;
 
     // Numeric id of the reference sequence.
     int32_t rID;


### PR DESCRIPTION
The definition of some variables are missing. This PR adds them.