### PR TITLE
[FIX] CMake: Use execute_process

### DIFF
--- a/util/cmake/seqan-config.cmake
+++ b/util/cmake/seqan-config.cmake
@@ -206,9 +206,8 @@ if (COMPILER_GCC OR COMPILER_CLANG OR COMPILER_LINTEL)
   set (SEQAN_DEFINITIONS ${SEQAN_DEFINITIONS} -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64)
 
   # Determine GCC version.
-  EXEC_PROGRAM(${CMAKE_CXX_COMPILER}
-               ARGS --version
-               OUTPUT_VARIABLE __GCC_VERSION)
+  EXECUTE_PROCESS(COMMAND ${CMAKE_CXX_COMPILER} --version
+                  OUTPUT_VARIABLE __GCC_VERSION)
   # Remove all but first line.
   STRING(REGEX REPLACE "([^\n]+).*" "\\1" __GCC_VERSION ${__GCC_VERSION})
   # Find out version (3 or 2 components).


### PR DESCRIPTION
```
[cmake]   CMake Warning (dev) at util/cmake/seqan-config.cmake:209 (EXEC_PROGRAM):
[cmake]   Policy CMP0153 is not set: The exec_program command should not be called.
[cmake]   Run "cmake --help-policy CMP0153" for policy details.  Use the cmake_policy
[cmake]   command to set the policy and suppress this warning.
[cmake] 
[cmake]   Use execute_process() instead.
```