### PR TITLE
[FIX] mason2: Detect when out of disk space.

### DIFF
--- a/apps/mason2/mason_simulator.cpp
+++ b/apps/mason2/mason_simulator.cpp
@@ -991,14 +991,23 @@ public:
                 }
 
                 // Write out the temporary sequence.
-                for (int tID = 0; tID < options.numThreads; ++tID)
+                try
                 {
-                    unsigned idx = rID * haplotypeCount + hID;
-                    writeRecords(*seqFileOuts[idx], threads[tID].ids, threads[tID].seqs, threads[tID].quals);
-                    if (!empty(options.outFileNameSam))
-                        for (unsigned i = 0; i < length(threads[tID].alignmentRecords); ++i)
-                            writeRecord(*bamFileOuts[idx], threads[tID].alignmentRecords[i]);
-                    std::cerr << '.' << std::flush;
+                    for (int tID = 0; tID < options.numThreads; ++tID)
+                    {
+                        unsigned idx = rID * haplotypeCount + hID;
+                        writeRecords(*seqFileOuts[idx], threads[tID].ids, threads[tID].seqs, threads[tID].quals);
+                        if (!empty(options.outFileNameSam))
+                            for (unsigned i = 0; i < length(threads[tID].alignmentRecords); ++i)
+                                writeRecord(*bamFileOuts[idx], threads[tID].alignmentRecords[i]);
+                        std::cerr << '.' << std::flush;
+                    }
+                }
+                catch (seqan2::IOError const &)
+                {
+                    std::throw_with_nested(seqan2::IOError{"Ran out of disk space for temporary files. "
+                        "Try setting the environment variable TMPDIR to a directory with more available disk space. "
+                        "For more information, see mason's help page ('Caveats')."});
                 }
 
                 if (doBreak)

--- a/include/seqan/stream/iostream_bgzf.h
+++ b/include/seqan/stream/iostream_bgzf.h
@@ -217,7 +217,7 @@ public:
     int_type overflow(int_type c)
     {
         int w = static_cast<int>(this->pptr() - this->pbase());
-        if (c != EOF)
+        if (!Tr::eq_int_type(c, Tr::eof()))
         {
             *this->pptr() = c;
             ++w;
@@ -226,11 +226,11 @@ public:
         {
             CompressionJob &job = jobs[currentJobId];
             this->setp(&job.buffer[0], &job.buffer[0] + (job.buffer.size() - 1));
-            return c;
+            return Tr::not_eof(c);
         }
         else
         {
-            return EOF;
+            return Tr::eof();
         }
     }
 

--- a/include/seqan/stream/iostream_bzip2_impl.h
+++ b/include/seqan/stream/iostream_bzip2_impl.h
@@ -118,15 +118,15 @@ namespace bzip2_stream{
                     )
     {
         int w = static_cast<int>(this->pptr() - this->pbase());
-        if (c != EOF) {
+        if (!Tr::eq_int_type(c, Tr::eof())) {
              *this->pptr() = c;
              ++w;
          }
          if ( bzip2_to_stream( this->pbase(), w)) {
              this->setp( this->pbase(), this->epptr());
-             return c;
+             return Tr::not_eof(c);
          } else
-             return EOF;
+             return Tr::eof();
     }
 
     template<

--- a/include/seqan/stream/iostream_zip_impl.h
+++ b/include/seqan/stream/iostream_zip_impl.h
@@ -112,7 +112,7 @@ basic_zip_streambuf<Elem, Tr, ElemA, ByteT, ByteAT>::overflow(
     if (zip_to_stream(this->pbase(), w))
     {
         this->setp(this->pbase(), this->epptr() - 1);
-        return c;
+        return traits_type::not_eof(c);
     }
     else
     {

--- a/include/seqan/stream/iter_stream.h
+++ b/include/seqan/stream/iter_stream.h
@@ -147,7 +147,8 @@ public:
     void reserveChunk(Output)
     {
         if (baseBuf()->pptr() == baseBuf()->epptr())
-            baseBuf()->overflow(EOF);
+            if (baseBuf()->overflow(EOF) == EOF)
+                throw IOError{"StreamBuffer: Calling overflow() failed."};
     }
 
     template <typename TOffset>

--- a/include/seqan/stream/iter_stream.h
+++ b/include/seqan/stream/iter_stream.h
@@ -103,6 +103,14 @@ struct StreamBuffer : public std::basic_streambuf<TValue, TTraits_>
 template <typename TValue, typename TTraits_ = std::char_traits<TValue>>
 class StreamBufferWrapper
 {
+protected:
+    // Having the throw in a separate function results in overflow()'s assembly using a jump instruction,
+    // instead of inline construction and throw of the exception.
+    [[noreturn]] void overflow_failure()
+    {
+        throw IOError{"StreamBuffer: Calling overflow() failed."};
+    }
+
 public:
 
     typedef std::basic_streambuf<TValue, TTraits_> TBasicStreamBuffer;
@@ -148,7 +156,7 @@ public:
     {
         if (baseBuf()->pptr() == baseBuf()->epptr())
             if (baseBuf()->overflow(EOF) == EOF)
-                throw IOError{"StreamBuffer: Calling overflow() failed."};
+                overflow_failure();
     }
 
     template <typename TOffset>


### PR DESCRIPTION
Resolves #2552

- [ ] Do this for all `underflow` and `overflow` calls in functions that return `void` and do not check the return value? 
- [ ] The compression stream changes should probably be ported to seqan3.
- [x] Check if putting the throw in a noreturn function produces better assembly