### PR TITLE
fix: bgzf data race

### DIFF
--- a/include/seqan/stream/iostream_bgzf.h
+++ b/include/seqan/stream/iostream_bgzf.h
@@ -590,12 +590,16 @@ public:
                     &job.buffer[0] + (MAX_PUTBACK - putback));
 
             // wait for the end of decompression
+            int jobSize;
+            bool bgzfEofMarker;
             {
                 std::unique_lock<std::mutex> lock(job.cs);
                 job.readyEvent.wait(lock, [&job]{return job.ready.load();});
+                jobSize = job.size;
+                bgzfEofMarker = job.bgzfEofMarker;
             }
 
-            size_t size = (job.size != -1)? job.size : 0;
+            size_t size = (jobSize != -1)? jobSize : 0;
 
             // reset buffer pointers
             this->setg(
@@ -605,9 +609,9 @@ public:
 
             // The end of the bgzf file is reached, either if there was an error, or if the
             // end-of-file marker was reached, while the uncompressed block had zero size.
-            if (job.size == -1 || (job.size == 0 && job.bgzfEofMarker))
+            if (jobSize == -1 || (jobSize == 0 && bgzfEofMarker))
                 return EOF;
-            else if (job.size > 0)
+            else if (jobSize > 0)
                 return Tr::to_int_type(*this->gptr());      // return next character
 
             throw IOError("BGZF: Invalid end condition in decompression. "
@@ -716,9 +720,11 @@ public:
                     // wait for the end of decompression
                     DecompressionJob &job = jobs[currentJobId];
 
+                    int jobSize;
                     {
                         std::unique_lock<std::mutex> lock(job.cs);
                         job.readyEvent.wait(lock, [&job]{return job.ready.load();});
+                        jobSize = job.size;
                     }
 
                     SEQAN_ASSERT_EQ(job.fileOfs, (off_type)destFileOfs);
@@ -727,7 +733,7 @@ public:
                     this->setg(
                           &job.buffer[0] + MAX_PUTBACK,                     // no putback area
                           &job.buffer[0] + (MAX_PUTBACK + (ofs & 0xffff)),  // read position
-                          &job.buffer[0] + (MAX_PUTBACK + job.size));       // end of buffer
+                          &job.buffer[0] + (MAX_PUTBACK + jobSize));        // end of buffer
                     return ofs;
                 }
             }


### PR DESCRIPTION
We read `job.size` and `job.bgzfEofMarker` after the lock goes out of scope.

<details><summary>Example log</summary>

```
TEST SUITE test_bam_io
SEQAN_ENABLE_DEBUG == 1
SEQAN_ENABLE_TESTING == 1
SEQAN_CXX_FLAGS == "SEQAN_CXX_FLAGS_NOT_SET"
SEQAN_ASYNC_IO == 1
==================
WARNING: ThreadSanitizer: data race (pid=18559)
  Write of size 4 at 0x72a400004638 by thread T108 (mutexes: write M0):
    #0 seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread::operator()() /__w/seqan/seqan/include/seqan/stream/iostream_bgzf.h:500:34 (test_bam_io+0x17d5c8) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)
    #1 std::__1::__invoke_result_impl<void, seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>::type std::__1::__invoke[abi:nqe220107]<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>(seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread&&) /usr/lib/llvm-22/bin/../include/c++/v1/__type_traits/invoke.h:90:27 (test_bam_io+0x17d4df) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)
    #2 void std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>::operator()[abi:nqe220107]()::'lambda'<unsigned long ...$N>(std::__1::__integer_sequence<unsigned long, $N...>)::operator()<0ul>(std::__1::__integer_sequence<unsigned long, $N...>) const /usr/lib/llvm-22/bin/../include/c++/v1/future:1840:14 (test_bam_io+0x17d4df)
    #3 std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>::operator()[abi:nqe220107]() /usr/lib/llvm-22/bin/../include/c++/v1/future:1839:12 (test_bam_io+0x17d4df)
    #4 std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>::__execute() /usr/lib/llvm-22/bin/../include/c++/v1/future:887:5 (test_bam_io+0x17d4df)
    #5 std::__1::__invoke_result_impl<void, void (std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>::*)(), std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>*>::type std::__1::__invoke[abi:nqe220107]<void (std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>::*)(), std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>*>(void (std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>::*&&)(), std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>*&&) /usr/lib/llvm-22/bin/../include/c++/v1/__type_traits/invoke.h (test_bam_io+0x17f175) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)
    #6 void std::__1::__thread_execute[abi:nqe220107]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>::*)(), std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>*, 0ul, 1ul>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>::*)(), std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>*>&, std::__1::__integer_sequence<unsigned long, 0ul, 1ul>) /usr/lib/llvm-22/bin/../include/c++/v1/__thread/thread.h:161:3 (test_bam_io+0x17f175)
    #7 void* std::__1::__thread_proxy[abi:nqe220107]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>::*)(), std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>*>>(void*) /usr/lib/llvm-22/bin/../include/c++/v1/__thread/thread.h:169:3 (test_bam_io+0x17f175)

  Previous read of size 4 at 0x72a400004638 by main thread:
    #0 seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::seekoff(long long, std::__1::ios_base::seekdir, unsigned int) /__w/seqan/seqan/include/seqan/stream/iostream_bgzf.h:730:63 (test_bam_io+0x17b738) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)
    #1 seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::seekpos(std::__1::fpos<__mbstate_t>, unsigned int) /__w/seqan/seqan/include/seqan/stream/iostream_bgzf.h:740:16 (test_bam_io+0x17b942) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)
    #2 std::__1::basic_streambuf<char, std::__1::char_traits<char>>::pubseekpos[abi:nqe220107](std::__1::fpos<__mbstate_t>, unsigned int) /usr/lib/llvm-22/bin/../include/c++/v1/streambuf:174:12 (test_bam_io+0x1e74de) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)
    #3 bool seqan2::setPosition<seqan2::Tag<seqan2::Bam_>, void, std::__1::fpos<__mbstate_t>>(seqan2::FormattedFile<seqan2::Tag<seqan2::Bam_>, seqan2::Tag<seqan2::Input_>, void>&, std::__1::fpos<__mbstate_t>) /__w/seqan/seqan/include/seqan/stream/formatted_file.h:839:44 (test_bam_io+0x1e74de)
    #4 void SEQAN_TEST_test_bam_io_bam_file_bam_file_seek<true>() /__w/seqan/seqan/tests/bam_io/test_bam_file.h:500:9 (test_bam_io+0x1e74de)
    #5 main /__w/seqan/seqan/tests/bam_io/test_bam_io.cpp:178:5 (test_bam_io+0x1624bd) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)

  Location is heap block of size 20480 at 0x72a400000000 allocated by main thread:
    #0 operator new(unsigned long) <null> (test_bam_io+0x152986) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)
    #1 void seqan2::allocate<seqan2::String<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionJob, seqan2::Alloc<void>>, seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionJob, unsigned long, seqan2::AllocateStorage_>(seqan2::String<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionJob, seqan2::Alloc<void>> const&, seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionJob*&, unsigned long, seqan2::Tag<seqan2::AllocateStorage_> const&) /__w/seqan/seqan/include/seqan/basic/allocator_interface.h:211:23 (test_bam_io+0x17c683) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)
    #2 seqan2::Value<seqan2::String<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionJob, seqan2::Alloc<void>>, 0>::Type* seqan2::_allocateStorage<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionJob, void, unsigned long>(seqan2::String<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionJob, seqan2::Alloc<void>>&, unsigned long) /__w/seqan/seqan/include/seqan/sequence/string_alloc.h:372:5 (test_bam_io+0x17c683)
    #3 seqan2::Value<seqan2::String<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionJob, seqan2::Alloc<void>>, 0>::Type* seqan2::_reallocateStorage<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionJob, seqan2::Alloc<void>, unsigned long>(seqan2::String<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionJob, seqan2::Alloc<void>>&, unsigned long) /__w/seqan/seqan/include/seqan/sequence/string_base.h:1540:12 (test_bam_io+0x17c683)
    #4 seqan2::Value<seqan2::String<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionJob, seqan2::Alloc<void>>, 0>::Type* seqan2::_reallocateStorage<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionJob, seqan2::Alloc<void>, unsigned long>(seqan2::String<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionJob, seqan2::Alloc<void>>&, unsigned long, seqan2::Tag<seqan2::TagExact_>) /__w/seqan/seqan/include/seqan/sequence/string_base.h:1554:12 (test_bam_io+0x17c683)
    #5 void seqan2::_reserveStorage<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionJob, seqan2::Alloc<void>, unsigned long, seqan2::TagExact_>(seqan2::String<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionJob, seqan2::Alloc<void>>&, unsigned long, seqan2::Tag<seqan2::TagExact_>) /__w/seqan/seqan/include/seqan/sequence/string_base.h:1687:65 (test_bam_io+0x17c683)
    #6 seqan2::Size<seqan2::String<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionJob, seqan2::Alloc<void>>>::Type seqan2::reserve<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionJob, seqan2::Alloc<void>, unsigned long, seqan2::TagExact_>(seqan2::String<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionJob, seqan2::Alloc<void>>&, unsigned long, seqan2::Tag<seqan2::TagExact_>) /__w/seqan/seqan/include/seqan/sequence/string_base.h:1705:5 (test_bam_io+0x17c3b2) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)
    #7 seqan2::Size<seqan2::String<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionJob, seqan2::Alloc<void>>>::Type seqan2::_Resize_String<seqan2::Tag<seqan2::TagExact_>>::resize_<seqan2::String<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionJob, seqan2::Alloc<void>>>(seqan2::String<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionJob, seqan2::Alloc<void>>&, seqan2::Size<seqan2::String<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionJob, seqan2::Alloc<void>>>::Type) /__w/seqan/seqan/include/seqan/sequence/string_base.h:1733:38 (test_bam_io+0x17c3b2)
    #8 seqan2::Size<seqan2::String<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionJob, seqan2::Alloc<void>>>::Type seqan2::resize<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionJob, seqan2::Alloc<void>, unsigned long, seqan2::TagExact_>(seqan2::String<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionJob, seqan2::Alloc<void>>&, unsigned long, seqan2::Tag<seqan2::TagExact_>) /__w/seqan/seqan/include/seqan/sequence/string_base.h:1793:12 (test_bam_io+0x17a24e) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)
    #9 seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::basic_unbgzf_streambuf(std::__1::basic_istream<char, std::__1::char_traits<char>>&, unsigned long, unsigned long) /__w/seqan/seqan/include/seqan/stream/iostream_bgzf.h:524:9 (test_bam_io+0x17a24e)
    #10 seqan2::basic_bgzf_istreambase<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::basic_bgzf_istreambase(std::__1::basic_istream<char, std::__1::char_traits<char>>&) /__w/seqan/seqan/include/seqan/stream/iostream_bgzf.h:803:11 (test_bam_io+0x179741) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)
    #11 seqan2::basic_bgzf_istream<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::basic_bgzf_istream(std::__1::basic_istream<char, std::__1::char_traits<char>>&) /__w/seqan/seqan/include/seqan/stream/iostream_bgzf.h:890:9 (test_bam_io+0x179741)
    #12 seqan2::VirtualStreamContext_<char, seqan2::Tag<seqan2::Input_>, std::__1::char_traits<char>, seqan2::Tag<seqan2::BgzfFile_>>::VirtualStreamContext_<std::__1::basic_istream<char, std::__1::char_traits<char>>>(std::__1::basic_istream<char, std::__1::char_traits<char>>&) /__w/seqan/seqan/include/seqan/stream/virtual_stream.h:197:9 (test_bam_io+0x1747c7) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)
    #13 seqan2::VirtualStreamContextBase_<char, std::__1::char_traits<char>>* seqan2::tagApply<char, seqan2::Tag<seqan2::Input_>, std::__1::char_traits<char>, seqan2::BgzfFile_>(seqan2::VirtualStreamFactoryContext_<seqan2::VirtualStream<char, seqan2::Tag<seqan2::Input_>, std::__1::char_traits<char>>>&, seqan2::Tag<seqan2::BgzfFile_>) /__w/seqan/seqan/include/seqan/stream/virtual_stream.h:460:16 (test_bam_io+0x1747c7)
    #14 seqan2::Value<seqan2::VirtualStreamFactoryContext_<seqan2::VirtualStream<char, seqan2::Tag<seqan2::Input_>, std::__1::char_traits<char>>>, 0>::Type seqan2::tagApply<seqan2::VirtualStreamFactoryContext_<seqan2::VirtualStream<char, seqan2::Tag<seqan2::Input_>, std::__1::char_traits<char>>>, seqan2::TagList<seqan2::Tag<seqan2::BgzfFile_>, seqan2::TagList<seqan2::Tag<seqan2::GZFile_>, seqan2::TagList<seqan2::Tag<seqan2::BZ2File_>, seqan2::TagList<seqan2::Tag<seqan2::Nothing_>, void>>>>>(seqan2::VirtualStreamFactoryContext_<seqan2::VirtualStream<char, seqan2::Tag<seqan2::Input_>, std::__1::char_traits<char>>>&, seqan2::TagSelector<seqan2::TagList<seqan2::Tag<seqan2::BgzfFile_>, seqan2::TagList<seqan2::Tag<seqan2::GZFile_>, seqan2::TagList<seqan2::Tag<seqan2::BZ2File_>, seqan2::TagList<seqan2::Tag<seqan2::Nothing_>, void>>>>>&) /__w/seqan/seqan/include/seqan/basic/fundamental_tags.h:653:16 (test_bam_io+0x1747c7)
    #15 bool seqan2::open<char, seqan2::Tag<seqan2::Input_>, std::__1::char_traits<char>>(seqan2::VirtualStream<char, seqan2::Tag<seqan2::Input_>, std::__1::char_traits<char>>&, char const*, int) /__w/seqan/seqan/include/seqan/stream/virtual_stream.h:632:22 (test_bam_io+0x1747c7)
    #16 bool seqan2::_open<seqan2::Tag<seqan2::Bam_>, seqan2::Tag<seqan2::Input_>, void, seqan2::True>(seqan2::FormattedFile<seqan2::Tag<seqan2::Bam_>, seqan2::Tag<seqan2::Input_>, void>&, char const*, int, seqan2::True) /__w/seqan/seqan/include/seqan/stream/formatted_file.h:703:10 (test_bam_io+0x170e30) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)
    #17 seqan2::FormattedFile<seqan2::Tag<seqan2::Bam_>, seqan2::Tag<seqan2::Input_>, void>::FormattedFile(char const*, int) /__w/seqan/seqan/include/seqan/stream/formatted_file.h:257:9 (test_bam_io+0x16e763) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)
    #18 void SEQAN_TEST_test_bam_io_bam_file_bam_file_seek<true>() /__w/seqan/seqan/tests/bam_io/test_bam_file.h:470:23 (test_bam_io+0x1e6b7f) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)
    #19 main /__w/seqan/seqan/tests/bam_io/test_bam_io.cpp:178:5 (test_bam_io+0x1624bd) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)

  Mutex M0 (0x72a400004640) created at:
    #0 pthread_mutex_lock <null> (test_bam_io+0xced8b) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)
    #1 std::__1::mutex::lock() <null> (libc++.so.1+0xa9d29) (BuildId: 4dbf33bcbf5e72bd9246b6d42893c5cf336424c4)
    #2 std::__1::__invoke_result_impl<void, seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>::type std::__1::__invoke[abi:nqe220107]<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>(seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread&&) /usr/lib/llvm-22/bin/../include/c++/v1/__type_traits/invoke.h:90:27 (test_bam_io+0x17d4df) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)
    #3 void std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>::operator()[abi:nqe220107]()::'lambda'<unsigned long ...$N>(std::__1::__integer_sequence<unsigned long, $N...>)::operator()<0ul>(std::__1::__integer_sequence<unsigned long, $N...>) const /usr/lib/llvm-22/bin/../include/c++/v1/future:1840:14 (test_bam_io+0x17d4df)
    #4 std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>::operator()[abi:nqe220107]() /usr/lib/llvm-22/bin/../include/c++/v1/future:1839:12 (test_bam_io+0x17d4df)
    #5 std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>::__execute() /usr/lib/llvm-22/bin/../include/c++/v1/future:887:5 (test_bam_io+0x17d4df)
    #6 std::__1::__invoke_result_impl<void, void (std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>::*)(), std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>*>::type std::__1::__invoke[abi:nqe220107]<void (std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>::*)(), std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>*>(void (std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>::*&&)(), std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>*&&) /usr/lib/llvm-22/bin/../include/c++/v1/__type_traits/invoke.h (test_bam_io+0x17f175) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)
    #7 void std::__1::__thread_execute[abi:nqe220107]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>::*)(), std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>*, 0ul, 1ul>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>::*)(), std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>*>&, std::__1::__integer_sequence<unsigned long, 0ul, 1ul>) /usr/lib/llvm-22/bin/../include/c++/v1/__thread/thread.h:161:3 (test_bam_io+0x17f175)
    #8 void* std::__1::__thread_proxy[abi:nqe220107]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>::*)(), std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>*>>(void*) /usr/lib/llvm-22/bin/../include/c++/v1/__thread/thread.h:169:3 (test_bam_io+0x17f175)

  Thread T108 (tid=18668, running) created by main thread at:
    #0 pthread_create <null> (test_bam_io+0xcd07e) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)
    #1 std::__1::__libcpp_thread_create[abi:nqe220107](unsigned long*, void* (*)(void*), void*) /usr/lib/llvm-22/bin/../include/c++/v1/__thread/support/pthread.h:182:10 (test_bam_io+0x17d365) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)
    #2 std::__1::thread::thread[abi:nqe220107]<void (std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>::*)(), std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>*, 0>(void (std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>::*&&)(), std::__1::__async_assoc_state<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>*&&) /usr/lib/llvm-22/bin/../include/c++/v1/__thread/thread.h:218:16 (test_bam_io+0x17d365)
    #3 std::__1::future<void> std::__1::__make_async_assoc_state[abi:nqe220107]<void, std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>>(std::__1::__async_func<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>&&) /usr/lib/llvm-22/bin/../include/c++/v1/future:1818:3 (test_bam_io+0x17d176) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)
    #4 std::__1::future<std::__1::__invoke_result_impl<void, __decay(seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread)>::type> std::__1::async[abi:nqe220107]<seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread>(std::__1::launch, seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread&&) /usr/lib/llvm-22/bin/../include/c++/v1/future:1863:14 (test_bam_io+0x17a491) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)
    #5 seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::basic_unbgzf_streambuf(std::__1::basic_istream<char, std::__1::char_traits<char>>&, unsigned long, unsigned long) /__w/seqan/seqan/include/seqan/stream/iostream_bgzf.h:541:31 (test_bam_io+0x17a491)
    #6 seqan2::basic_bgzf_istreambase<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::basic_bgzf_istreambase(std::__1::basic_istream<char, std::__1::char_traits<char>>&) /__w/seqan/seqan/include/seqan/stream/iostream_bgzf.h:803:11 (test_bam_io+0x179741) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)
    #7 seqan2::basic_bgzf_istream<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::basic_bgzf_istream(std::__1::basic_istream<char, std::__1::char_traits<char>>&) /__w/seqan/seqan/include/seqan/stream/iostream_bgzf.h:890:9 (test_bam_io+0x179741)
    #8 seqan2::VirtualStreamContext_<char, seqan2::Tag<seqan2::Input_>, std::__1::char_traits<char>, seqan2::Tag<seqan2::BgzfFile_>>::VirtualStreamContext_<std::__1::basic_istream<char, std::__1::char_traits<char>>>(std::__1::basic_istream<char, std::__1::char_traits<char>>&) /__w/seqan/seqan/include/seqan/stream/virtual_stream.h:197:9 (test_bam_io+0x1747c7) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)
    #9 seqan2::VirtualStreamContextBase_<char, std::__1::char_traits<char>>* seqan2::tagApply<char, seqan2::Tag<seqan2::Input_>, std::__1::char_traits<char>, seqan2::BgzfFile_>(seqan2::VirtualStreamFactoryContext_<seqan2::VirtualStream<char, seqan2::Tag<seqan2::Input_>, std::__1::char_traits<char>>>&, seqan2::Tag<seqan2::BgzfFile_>) /__w/seqan/seqan/include/seqan/stream/virtual_stream.h:460:16 (test_bam_io+0x1747c7)
    #10 seqan2::Value<seqan2::VirtualStreamFactoryContext_<seqan2::VirtualStream<char, seqan2::Tag<seqan2::Input_>, std::__1::char_traits<char>>>, 0>::Type seqan2::tagApply<seqan2::VirtualStreamFactoryContext_<seqan2::VirtualStream<char, seqan2::Tag<seqan2::Input_>, std::__1::char_traits<char>>>, seqan2::TagList<seqan2::Tag<seqan2::BgzfFile_>, seqan2::TagList<seqan2::Tag<seqan2::GZFile_>, seqan2::TagList<seqan2::Tag<seqan2::BZ2File_>, seqan2::TagList<seqan2::Tag<seqan2::Nothing_>, void>>>>>(seqan2::VirtualStreamFactoryContext_<seqan2::VirtualStream<char, seqan2::Tag<seqan2::Input_>, std::__1::char_traits<char>>>&, seqan2::TagSelector<seqan2::TagList<seqan2::Tag<seqan2::BgzfFile_>, seqan2::TagList<seqan2::Tag<seqan2::GZFile_>, seqan2::TagList<seqan2::Tag<seqan2::BZ2File_>, seqan2::TagList<seqan2::Tag<seqan2::Nothing_>, void>>>>>&) /__w/seqan/seqan/include/seqan/basic/fundamental_tags.h:653:16 (test_bam_io+0x1747c7)
    #11 bool seqan2::open<char, seqan2::Tag<seqan2::Input_>, std::__1::char_traits<char>>(seqan2::VirtualStream<char, seqan2::Tag<seqan2::Input_>, std::__1::char_traits<char>>&, char const*, int) /__w/seqan/seqan/include/seqan/stream/virtual_stream.h:632:22 (test_bam_io+0x1747c7)
    #12 bool seqan2::_open<seqan2::Tag<seqan2::Bam_>, seqan2::Tag<seqan2::Input_>, void, seqan2::True>(seqan2::FormattedFile<seqan2::Tag<seqan2::Bam_>, seqan2::Tag<seqan2::Input_>, void>&, char const*, int, seqan2::True) /__w/seqan/seqan/include/seqan/stream/formatted_file.h:703:10 (test_bam_io+0x170e30) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)
    #13 seqan2::FormattedFile<seqan2::Tag<seqan2::Bam_>, seqan2::Tag<seqan2::Input_>, void>::FormattedFile(char const*, int) /__w/seqan/seqan/include/seqan/stream/formatted_file.h:257:9 (test_bam_io+0x16e763) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)
    #14 void SEQAN_TEST_test_bam_io_bam_file_bam_file_seek<true>() /__w/seqan/seqan/tests/bam_io/test_bam_file.h:470:23 (test_bam_io+0x1e6b7f) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)
    #15 main /__w/seqan/seqan/tests/bam_io/test_bam_io.cpp:178:5 (test_bam_io+0x1624bd) (BuildId: 6e32128e2bf64539343f673d9193fc3de4939bc1)

SUMMARY: ThreadSanitizer: data race /__w/seqan/seqan/include/seqan/stream/iostream_bgzf.h:500:34 in seqan2::basic_unbgzf_streambuf<char, std::__1::char_traits<char>, std::__1::allocator<char>, char, std::__1::allocator<char>>::DecompressionThread::operator()()
==================

ThreadSanitizer: reported 1 warnings

0% tests passed, 1 tests failed out of 1

Total Test time (real) =   5.69 sec
```
</details> 