### PR TITLE
Converts assertion to exception in case two traces cannot be merged.

### DIFF
--- a/include/seqan/seeds/banded_chain_alignment.h
+++ b/include/seqan/seeds/banded_chain_alignment.h
@@ -96,6 +96,8 @@ namespace seqan2 {
  *                smallest value of the score type @endlink is used to return the minimal value of the selected score
  *                type and no alignment is computed.
  *
+ * @throws std::logic_error if during the alignment no valid alignment path can be found connecting two anchors.
+ *
  * There exist multiple overloads for this function with four configuration dimensions.
  *
  * First, you can select whether begin and end gaps are free in either sequence using <tt>alignConfig</tt>.

--- a/include/seqan/seeds/banded_chain_alignment_traceback.h
+++ b/include/seqan/seeds/banded_chain_alignment_traceback.h
@@ -194,12 +194,13 @@ inline void _glueTracebacks(TTraceSet & globalTraces, TTraceSet & localTraces)
         }
     }
 
+    if (!isGlued)
+        throw std::logic_error("Fatal error while trying to connect trace backs: No glue point available!");
+
     for (unsigned i = length(elementsToErase); i > 0; --i)
     {
         erase(globalTraces, elementsToErase[i-1]); // erase from behind to avoid accessing an element beyond the scope
     }
-    SEQAN_ASSERT_EQ_MSG(isGlued, true, "Fatal error while trying to connect trace backs: No glue point available!");
-    ignoreUnusedVariableWarning(isGlued);
 }
 
 // ----------------------------------------------------------------------------

--- a/tests/seeds/CMakeLists.txt
+++ b/tests/seeds/CMakeLists.txt
@@ -53,6 +53,8 @@ add_executable (test_seeds_align_banded_chain_impl
                 test_align_banded_chain_impl.cpp)
 add_executable (test_seeds_banded_chain_alignment_interface
                 test_banded_chain_alignment_interface.cpp)
+add_executable (test_seeds_align_banded_chain_issue_2540
+                test_align_banded_chain_issue_2540.cpp)
 
 # Add dependencies found by find_package (SeqAn).
 target_link_libraries (test_seeds_combination ${SEQAN_LIBRARIES})
@@ -65,6 +67,7 @@ target_link_libraries (test_seeds_seed_set_base ${SEQAN_LIBRARIES})
 target_link_libraries (test_seeds_seed_set_unordered ${SEQAN_LIBRARIES})
 target_link_libraries (test_seeds_align_banded_chain_impl ${SEQAN_LIBRARIES})
 target_link_libraries (test_seeds_banded_chain_alignment_interface ${SEQAN_LIBRARIES})
+target_link_libraries (test_seeds_align_banded_chain_issue_2540 ${SEQAN_LIBRARIES})
 
 # ----------------------------------------------------------------------------
 # Register with CTest
@@ -80,3 +83,4 @@ add_test (NAME test_test_seeds_seed_set_base COMMAND $<TARGET_FILE:test_seeds_se
 add_test (NAME test_test_seeds_seed_set_unordered COMMAND $<TARGET_FILE:test_seeds_seed_set_unordered>)
 add_test (NAME test_test_seeds_align_banded_chain_impl COMMAND $<TARGET_FILE:test_seeds_align_banded_chain_impl>)
 add_test (NAME test_test_seeds_banded_chain_alignment_interface COMMAND $<TARGET_FILE:test_seeds_banded_chain_alignment_interface>)
+add_test (NAME test_seeds_align_banded_chain_issue_2540 COMMAND $<TARGET_FILE:test_seeds_align_banded_chain_issue_2540>)


### PR DESCRIPTION
Not fixing #2540 but working around assert that could in release mode lead to UB. This way there is a decent abortion when two traces cannot be merged.
Looking deeper into the code suggests that a larger rework is necessary and better be dealt with when implementing such algorithm inside of modern SeqAn versions.