### PR TITLE
[FIX] Segfault in GlobalAlignment

### DIFF
--- a/include/seqan/align/dp_matrix_navigator_score_matrix.h
+++ b/include/seqan/align/dp_matrix_navigator_score_matrix.h
@@ -361,7 +361,7 @@ _goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix, THost>, DPScoreMa
 template <typename TDPCell,
           typename TValue, typename TMatrixSpec, typename THost,
           typename TColumnType>
-inline void
+inline std::enable_if_t<!std::is_same_v<TColumnType, DPInitialColumn>>
 _preInitCacheDiagonal(TDPCell & cacheDiagonal,
                       DPMatrixNavigator_<DPMatrix_<TValue, TMatrixSpec, THost>, DPScoreMatrix, NavigateColumnWiseBanded> const & dpNavigator,
                       MetaColumnDescriptor<TColumnType, PartialColumnMiddle> const & /*tag*/)
@@ -372,7 +372,7 @@ _preInitCacheDiagonal(TDPCell & cacheDiagonal,
 template <typename TDPCell,
           typename TValue, typename TMatrixSpec, typename THost,
           typename TColumnType>
-inline void
+inline std::enable_if_t<!std::is_same_v<TColumnType, DPInitialColumn>>
 _preInitCacheDiagonal(TDPCell & cacheDiagonal,
                       DPMatrixNavigator_<DPMatrix_<TValue, TMatrixSpec, THost>, DPScoreMatrix, NavigateColumnWiseBanded> const & dpNavigator,
                       MetaColumnDescriptor<TColumnType, PartialColumnBottom> const & /*tag*/)


### PR DESCRIPTION
Resolves #2524 

We are in this case: https://github.com/seqan/seqan/blob/main/include/seqan/align/dp_algorithm_impl.h#L691

Some time later, this line will also be called on the first Column:
https://github.com/seqan/seqan/blob/45fa675f63514f1b95f746644bf5648379d0101e/include/seqan/align/dp_algorithm_impl.h#L361

However, there is no previous column.

<details><summary>Testcode (click to expand)</summary>

```cpp
#include <iostream>

#include <seqan/align.h>

int main()
{
    seqan2::String<char> const seq1{"CDFGHC"};
    seqan2::String<char> const seq2{"CDEFGAHC"};

    seqan2::Align<seqan2::String<char>, seqan2::ArrayGaps> align{};
    seqan2::resize(seqan2::rows(align), 2);
    seqan2::assignSource(seqan2::row(align, 0), seq1);
    seqan2::assignSource(seqan2::row(align, 1), seq2);

    int const score = seqan2::globalAlignment(align,
                                              seqan2::Score<int, seqan2::Simple>(0, -1, -1),
                                              seqan2::AlignConfig<true, true, true, true>(),
                                              -2,
                                              -1);
    std::cout << "Score: " << score << std::endl;
    std::cout << align << std::endl;

    return 0;
}
```
</details> 