### PR TITLE
[FIX] heap-use-after-free

### DIFF
--- a/include/seqan/align_parallel/wavefront_task.h
+++ b/include/seqan/align_parallel/wavefront_task.h
@@ -83,7 +83,7 @@ public:
     using TContext  = TAlignmentContext;
 
     TContext &                     context;
-    std::array<WavefrontTask*, 2>  successor{{nullptr, nullptr}};
+    std::array<std::shared_ptr<WavefrontTask>, 2>  successor{{nullptr, nullptr}};
     size_t                         col{0};
     size_t                         row{0};
     std::atomic<size_t>            refCount{0};
@@ -95,7 +95,7 @@ public:
     // Constructor
     WavefrontTask() = delete;
 
-    WavefrontTask(TContext & context, std::array<WavefrontTask*, 2> successor,
+    WavefrontTask(TContext & context, std::array<std::shared_ptr<WavefrontTask>, 2> successor,
                   size_t const col,
                   size_t const row,
                   size_t const refCount,
@@ -315,7 +315,7 @@ template <typename TTasks, typename TDPLocalData>
 inline void
 executeSimd(TTasks & tasks, TDPLocalData & dpLocal)
 {
-    using TTask = typename std::remove_pointer<typename Value<TTasks>::Type>::type;
+    using TTask = typename std::pointer_traits<typename Value<TTasks>::Type>::element_type;
     using TExecTraits = SimdTaskExecutionTraits<typename TTask::TContext>;
 
     auto offset = impl::computeOffset(tasks, TExecTraits{});

--- a/include/seqan/align_parallel/wavefront_task_executor.h
+++ b/include/seqan/align_parallel/wavefront_task_executor.h
@@ -86,7 +86,7 @@ struct WavefrontTaskExecutionPolicy<WavefrontTask<TArgs...>>
         for (auto succ : successor(task))
         {
             if (succ && decrementRefCount(*succ) == 0)
-                spawn(wavefrontExec, TWaveTaskExec{succ, &wavefrontExec});
+                spawn(wavefrontExec, TWaveTaskExec{&*succ, &wavefrontExec});
         }
         if (isLastTask(task))
         {
@@ -121,7 +121,7 @@ struct WavefrontTaskExecutionPolicy<WavefrontTaskQueue<TValue, VECTOR_SIZE>>
             {
                 if (succ && decrementRefCount(*succ) == 0)
                 {
-                    appendValue(resource, *succ);
+                    appendValue(resource, succ);
                     spawn(wavefrontExec, TWaveTaskExec{&resource, &wavefrontExec});
                 }
             }

--- a/include/seqan/align_parallel/wavefront_task_queue.h
+++ b/include/seqan/align_parallel/wavefront_task_queue.h
@@ -55,8 +55,8 @@ public:
 
 
     // Member Types.
-    using TQueue = ConcurrentQueue<TValue*>;
-    using ResultType = std::vector<TValue*>;
+    using TQueue = ConcurrentQueue<std::shared_ptr<TValue>>;
+    using ResultType = std::vector<std::shared_ptr<TValue>>;
     using ValueType = TValue;
 
     // Members.
@@ -121,9 +121,9 @@ tryPopTasks(typename WavefrontTaskQueue<TValue, VECTOR_SIZE>::ResultType & tasks
 template <typename TValue, size_t VECTOR_SIZE>
 inline void
 appendValue(WavefrontTaskQueue<TValue, VECTOR_SIZE> & me,
-            TValue & newTask)
+            std::shared_ptr<TValue> newTask)
 {
-    appendValue(me.queue, &newTask);
+    appendValue(me.queue, newTask);
 }
 
 template <typename TValue, size_t VECTOR_SIZE>


### PR DESCRIPTION
In the original line `appendValue(taskQueue, *taskGraph[0][0])`, the std::shared_ptr was dereferenced and appended to the taskQueue. This taskQueue was then used by the executor. On rare occassions (depending on which thread does what and when), it could happen that the executor tries to access the task* after it was destructed when all std::shared_ptr instances were destructed.

By passing the task via shared_ptr instead of raw pointer, we can ensure that any access by the executor is valid.