### PR TITLE
[FIX] Missing SQ header in BAM output

### DIFF
--- a/include/seqan/bam_io/write_bam.h
+++ b/include/seqan/bam_io/write_bam.h
@@ -57,9 +57,7 @@ void write(TTarget & target,
     write(target, "BAM\1");
     clear(context.buffer);
 
-    // Create text of header.
-    for (unsigned i = 0; i < length(header); ++i)
-        write(context.buffer, header[i], context, Sam());
+    write(context.buffer, header, context, Sam());
 
     // Note that we do not write out a null-character to terminate the header.  This would be valid by the SAM standard
     // but the samtools do not expect this and write out the '\0' when converting from BAM to SAM.


### PR DESCRIPTION
The BAM output is missing the `@SQ` headers derived from the context.

According to the SAM spec, the header *should* contain the references.

When rewriting a seqan2 BAM with `samtools view -hb`, the `@SQ` lines are silently regenerated (from the `l_name`, `name`, and `l_ref` data fields in the list of reference information in the BAM file).

