### PR TITLE
[FIX] ICE on MSVC 19.44

### DIFF
--- a/include/seqan/basic/pair_bit_compressed.h
+++ b/include/seqan/basic/pair_bit_compressed.h
@@ -72,8 +72,13 @@ namespace seqan2 {
  */
 
 #pragma pack(push,1)
+#if defined(_MSC_VER) && _MSC_VER >= 1944
+template <typename T1, typename T2, template <unsigned, unsigned> typename TSpec, int BITSIZE1, int BITSIZE2>
+struct Pair<T1, T2, TSpec<BITSIZE1, BITSIZE2>>
+#else
 template <typename T1, typename T2, unsigned BITSIZE1, unsigned BITSIZE2>
 struct Pair<T1, T2, BitPacked<BITSIZE1, BITSIZE2> >
+#endif
 {
     // ------------------------------------------------------------------------
     // Members


### PR DESCRIPTION
Note that, at time of writing, godbolt's MSVC is 19.43. Current and the runner's version is 19.44.

Simplest test is `test_basic_aggregate`.

Using `unsigned` instead of `int` in `template <typename T1, typename T2, template <unsigned, unsigned> typename TSpec, int BITSIZE1, int BITSIZE2>` causes another ICE for razers, param_chooser, splazers, and others. 