### PR TITLE
[FIX] mason_variator: Fix StructuralVariantRecord::endPosition() for deletions.

### DIFF
--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -52,9 +52,17 @@ jobs:
 
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: ""
+          auto-activate-base: true
+          auto-update-conda: false
 
       - name: Install conda dependencies
-        run: conda install -c conda-forge boost-cpp bzip2 libxml2 zlib
+        run: |
+          conda install -c conda-forge boost-cpp bzip2 libxml2 zlib
+          $CONDA_BASE = conda info --base
+          "$CONDA_BASE\Library\include" | Out-File -FilePath $env:GITHUB_PATH -Append
+          "$CONDA_BASE\Library\lib" | Out-File -FilePath $env:GITHUB_PATH -Append
 
       - name: Configure tests
         run: |

--- a/apps/mason2/README
+++ b/apps/mason2/README
@@ -86,12 +86,6 @@ VCF file:
 3. Reference and Contact
 ------------------------------------------------------------------------------
 
-In case of questions and problems please contact the mailing list
+In case of questions and problems please contact us on
 
-  https://lists.fu-berlin.de/listinfo/seqan-dev
-
-or file a bug at
-
-  https://trac.seqan.de/newticket
-
-
+https://github.com/seqan/seqan

--- a/apps/mason2/genomic_variants.cpp
+++ b/apps/mason2/genomic_variants.cpp
@@ -59,7 +59,7 @@ int StructuralVariantRecord::endPosition() const
             if (size > 0)
                 return pos;
             else
-                return pos + size;
+                return pos - size; // for deletions, size is negative!
         case INVERSION:
             return pos + size;
         case TRANSLOCATION:

--- a/include/seqan/graph_types/graph_impl_hmm.h
+++ b/include/seqan/graph_types/graph_impl_hmm.h
@@ -740,6 +740,9 @@ getTransitionProbability(Graph<Hmm<TAlphabet, TCargo, TSpec> > const& g,
     typedef Graph<Hmm<TAlphabet, TCargo, TSpec> > const TGraph;
     typedef typename EdgeDescriptor<TGraph>::Type TEdgeDescriptor;
     TEdgeDescriptor e = findEdge(g, state1, state2);
+#ifdef __INTEL_LLVM_COMPILER
+    asm volatile("" : : "r,m"(e) : "memory"); // Kindly request IntelLLVM (2024.1) to not optimize result away.
+#endif
     if (e == 0) return 0.0;
     else return cargo(e);
 }

--- a/util/bin/demo_checker.py
+++ b/util/bin/demo_checker.py
@@ -44,7 +44,7 @@ def fuzzyEqual(pattern, text):
                 print('Line %s is different between expected and actual outputs.' % (i), file=sys.stderr)
                 return False
             else:
-                P = (re.escape(P)).replace('\\[VAR\\]', "[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?")
+                P = (re.escape(P)).replace('\\[VAR\\]', r'[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?')
                 r = re.compile(P)
                 if re.match(r, T) == None:
                     print('Line %s is different (REGEX) between expected and actual outputs.' % (i), file=sys.stderr)


### PR DESCRIPTION
This fixes #2511 

Let's see what the tests say as it seems to be an rather invasive fix.

So the reported error in Debug mode, was that a SNP is within the region of a deletion.

```
Assertion failed : snpRecord.getPos() != svRecord.getPos() should be true but was 0 (Should be generated non-overlapping (snp pos = 148753369, sv pos = 148753369).)
```

What happens is the following: 

1) mason_variator simulates SVs
2) mason_variator simulates SNP/Indels: It goes over every position in the contig (e.g. a chromosome) and at the same time maintains the current SV of the region to avoid overlaps. It jumps to the next SV if the current position is greater than the end position of the current SV [`pos >= svRecord.endPosition()`](https://github.com/seqan/seqan/blob/main/apps/mason2/mason_variator.cpp#L630)
3) An `svRecord` of type [StructuralVariantRecord](https://github.com/seqan/seqan/blob/main/apps/mason2/genomic_variants.h#L179) stores a size. The size is negative if it is a deletion.
4) [StructuralVariantRecord::endPosition()](https://github.com/seqan/seqan/blob/main/apps/mason2/genomic_variants.cpp#L51) returns `pos + size` for deletions.. but since `size` is negative, the end position of the deletion is **BEFORE** its start position.
5) (4) leads to a bug in the while loop in (2). The while loop will to jump to the next SV because and end pos is reached already before the start of the deletion has been reached. The overlap of a SNP with the start position of an Deletion is not checked anymore.
