### PR TITLE
[MISC] Use is_same<...>::value

### DIFF
--- a/include/seqan/align/dp_matrix_navigator_score_matrix.h
+++ b/include/seqan/align/dp_matrix_navigator_score_matrix.h
@@ -361,7 +361,7 @@ _goNextCell(DPMatrixNavigator_<DPMatrix_<TValue, FullDPMatrix, THost>, DPScoreMa
 template <typename TDPCell,
           typename TValue, typename TMatrixSpec, typename THost,
           typename TColumnType>
-inline std::enable_if_t<!std::is_same_v<TColumnType, DPInitialColumn>>
+inline std::enable_if_t<!std::is_same<TColumnType, DPInitialColumn>::value>
 _preInitCacheDiagonal(TDPCell & cacheDiagonal,
                       DPMatrixNavigator_<DPMatrix_<TValue, TMatrixSpec, THost>, DPScoreMatrix, NavigateColumnWiseBanded> const & dpNavigator,
                       MetaColumnDescriptor<TColumnType, PartialColumnMiddle> const & /*tag*/)
@@ -372,7 +372,7 @@ _preInitCacheDiagonal(TDPCell & cacheDiagonal,
 template <typename TDPCell,
           typename TValue, typename TMatrixSpec, typename THost,
           typename TColumnType>
-inline std::enable_if_t<!std::is_same_v<TColumnType, DPInitialColumn>>
+inline std::enable_if_t<!std::is_same<TColumnType, DPInitialColumn>::value>
 _preInitCacheDiagonal(TDPCell & cacheDiagonal,
                       DPMatrixNavigator_<DPMatrix_<TValue, TMatrixSpec, THost>, DPScoreMatrix, NavigateColumnWiseBanded> const & dpNavigator,
                       MetaColumnDescriptor<TColumnType, PartialColumnBottom> const & /*tag*/)


### PR DESCRIPTION
Instead is_same_v<...>. Latter is C++17 and the only thing that fails when compiling with C++14