### PR TITLE
[INFRA] Bump app versions

### DIFF
--- a/apps/alf/CMakeLists.txt
+++ b/apps/alf/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required (VERSION 3.12)
 project (seqan_apps_alf CXX)
 message (STATUS "Configuring apps/alf")
 
-set (SEQAN_APP_VERSION "1.1.11")
+set (SEQAN_APP_VERSION "1.1.12")
 
 # ----------------------------------------------------------------------------
 # Dependencies

--- a/apps/bs_tools/CMakeLists.txt
+++ b/apps/bs_tools/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required (VERSION 3.12)
 project (seqan_apps_bs_tools CXX)
 message (STATUS "Configuring apps/bs_tools")
 
-set (SEQAN_APP_VERSION "0.1.11")
+set (SEQAN_APP_VERSION "0.1.12")
 
 if ((${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD") AND ("$ENV{MODEL}" STREQUAL "Nightly"))
     message (STATUS "bs_tools skipped on FreeBSD because math.h rounding errors.")

--- a/apps/dfi/CMakeLists.txt
+++ b/apps/dfi/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required (VERSION 3.12)
 project (seqan_apps_dfi CXX)
 message (STATUS "Configuring apps/dfi")
 
-set (SEQAN_APP_VERSION "2.1.11")
+set (SEQAN_APP_VERSION "2.1.12")
 
 # ----------------------------------------------------------------------------
 # Dependencies

--- a/apps/fiona/CMakeLists.txt
+++ b/apps/fiona/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required (VERSION 3.12)
 project (seqan_apps_fiona CXX)
 message (STATUS "Configuring apps/fiona")
 
-set (SEQAN_APP_VERSION "0.2.11")
+set (SEQAN_APP_VERSION "0.2.12")
 
 # ----------------------------------------------------------------------------
 # Dependencies

--- a/apps/fx_tools/CMakeLists.txt
+++ b/apps/fx_tools/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required (VERSION 3.12)
 project (seqan_apps_fx_tools CXX)
 message (STATUS "Configuring apps/fx_tools")
 
-set (SEQAN_APP_VERSION "0.2.11")
+set (SEQAN_APP_VERSION "0.2.12")
 
 # ----------------------------------------------------------------------------
 # Dependencies

--- a/apps/gustaf/CMakeLists.txt
+++ b/apps/gustaf/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required (VERSION 3.12)
 project (seqan_apps_gustaf CXX)
 message (STATUS "Configuring apps/gustaf")
 
-set (SEQAN_APP_VERSION "1.0.11")
+set (SEQAN_APP_VERSION "1.0.12")
 
 # ----------------------------------------------------------------------------
 # Dependencies

--- a/apps/insegt/CMakeLists.txt
+++ b/apps/insegt/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required (VERSION 3.12)
 project (seqan_apps_insegt CXX)
 message (STATUS "Configuring apps/insegt")
 
-set (SEQAN_APP_VERSION "1.1.11")
+set (SEQAN_APP_VERSION "1.1.12")
 
 # ----------------------------------------------------------------------------
 # Dependencies

--- a/apps/mason2/CMakeLists.txt
+++ b/apps/mason2/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required (VERSION 3.12)
 project (seqan_apps_mason2 CXX)
 message (STATUS "Configuring apps/mason2")
 
-set (SEQAN_APP_VERSION "2.0.10")
+set (SEQAN_APP_VERSION "2.0.11")
 
 # ----------------------------------------------------------------------------
 # Dependencies

--- a/apps/micro_razers/CMakeLists.txt
+++ b/apps/micro_razers/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required (VERSION 3.12)
 project (seqan_apps_micro_razers CXX)
 message (STATUS "Configuring apps/micro_razers")
 
-set (SEQAN_APP_VERSION "1.0.12")
+set (SEQAN_APP_VERSION "1.0.13")
 
 # ----------------------------------------------------------------------------
 # Dependencies

--- a/apps/ngs_roi/CMakeLists.txt
+++ b/apps/ngs_roi/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required (VERSION 3.12)
 project (seqan_apps_ngs_roi CXX)
 message (STATUS "Configuring apps/ngs_roi")
 
-set (SEQAN_APP_VERSION "0.2.13")
+set (SEQAN_APP_VERSION "0.2.14")
 
 # ----------------------------------------------------------------------------
 # Dependencies

--- a/apps/pair_align/CMakeLists.txt
+++ b/apps/pair_align/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required (VERSION 3.12)
 project (seqan_apps_pair_align CXX)
 message (STATUS "Configuring apps/pair_align")
 
-set (SEQAN_APP_VERSION "1.3.9")
+set (SEQAN_APP_VERSION "1.3.10")
 
 # ----------------------------------------------------------------------------
 # Dependencies

--- a/apps/param_chooser/CMakeLists.txt
+++ b/apps/param_chooser/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required (VERSION 3.12)
 project (seqan_apps_param_chooser CXX)
 message (STATUS "Configuring apps/param_chooser")
 
-set (SEQAN_APP_VERSION "0.0.10")
+set (SEQAN_APP_VERSION "0.0.11")
 
 # ----------------------------------------------------------------------------
 # Dependencies

--- a/apps/rabema/CMakeLists.txt
+++ b/apps/rabema/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required (VERSION 3.12)
 project (seqan_apps_rabema CXX)
 message (STATUS "Configuring apps/rabema")
 
-set (SEQAN_APP_VERSION "1.2.11")
+set (SEQAN_APP_VERSION "1.2.12")
 
 # ----------------------------------------------------------------------------
 # Dependencies

--- a/apps/razers/CMakeLists.txt
+++ b/apps/razers/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required (VERSION 3.12)
 project (seqan_apps_razers CXX)
 message (STATUS "Configuring apps/razers")
 
-set (SEQAN_APP_VERSION "1.5.9")
+set (SEQAN_APP_VERSION "1.5.10")
 
 # ----------------------------------------------------------------------------
 # Dependencies

--- a/apps/razers3/CMakeLists.txt
+++ b/apps/razers3/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required (VERSION 3.12)
 project (seqan_apps_razers3 CXX)
 message (STATUS "Configuring apps/razers3")
 
-set (SEQAN_APP_VERSION "3.5.9")
+set (SEQAN_APP_VERSION "3.5.10")
 
 # ----------------------------------------------------------------------------
 # Dependencies

--- a/apps/rep_sep/CMakeLists.txt
+++ b/apps/rep_sep/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required (VERSION 3.12)
 project (seqan_apps_rep_sep CXX)
 message (STATUS "Configuring apps/rep_sep")
 
-set (SEQAN_APP_VERSION "0.1.12")
+set (SEQAN_APP_VERSION "0.1.13")
 
 # ----------------------------------------------------------------------------
 # Dependencies

--- a/apps/sak/CMakeLists.txt
+++ b/apps/sak/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required (VERSION 3.12)
 project (seqan_apps_sak CXX)
 message (STATUS "Configuring apps/sak")
 
-set (SEQAN_APP_VERSION "0.4.9")
+set (SEQAN_APP_VERSION "0.4.10")
 
 # ----------------------------------------------------------------------------
 # Dependencies

--- a/apps/sam2matrix/CMakeLists.txt
+++ b/apps/sam2matrix/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required (VERSION 3.12)
 project (seqan_apps_sam2matrix CXX)
 message (STATUS "Configuring apps/sam2matrix")
 
-set (SEQAN_APP_VERSION "0.3.9")
+set (SEQAN_APP_VERSION "0.3.10")
 
 # ----------------------------------------------------------------------------
 # Dependencies

--- a/apps/samcat/CMakeLists.txt
+++ b/apps/samcat/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required (VERSION 3.12)
 project (seqan_apps_samcat CXX)
 message (STATUS "Configuring apps/samcat")
 
-set (SEQAN_APP_VERSION "0.3.9")
+set (SEQAN_APP_VERSION "0.3.10")
 
 # ----------------------------------------------------------------------------
 # Dependencies

--- a/apps/searchjoin/CMakeLists.txt
+++ b/apps/searchjoin/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required (VERSION 3.12)
 project (seqan_apps_searchjoin CXX)
 message (STATUS "Configuring apps/searchjoin")
 
-set (SEQAN_APP_VERSION "0.5.9")
+set (SEQAN_APP_VERSION "0.5.10")
 
 # ----------------------------------------------------------------------------
 # Dependencies

--- a/apps/seqan_tcoffee/CMakeLists.txt
+++ b/apps/seqan_tcoffee/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required (VERSION 3.12)
 project (seqan_apps_seqan_tcoffee CXX)
 message (STATUS "Configuring apps/seqan_tcoffee")
 
-set (SEQAN_APP_VERSION "1.13.9")
+set (SEQAN_APP_VERSION "1.13.10")
 
 # ----------------------------------------------------------------------------
 # Dependencies

--- a/apps/seqcons2/CMakeLists.txt
+++ b/apps/seqcons2/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required (VERSION 3.12)
 project (seqan_apps_seqcons2 CXX)
 message (STATUS "Configuring apps/seqcons2")
 
-set (SEQAN_APP_VERSION "2.0.10")
+set (SEQAN_APP_VERSION "2.0.11")
 
 # ----------------------------------------------------------------------------
 # Dependencies

--- a/apps/sgip/CMakeLists.txt
+++ b/apps/sgip/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required (VERSION 3.12)
 project (seqan_apps_sgip CXX)
 message (STATUS "Configuring apps/sgip")
 
-set (SEQAN_APP_VERSION "1.4.9")
+set (SEQAN_APP_VERSION "1.4.10")
 
 # ----------------------------------------------------------------------------
 # Dependencies

--- a/apps/snp_store/CMakeLists.txt
+++ b/apps/snp_store/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required (VERSION 3.12)
 project (seqan_apps_snp_store CXX)
 message (STATUS "Configuring apps/snp_store")
 
-set (SEQAN_APP_VERSION "1.3.9")
+set (SEQAN_APP_VERSION "1.3.10")
 
 # ----------------------------------------------------------------------------
 # Dependencies

--- a/apps/splazers/CMakeLists.txt
+++ b/apps/splazers/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required (VERSION 3.12)
 project (seqan_apps_splazers CXX)
 message (STATUS "Configuring apps/splazers")
 
-set (SEQAN_APP_VERSION "1.3.9")
+set (SEQAN_APP_VERSION "1.3.10")
 
 # ----------------------------------------------------------------------------
 # Dependencies

--- a/apps/stellar/CMakeLists.txt
+++ b/apps/stellar/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required (VERSION 3.12)
 project (seqan_apps_stellar CXX)
 message (STATUS "Configuring apps/stellar")
 
-set (SEQAN_APP_VERSION "1.4.12")
+set (SEQAN_APP_VERSION "1.4.13")
 
 # ----------------------------------------------------------------------------
 # Dependencies

--- a/apps/tree_recon/CMakeLists.txt
+++ b/apps/tree_recon/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required (VERSION 3.12)
 project (seqan_apps_tree_recon CXX)
 message (STATUS "Configuring apps/tree_recon")
 
-set (SEQAN_APP_VERSION "1.4.9")
+set (SEQAN_APP_VERSION "1.4.10")
 
 # ----------------------------------------------------------------------------
 # Dependencies

--- a/apps/yara/CMakeLists.txt
+++ b/apps/yara/CMakeLists.txt
@@ -41,7 +41,7 @@ endif (NOT BZIP2_FOUND)
 # App-Level Configuration
 # ----------------------------------------------------------------------------
 
-set (SEQAN_APP_VERSION "1.0.3")
+set (SEQAN_APP_VERSION "1.0.4")
 
 option (YARA_LARGE_CONTIGS "Set to OFF to disable support for more than 32k contigs or contigs longer than 4Gbp." ON)
 if (YARA_LARGE_CONTIGS)

--- a/util/bump_app_versions.sh
+++ b/util/bump_app_versions.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# ----------------------------------------------------------------------------
+#                  SeqAn - The Library for Sequence Analysis
+# ----------------------------------------------------------------------------
+# Copyright (c) 2006-2024, Knut Reinert, FU Berlin
+# All rights reserved.
+#
+# License: BSD 3-clause
+
+set -Eeuo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <seqan_root>"
+    exit 1
+fi
+
+directory=$(readlink -m "$1")
+
+if [[ ! -d "${directory}" ]]; then
+    echo "Not a valid directory: ${directory}"
+    exit 1
+fi
+
+if [[ ! -f "${directory}/apps/CMakeLists.txt" ]]; then
+    echo "This does not seem to be the SeqAn root directory: ${directory}"
+    exit 1
+fi
+
+while IFS= read -r -d '' file; do
+    # shellcheck disable=SC2016
+    sed -i -E 's@set \(SEQAN_APP_VERSION "([0-9]+)\.([0-9]+)\.([0-9]+)"\)@echo "set (SEQAN_APP_VERSION \\"\1.\2.$((\3 + 1))\\")"@ge' "${file}"
+done < <(find "${directory}/apps/" -type f -name "CMakeLists.txt" -print0)


### PR DESCRIPTION
Some app versions are out of sync. E.g., there is already a yara 1.0.3 on packages.seqan.de, but the version wasn't bumped afterwards.
To avoid clashes, just bump all the app versions.